### PR TITLE
Add linefill utilities and partial DRA reach handling

### DIFF
--- a/dra_utils.py
+++ b/dra_utils.py
@@ -132,3 +132,11 @@ def get_dr_for_ppm(
     dr_upper = _dr_from_df(df_upper, ppm)
     dr_interp = np.interp(visc, [lower, upper], [dr_lower, dr_upper])
     return float(dr_interp)
+
+
+__all__ = [
+    "DRA_CSV_FILES",
+    "DRA_CURVE_DATA",
+    "get_ppm_for_dr",
+    "get_dr_for_ppm",
+]

--- a/linefill_utils.py
+++ b/linefill_utils.py
@@ -1,0 +1,86 @@
+"""Utility functions for handling pipeline linefill tables.
+
+Provides helpers to translate volume based linefill information into
+length-wise positions along the pipeline and to update the linefill after a
+certain throughput has been delivered.
+"""
+
+from __future__ import annotations
+
+from math import pi
+from typing import List, Dict
+
+
+def linefill_lengths(linefill: List[Dict], diameter: float) -> List[Dict]:
+    """Return length information for each product batch in ``linefill``.
+
+    Parameters
+    ----------
+    linefill:
+        List of dictionaries each describing a batch with keys ``volume``
+        (m³) along with optional ``product``, ``viscosity`` and ``density``.
+        The first element is assumed to be the batch closest to the
+        originating station.
+    diameter:
+        Inner diameter of the pipeline in metres.
+
+    Returns
+    -------
+    List[Dict]
+        ``linefill`` augmented with ``length_km`` plus ``length_km_start`` and
+        ``length_km_end`` giving the occupied interval measured from the
+        origin.
+    """
+    if diameter <= 0:
+        raise ValueError("Pipe diameter must be positive")
+    area = pi * (diameter ** 2) / 4.0
+    result = []
+    cum_len = 0.0
+    for entry in linefill:
+        vol = float(entry.get("volume", 0.0))
+        length_km = vol / area / 1000.0
+        new_entry = entry.copy()
+        new_entry.update(
+            {
+                "length_km": length_km,
+                "length_km_start": cum_len,
+                "length_km_end": cum_len + length_km,
+            }
+        )
+        result.append(new_entry)
+        cum_len += length_km
+    return result
+
+
+def advance_linefill(linefill: List[Dict], schedule: List[Dict], delivered: float) -> List[Dict]:
+    """Update ``linefill`` after ``delivered`` m³ has left the pipeline.
+
+    The same volume is injected at the origin according to ``schedule``.  Both
+    ``linefill`` and ``schedule`` are modified in-place and the updated
+    ``linefill`` is returned for convenience.
+    """
+    remaining = delivered
+    # Remove delivered volume from the terminal side (end of list)
+    while remaining > 0 and linefill:
+        tail = linefill[-1]
+        vol = float(tail.get("volume", 0.0))
+        if vol > remaining:
+            tail["volume"] = vol - remaining
+            remaining = 0
+        else:
+            remaining -= vol
+            linefill.pop()
+    # Inject new product batches at the origin side (front of list)
+    added = delivered
+    while added > 0 and schedule:
+        head = schedule[0]
+        vol = float(head.get("volume", 0.0))
+        take = min(vol, added)
+        new_batch = head.copy()
+        new_batch["volume"] = take
+        linefill.insert(0, new_batch)
+        head["volume"] = vol - take
+        if head["volume"] <= 0:
+            schedule.pop(0)
+        added -= take
+    return linefill

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -210,6 +210,7 @@ def solve_pipeline(
     linefill_dict: dict | None = None,
     dra_reach_km: float = 0.0,
     mop_kgcm2: float | None = None,
+    hours: float = 24.0,
 ) -> dict:
     """Enumerate feasible options across all stations to find the lowest-cost
     operating strategy.  This replaces the previous greedy approach and
@@ -296,12 +297,12 @@ def solve_pipeline(
                         if stn.get('sfc', 0) and motor_kw_total > 0:
                             sfc_val = stn['sfc']
                             fuel_per_kWh = (sfc_val * 1.34102) / 820.0
-                            power_cost = motor_kw_total * 24.0 * fuel_per_kWh * Price_HSD
+                            power_cost = motor_kw_total * hours * fuel_per_kWh * Price_HSD
                         else:
                             rate = stn.get('rate', 0.0)
-                            power_cost = motor_kw_total * 24.0 * rate
+                            power_cost = motor_kw_total * hours * rate
                         ppm = get_ppm_for_dr(kv, dra) if dra > 0 else 0.0
-                        dra_cost = ppm * (flow * 1000.0 * 24.0 / 1e6) * RateDRA if dra > 0 else 0.0
+                        dra_cost = ppm * (flow * 1000.0 * hours / 1e6) * RateDRA if dra > 0 else 0.0
                         cost = power_cost + dra_cost
                         opts.append({
                             'nop': nop,
@@ -508,6 +509,7 @@ def solve_pipeline_multi_origin(
     linefill_dict: dict | None = None,
     dra_reach_km: float = 0.0,
     mop_kgcm2: float | None = None,
+    hours: float = 24.0,
 ) -> dict:
     """Enumerate pump type combinations at the origin and call ``solve_pipeline``."""
 
@@ -586,7 +588,7 @@ def solve_pipeline_multi_origin(
         kv_combo.extend(KV_list[1:])
         rho_combo.extend(rho_list[1:])
 
-        result = solve_pipeline(stations_combo, terminal, FLOW, kv_combo, rho_combo, RateDRA, Price_HSD, linefill_dict, dra_reach_km, mop_kgcm2)
+        result = solve_pipeline(stations_combo, terminal, FLOW, kv_combo, rho_combo, RateDRA, Price_HSD, linefill_dict, dra_reach_km, mop_kgcm2, hours)
         if result.get("error"):
             continue
         cost = result.get("total_cost", float('inf'))

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -264,7 +264,10 @@ def solve_pipeline(
         elev_delta = elev_next - elev_i
 
         opts = []
-        dra_len_here = max(0.0, min(L, dra_reach_km - cum_dist))
+        flow_m3s = flow / 3600.0
+        area = pi * d_inner ** 2 / 4.0
+        v_nom = flow_m3s / area if area > 0 else 0.0
+        travel_km = v_nom * hours * 3600.0 / 1000.0
 
         if stn.get('is_pump', False):
             min_p = stn.get('min_pumps', 0)
@@ -280,6 +283,8 @@ def solve_pipeline(
                 dra_opts = dra_vals
                 for rpm in rpm_opts:
                     for dra in dra_opts:
+                        reach = dra_reach_km + travel_km if dra > 0 else dra_reach_km
+                        dra_len_here = max(0.0, min(L, reach - cum_dist))
                         effective_dra = dra if dra_len_here > 0 else 0.0
                         head_loss, v, Re, f = _segment_hydraulics(flow, L, d_inner, rough, kv, effective_dra, dra_len_here)
                         if nop > 0 and rpm > 0:

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1432,6 +1432,7 @@ if not auto_batch:
                 st.session_state["daily_linefill_all"] = lf_all
                 st.session_state["detail_time_idx"] = 0
                 update_detail_time()
+                st.rerun()
 
 
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -133,7 +133,7 @@ def check_login():
         )
         st.stop()
     with st.sidebar:
-        if st.button("Logout", key="main_logout_btn"):
+        if st.button("Logout", key="sidebar_logout_btn"):
             st.session_state.authenticated = False
             st.rerun()
 check_login()

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1182,7 +1182,18 @@ if not auto_batch:
             current_vol = vol_df.copy()
 
             for ti, hr in enumerate(hours):
-                kv_list, rho_list = kv_rho_from_vol(current_vol)
+                # Determine worst-case fluid properties over this 4h window
+                kv_now, rho_now = kv_rho_from_vol(current_vol)
+                kv_next, rho_next = kv_now, rho_now
+                if st.session_state.get("op_mode") == "Pumping Schedule":
+                    pumped_tmp = FLOW_sched * 4.0
+                    future_vol, _ = shift_vol_linefill(
+                        current_vol.copy(), pumped_tmp, plan_df.copy() if plan_df is not None else None
+                    )
+                    kv_next, rho_next = kv_rho_from_vol(future_vol)
+                kv_list = [max(a, b) for a, b in zip(kv_now, kv_next)]
+                rho_list = [max(a, b) for a, b in zip(rho_now, rho_next)]
+
                 stns_run = copy.deepcopy(stations_base)
 
                 res = solve_pipeline(

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -713,7 +713,17 @@ def fmt_pressure(res, key_m, key_kg):
     kg = res.get(key_kg, 0.0) or 0.0
     return f"{m:.2f} m / {kg:.2f} kg/cm²"
 
-def solve_pipeline(stations, terminal, FLOW, KV_list, rho_list, RateDRA, Price_HSD, linefill_dict):
+def solve_pipeline(
+    stations,
+    terminal,
+    FLOW,
+    KV_list,
+    rho_list,
+    RateDRA,
+    Price_HSD,
+    linefill_dict,
+    dra_reach_km: float = 0.0,
+):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
     import pipeline_model
@@ -730,10 +740,26 @@ def solve_pipeline(stations, terminal, FLOW, KV_list, rho_list, RateDRA, Price_H
     try:
         if stations and stations[0].get('pump_types'):
             return pipeline_model.solve_pipeline_multi_origin(
-                stations, terminal, FLOW, KV_list, rho_list, RateDRA, Price_HSD, linefill_dict
+                stations,
+                terminal,
+                FLOW,
+                KV_list,
+                rho_list,
+                RateDRA,
+                Price_HSD,
+                linefill_dict,
+                dra_reach_km,
             )
         return pipeline_model.solve_pipeline(
-            stations, terminal, FLOW, KV_list, rho_list, RateDRA, Price_HSD, linefill_dict
+            stations,
+            terminal,
+            FLOW,
+            KV_list,
+            rho_list,
+            RateDRA,
+            Price_HSD,
+            linefill_dict,
+            dra_reach_km,
         )
     except Exception as exc:  # pragma: no cover - diagnostic path
         return {"error": True, "message": str(exc)}

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1444,16 +1444,24 @@ if not auto_batch:
 
         hours = st.session_state.get("day_hours", [])
         labels = [f"{h%24:02d}:00" for h in hours]
-        sel_idx = st.session_state.get("daily_selected_idx", 0)
         if labels:
-            choice = st.selectbox("Select Time for Detailed Results", labels, index=sel_idx)
+            if "daily_selected_idx" not in st.session_state:
+                st.session_state["daily_selected_idx"] = 0
+            choice = st.selectbox(
+                "Select Time for Detailed Results",
+                labels,
+                index=st.session_state["daily_selected_idx"],
+                key="detail_time",
+            )
             idx = labels.index(choice)
-            st.session_state["daily_selected_idx"] = idx
-            rec = st.session_state["day_reports"][idx]
-            st.session_state["last_res"] = copy.deepcopy(rec["result"])
-            st.session_state["last_stations_data"] = copy.deepcopy(st.session_state["day_stations"])
-            st.session_state["last_term_data"] = copy.deepcopy(st.session_state["day_term_data"])
-            st.session_state["last_linefill"] = copy.deepcopy(st.session_state["day_linefills"][idx])
+            if idx != st.session_state["daily_selected_idx"] or "last_res" not in st.session_state:
+                st.session_state["daily_selected_idx"] = idx
+                rec = st.session_state["day_reports"][idx]
+                st.session_state["last_res"] = copy.deepcopy(rec["result"])
+                st.session_state["last_stations_data"] = copy.deepcopy(st.session_state["day_stations"])
+                st.session_state["last_term_data"] = copy.deepcopy(st.session_state["day_term_data"])
+                st.session_state["last_linefill"] = copy.deepcopy(st.session_state["day_linefills"][idx])
+                st.rerun()
 
 
 if not auto_batch:

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1115,35 +1115,19 @@ if not auto_batch:
                             stn['P'], stn['Q'], stn['R'], stn['S'], stn['T'] = [float(c) for c in coeff_e]
             # ------------- END OF BLOCK -------------
 
-            import pipeline_model
-            import importlib
-            importlib.reload(pipeline_model)
-            if stations_data and stations_data[0].get('pump_types'):
-                res = pipeline_model.solve_pipeline_multi_origin(
-                    stations_data,
-                    term_data,
-                    FLOW,
-                    kv_list,
-                    rho_list,
-                    RateDRA,
-                    Price_HSD,
-                    linefill_df.to_dict(),
-                    dra_reach_km=0.0,
-                    mop_kgcm2=st.session_state.get("MOP_kgcm2"),
-                )
-            else:
-                res = pipeline_model.solve_pipeline(
-                    stations_data,
-                    term_data,
-                    FLOW,
-                    kv_list,
-                    rho_list,
-                    RateDRA,
-                    Price_HSD,
-                    linefill_df.to_dict(),
-                    dra_reach_km=0.0,
-                    mop_kgcm2=st.session_state.get("MOP_kgcm2"),
-                )
+            res = solve_pipeline(
+                stations_data,
+                term_data,
+                FLOW,
+                kv_list,
+                rho_list,
+                RateDRA,
+                Price_HSD,
+                linefill_df.to_dict(),
+                dra_reach_km=0.0,
+                mop_kgcm2=st.session_state.get("MOP_kgcm2"),
+                hours=4.0,
+            )
 
             import copy
             if not res or res.get("error"):

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -834,38 +834,72 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
     count_b = pump_combo.get('B', 0)
 
     if origin_unit_keys:
+        nop = _agg(origin_unit_keys, 'num_pumps')
+        power_total = _agg(origin_unit_keys, 'power_cost')
+        dra_total = _agg(origin_unit_keys, 'dra_cost')
         row = {
             'Station': origin_name,
             'Pipeline Flow (m³/hr)': _agg(origin_unit_keys, 'pipeline_flow', op='avg'),
-            'No. of Pumps': _agg(origin_unit_keys, 'num_pumps'),
+            'Pump Flow (m³/hr)': _agg(origin_unit_keys, 'pump_flow', op='avg'),
+            'No. of Pumps': nop,
             'Type A Pumps': count_a,
             'Type B Pumps': count_b,
             'Type of Pump': pump_type_str,
             'Pump Speed (rpm)': _agg(origin_unit_keys, 'speed', op='avg'),
             'Pump Efficiency (%)': _agg(origin_unit_keys, 'efficiency', op='avg'),
-            'Pump BKW (kW)': _agg(origin_unit_keys, 'pump_bkw'),
+            'Pump BKW (kW)': _agg(origin_unit_keys, 'pump_bkw', op='avg'),
+            'Motor Input (kW)': _agg(origin_unit_keys, 'motor_kw', op='avg'),
+            'Reynolds No.': _agg(origin_unit_keys, 'reynolds', op='avg'),
+            'Head Loss (m)': _agg(origin_unit_keys, 'head_loss', op='avg'),
+            'Head Loss (kg/cm²)': _agg(origin_unit_keys, 'head_loss_kgcm2', op='avg'),
+            'Vel (m/s)': _agg(origin_unit_keys, 'velocity', op='avg'),
+            'Residual Head (m)': _agg(origin_unit_keys, 'residual_head', op='avg'),
+            'Residual Head (kg/cm²)': _agg(origin_unit_keys, 'rh_kgcm2', op='avg'),
+            'SDH (m)': _agg(origin_unit_keys, 'sdh', op='avg'),
+            'SDH (kg/cm²)': _agg(origin_unit_keys, 'sdh_kgcm2', op='avg'),
+            'MAOP (m)': _agg(origin_unit_keys, 'maop', op='avg'),
+            'MAOP (kg/cm²)': _agg(origin_unit_keys, 'maop_kgcm2', op='avg'),
+            'Drag Reduction (%)': _agg(origin_unit_keys, 'drag_reduction', op='avg'),
             'DRA PPM': _agg(origin_unit_keys, 'dra_ppm', op='avg'),
-            'Power & Fuel Cost (INR)': _agg(origin_unit_keys, 'power_cost'),
-            'DRA Cost (INR)': _agg(origin_unit_keys, 'dra_cost'),
+            'Power Cost per Pump (INR)': power_total / nop if nop else 0.0,
+            'Power & Fuel Cost (INR)': power_total,
+            'DRA Cost (INR)': dra_total,
         }
         row['Total Cost (INR)'] = row['Power & Fuel Cost (INR)'] + row['DRA Cost (INR)']
         rows.append(row)
 
     for stn in base_stations[1:]:
         key = stn['name'].lower().replace(' ', '_')
+        nop = float(res.get(f"num_pumps_{key}", 0) or 0)
+        power_total = float(res.get(f"power_cost_{key}", 0.0) or 0.0)
+        dra_total = float(res.get(f"dra_cost_{key}", 0.0) or 0.0)
         row = {
             'Station': stn['name'],
             'Pipeline Flow (m³/hr)': float(res.get(f"pipeline_flow_{key}", 0.0) or 0.0),
-            'No. of Pumps': float(res.get(f"num_pumps_{key}", 0) or 0),
+            'Pump Flow (m³/hr)': float(res.get(f"pump_flow_{key}", 0.0) or 0.0),
+            'No. of Pumps': nop,
             'Type A Pumps': 0,
             'Type B Pumps': 0,
             'Type of Pump': '',
             'Pump Speed (rpm)': float(res.get(f"speed_{key}", 0.0) or 0.0),
             'Pump Efficiency (%)': float(res.get(f"efficiency_{key}", 0.0) or 0.0),
             'Pump BKW (kW)': float(res.get(f"pump_bkw_{key}", 0.0) or 0.0),
+            'Motor Input (kW)': float(res.get(f"motor_kw_{key}", 0.0) or 0.0),
+            'Reynolds No.': float(res.get(f"reynolds_{key}", 0.0) or 0.0),
+            'Head Loss (m)': float(res.get(f"head_loss_{key}", 0.0) or 0.0),
+            'Head Loss (kg/cm²)': float(res.get(f"head_loss_kgcm2_{key}", 0.0) or 0.0),
+            'Vel (m/s)': float(res.get(f"velocity_{key}", 0.0) or 0.0),
+            'Residual Head (m)': float(res.get(f"residual_head_{key}", 0.0) or 0.0),
+            'Residual Head (kg/cm²)': float(res.get(f"rh_kgcm2_{key}", 0.0) or 0.0),
+            'SDH (m)': float(res.get(f"sdh_{key}", 0.0) or 0.0),
+            'SDH (kg/cm²)': float(res.get(f"sdh_kgcm2_{key}", 0.0) or 0.0),
+            'MAOP (m)': float(res.get(f"maop_{key}", 0.0) or 0.0),
+            'MAOP (kg/cm²)': float(res.get(f"maop_kgcm2_{key}", 0.0) or 0.0),
+            'Drag Reduction (%)': float(res.get(f"drag_reduction_{key}", 0.0) or 0.0),
             'DRA PPM': float(res.get(f"dra_ppm_{key}", 0.0) or 0.0),
-            'Power & Fuel Cost (INR)': float(res.get(f"power_cost_{key}", 0.0) or 0.0),
-            'DRA Cost (INR)': float(res.get(f"dra_cost_{key}", 0.0) or 0.0),
+            'Power Cost per Pump (INR)': power_total / nop if nop else 0.0,
+            'Power & Fuel Cost (INR)': power_total,
+            'DRA Cost (INR)': dra_total,
         }
         row['Total Cost (INR)'] = row['Power & Fuel Cost (INR)'] + row['DRA Cost (INR)']
         rows.append(row)
@@ -1406,10 +1440,15 @@ if not auto_batch:
                 station_tables.append(df_int)
             df_day = pd.concat(station_tables, ignore_index=True).fillna(0.0).round(2)
             col_order = [
-                "Time", "Station", "Pipeline Flow (m³/hr)", "No. of Pumps",
-                "Type A Pumps", "Type B Pumps", "Type of Pump", "Pump Speed (rpm)",
-                "Pump Efficiency (%)", "Pump BKW (kW)", "DRA PPM",
-                "Power & Fuel Cost (INR)", "DRA Cost (INR)", "Total Cost (INR)"
+                "Time", "Station", "Pipeline Flow (m³/hr)", "Pump Flow (m³/hr)",
+                "No. of Pumps", "Type A Pumps", "Type B Pumps", "Type of Pump",
+                "Pump Speed (rpm)", "Pump Efficiency (%)", "Pump BKW (kW)",
+                "Motor Input (kW)", "Reynolds No.", "Head Loss (m)",
+                "Head Loss (kg/cm²)", "Vel (m/s)", "Residual Head (m)",
+                "Residual Head (kg/cm²)", "SDH (m)", "SDH (kg/cm²)",
+                "MAOP (m)", "MAOP (kg/cm²)", "Drag Reduction (%)", "DRA PPM",
+                "Power Cost per Pump (INR)", "Power & Fuel Cost (INR)",
+                "DRA Cost (INR)", "Total Cost (INR)"
             ]
             df_day = df_day.reindex(columns=col_order)
 
@@ -1437,7 +1476,8 @@ if not auto_batch:
 
 
     # --- Persisted daily schedule display and time selection ---
-    if "daily_df_day" in st.session_state:
+    mode = st.session_state.get("op_mode")
+    if mode == "Pumping Schedule" and "daily_df_day" in st.session_state:
         df_day = st.session_state["daily_df_day"]
         num_cols = [c for c in df_day.columns if c not in ["Time", "Station", "Type of Pump"]]
         styled = df_day.style.format({c: "{:.2f}" for c in num_cols}).background_gradient(
@@ -1484,7 +1524,7 @@ if not auto_batch:
         c3.metric("Total Cost (INR)", f"{total_cost:,.2f}")
 
 
-if not auto_batch:
+if not auto_batch and st.session_state.get("op_mode") == "Flow rate":
     tab1, tab2, tab3, tab4, tab5, tab6, tab7, tab8, tab_sens, tab_bench, tab_sim = st.tabs([
         "📋 Summary", "💰 Costs", "⚙️ Performance", "🌀 System Curves",
         "🔄 Pump-System", "📉 DRA Curves", "🧊 3D Analysis and Surface Plots", "🧮 3D Pressure Profile",

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1126,7 +1126,6 @@ if not auto_batch:
     if run_day:
         with st.spinner("Running 9 optimizations (07:00 to 23:00)..."):
             import copy
-            from dra_utils import get_ppm_for_dr
             stations_base = copy.deepcopy(st.session_state.stations)
             term_data = {"name": terminal_name, "elev": terminal_elev, "min_residual": terminal_head}
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1459,17 +1459,29 @@ if not auto_batch:
                 file_name="linefill_snapshots.csv",
             )
 
-        hours = st.session_state.get("day_hours", [])
-        labels = [f"{h%24:02d}:00" for h in hours]
-        if labels:
-            options = list(range(len(labels)))
-            st.selectbox(
-                "Select Time for Detailed Results",
-                options,
-                key="detail_time_idx",
-                format_func=lambda i: labels[i],
-                on_change=update_detail_time,
-            )
+        # --- Station-wise cost summary ---
+        cost_cols = [
+            "Power & Fuel Cost (INR)",
+            "DRA Cost (INR)",
+            "Total Cost (INR)",
+        ]
+        agg = df_day.groupby("Station")[cost_cols].sum().reset_index().round(2)
+        styled_cost = agg.style.format({c: "{:.2f}" for c in cost_cols}).background_gradient(
+            subset=cost_cols, cmap="Greens"
+        )
+        st.markdown(
+            "<div class='section-title'>Station-wise Cost Summary</div>",
+            unsafe_allow_html=True,
+        )
+        st.dataframe(styled_cost, use_container_width=True, hide_index=True)
+
+        total_power = agg["Power & Fuel Cost (INR)"].sum()
+        total_dra = agg["DRA Cost (INR)"].sum()
+        total_cost = agg["Total Cost (INR)"].sum()
+        c1, c2, c3 = st.columns(3)
+        c1.metric("Total Power & Fuel Cost (INR)", f"{total_power:,.2f}")
+        c2.metric("Total DRA Cost (INR)", f"{total_dra:,.2f}")
+        c3.metric("Total Cost (INR)", f"{total_cost:,.2f}")
 
 
 if not auto_batch:

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -133,7 +133,7 @@ def check_login():
         )
         st.stop()
     with st.sidebar:
-        if st.button("Logout", key="logout_btn"):
+        if st.button("Logout", key="main_logout_btn"):
             st.session_state.authenticated = False
             st.rerun()
 check_login()

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -210,78 +210,48 @@ with st.sidebar:
             "Viscosity (cSt)": [10.0],
             "Density (kg/m³)": [850.0]
         })
-mode = st.radio("Choose input mode", ["Flow rate", "Pumping Schedule"], horizontal=True, key="op_mode")
+    mode = st.radio("Choose input mode", ["Flow rate", "Pumping Schedule"], horizontal=True, key="op_mode")
 
-if mode == "Flow rate":
-    # Flow rate is already captured as FLOW above.
-    st.markdown("**Linefill at 07:00 Hrs (Volumetric)**")
-    if "linefill_vol_df" not in st.session_state:
-        st.session_state["linefill_vol_df"] = pd.DataFrame({
-            "Product": ["Product-1"],
-            "Volume (m³)": [50000.0],
-            "Viscosity (cSt)": [5.0],
-            "Density (kg/m³)": [810.0]
-        })
-    st.session_state["linefill_vol_df"] = st.data_editor(
-        st.session_state["linefill_vol_df"],
-        num_rows="dynamic", key="linefill_vol_editor"
-    )
-else:
-    st.markdown("**Linefill at 07:00 Hrs (Volumetric)**")
-    if "linefill_vol_df" not in st.session_state:
-        st.session_state["linefill_vol_df"] = pd.DataFrame({
-            "Product": ["Product-1","Product-2","Product-3"],
-            "Volume (m³)": [50000.0, 40000.0, 15000.0],
-            "Viscosity (cSt)": [5.0, 12.0, 15.0],
-            "Density (kg/m³)": [810.0, 825.0, 865.0]
-        })
-    st.session_state["linefill_vol_df"] = st.data_editor(
-        st.session_state["linefill_vol_df"],
-        num_rows="dynamic", key="linefill_vol_editor"
-    )
-    st.markdown("**Pumping Plan for the Day (Order of Pumping)**")
-    if "day_plan_df" not in st.session_state:
-        st.session_state["day_plan_df"] = pd.DataFrame({
-            "Product": ["Product-4","Product-5","Product-6","Product-7"],
-            "Volume (m³)": [12000.0, 6000.0, 10000.0, 8000.0],
-            "Viscosity (cSt)": [3.0, 10.0, 15.0, 4.0],
-            "Density (kg/m³)": [800.0, 840.0, 880.0, 770.0]
-        })
-    st.session_state["day_plan_df"] = st.data_editor(
-        st.session_state["day_plan_df"],
-        num_rows="dynamic", key="day_plan_editor"
-    )
+    if mode == "Flow rate":
+        # Flow rate is already captured as FLOW above.
+        st.markdown("**Linefill at 07:00 Hrs (Volumetric)**")
+        if "linefill_vol_df" not in st.session_state:
+            st.session_state["linefill_vol_df"] = pd.DataFrame({
+                "Product": ["Product-1"],
+                "Volume (m³)": [50000.0],
+                "Viscosity (cSt)": [5.0],
+                "Density (kg/m³)": [810.0]
+            })
+        st.session_state["linefill_vol_df"] = st.data_editor(
+            st.session_state["linefill_vol_df"],
+            num_rows="dynamic", key="linefill_vol_editor"
+        )
+    else:
+        st.markdown("**Linefill at 07:00 Hrs (Volumetric)**")
+        if "linefill_vol_df" not in st.session_state:
+            st.session_state["linefill_vol_df"] = pd.DataFrame({
+                "Product": ["Product-1","Product-2","Product-3"],
+                "Volume (m³)": [50000.0, 40000.0, 15000.0],
+                "Viscosity (cSt)": [5.0, 12.0, 15.0],
+                "Density (kg/m³)": [810.0, 825.0, 865.0]
+            })
+        st.session_state["linefill_vol_df"] = st.data_editor(
+            st.session_state["linefill_vol_df"],
+            num_rows="dynamic", key="linefill_vol_editor"
+        )
+        st.markdown("**Pumping Plan for the Day (Order of Pumping)**")
+        if "day_plan_df" not in st.session_state:
+            st.session_state["day_plan_df"] = pd.DataFrame({
+                "Product": ["Product-4","Product-5","Product-6","Product-7"],
+                "Volume (m³)": [12000.0, 6000.0, 10000.0, 8000.0],
+                "Viscosity (cSt)": [3.0, 10.0, 15.0, 4.0],
+                "Density (kg/m³)": [800.0, 840.0, 880.0, 770.0]
+            })
+        st.session_state["day_plan_df"] = st.data_editor(
+            st.session_state["day_plan_df"],
+            num_rows="dynamic", key="day_plan_editor"
+        )
 
-
-    st.subheader("Stations")
-    add_col, rem_col = st.columns(2)
-    if "stations" not in st.session_state:
-        st.session_state["stations"] = [{
-            'name': 'Station 1', 'elev': 0.0, 'D': 0.711, 't': 0.007,
-            'SMYS': 52000.0, 'rough': 0.00004, 'L': 50.0,
-            'min_residual': 50.0, 'is_pump': False,
-            'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
-            'max_pumps': 1, 'MinRPM': 1200.0, 'DOL': 1500.0,
-            'max_dr': 0.0,
-            'delivery': 0.0,
-            'supply': 0.0
-        }]
-    if add_col.button("➕ Add Station"):
-        n = len(st.session_state.get('stations',[])) + 1
-        default = {
-            'name': f'Station {n}', 'elev': 0.0, 'D': 0.711, 't': 0.007,
-            'SMYS': 52000.0, 'rough': 0.00004, 'L': 50.0,
-            'min_residual': 50.0, 'is_pump': False,
-            'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
-            'max_pumps': 1, 'MinRPM': 1000.0, 'DOL': 1500.0,
-            'max_dr': 0.0,
-            'delivery': 0.0,
-            'supply': 0.0
-        }
-        st.session_state.stations.append(default)
-    if rem_col.button("🗑️ Remove Station"):
-        if st.session_state.get('stations'):
-            st.session_state.stations.pop()
 
 st.markdown("<div style='height: 1.5rem;'></div>", unsafe_allow_html=True)
 st.markdown(
@@ -318,6 +288,37 @@ st.markdown(
     unsafe_allow_html=True
 )
 st.markdown("<hr style='margin-top:0.6em; margin-bottom:1.2em; border: 1px solid #e1e5ec;'>", unsafe_allow_html=True)
+
+st.subheader("Stations")
+add_col, rem_col = st.columns(2)
+if "stations" not in st.session_state:
+    st.session_state["stations"] = [{
+        'name': 'Station 1', 'elev': 0.0, 'D': 0.711, 't': 0.007,
+        'SMYS': 52000.0, 'rough': 0.00004, 'L': 50.0,
+        'min_residual': 50.0, 'is_pump': False,
+        'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
+        'max_pumps': 1, 'MinRPM': 1200.0, 'DOL': 1500.0,
+        'max_dr': 0.0,
+        'delivery': 0.0,
+        'supply': 0.0
+    }]
+if add_col.button("➕ Add Station"):
+    n = len(st.session_state.get('stations',[])) + 1
+    default = {
+        'name': f'Station {n}', 'elev': 0.0, 'D': 0.711, 't': 0.007,
+        'SMYS': 52000.0, 'rough': 0.00004, 'L': 50.0,
+        'min_residual': 50.0, 'is_pump': False,
+        'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
+        'max_pumps': 1, 'MinRPM': 1000.0, 'DOL': 1500.0,
+        'max_dr': 0.0,
+        'delivery': 0.0,
+        'supply': 0.0
+    }
+    st.session_state.stations.append(default)
+if rem_col.button("🗑️ Remove Station"):
+    if st.session_state.get('stations'):
+        st.session_state.stations.pop()
+
 
 for idx, stn in enumerate(st.session_state.stations, start=1):
     with st.expander(f"Station {idx}: {stn['name']}", expanded=False):
@@ -729,6 +730,7 @@ def solve_pipeline(
     linefill_dict,
     dra_reach_km: float = 0.0,
     mop_kgcm2: float | None = None,
+    hours: float = 24.0,
 ):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
@@ -759,6 +761,7 @@ def solve_pipeline(
                 linefill_dict,
                 dra_reach_km,
                 mop_kgcm2,
+                hours,
             )
         return pipeline_model.solve_pipeline(
             stations,
@@ -771,6 +774,7 @@ def solve_pipeline(
             linefill_dict,
             dra_reach_km,
             mop_kgcm2,
+            hours,
         )
     except Exception as exc:  # pragma: no cover - diagnostic path
         return {"error": True, "message": str(exc)}
@@ -1168,6 +1172,7 @@ if not auto_batch:
             reports = []
             linefill_snaps = []
             dra_reach_km = 0.0
+            total_length = sum(stn.get('L', 0.0) for stn in stations_base)
 
             current_vol = vol_df.copy()
 
@@ -1177,7 +1182,8 @@ if not auto_batch:
 
                 res = solve_pipeline(
                     stns_run, term_data, FLOW_sched, kv_list, rho_list,
-                    RateDRA, Price_HSD, current_vol.to_dict(), dra_reach_km, st.session_state.get("MOP_kgcm2")
+                    RateDRA, Price_HSD, current_vol.to_dict(), dra_reach_km,
+                    st.session_state.get("MOP_kgcm2"), hours=4.0
                 )
 
                 if res.get("error"):
@@ -1194,10 +1200,11 @@ if not auto_batch:
                     key0 = stations_base[0]['name'].lower().replace(' ', '_')
                     vel0 = float(res.get(f"velocity_{key0}", 0.0))
                     ppm0 = float(res.get(f"dra_ppm_{key0}", 0.0))
+                    travel_km = vel0 * 4.0 * 3600.0 / 1000.0
                     if ppm0 > 0:
-                        dra_reach_km += vel0 * 4.0 * 3600.0 / 1000.0
+                        dra_reach_km = min(total_length, dra_reach_km + travel_km)
                     else:
-                        dra_reach_km = 0.0
+                        dra_reach_km = max(0.0, dra_reach_km - travel_km)
 
             # Build a consolidated table
             # We'll extract a few key outputs per station
@@ -1206,10 +1213,13 @@ if not auto_batch:
             keys = [n.lower().replace(' ', '_') for n in names]
 
             out_rows = []
+            summaries = []
             for rec in reports:
                 res = rec["result"]
                 hr = rec["time"]
-                row = {"Time": f"{hr:02d}:00", "Total Cost (INR/day)": float(res.get("total_cost",0.0))}
+                cost = float(res.get("total_cost", 0.0))
+                summaries.append(f"{hr:02d}:00 → Global minimum cost: {cost:,.2f} INR")
+                row = {"Time": f"{hr:02d}:00", "Total Cost (INR/4h)": cost}
                 for s in stations_used:
                     key = s['name'].lower().replace(' ', '_')
                     row[f"Num Pumps {s['name']}"] = res.get(f"num_pumps_{key}", "")
@@ -1219,6 +1229,8 @@ if not auto_batch:
 
             import pandas as pd
             df_day = pd.DataFrame(out_rows)
+            for msg in summaries:
+                st.write(msg)
             st.dataframe(df_day, use_container_width=True)
             st.download_button("Download 4-hourly Results", df_day.to_csv(index=False), file_name="daily_schedule_results.csv")
 


### PR DESCRIPTION
## Summary
- add utilities for converting linefill volumes to lengths and updating batches as product moves
- model partial DRA effect via reachable length and expose `dra_reach_km` parameter through solver API
- allow app wrapper to pass through DRA reach to pipeline model

## Testing
- `python -m py_compile pipeline_model.py linefill_utils.py pipeline_optimization_app.py dra_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_689713f1e35c833180f9542a7cee9f3b