### PR TITLE
Fix detail view tabs refresh

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -892,6 +892,8 @@ def update_detail_time() -> None:
     )
     if idx < len(linefills):
         st.session_state["last_linefill"] = copy.deepcopy(linefills[idx])
+    # Trigger a rerun so UI reflects newly loaded results immediately
+    st.rerun()
 
 # Persisted DRA lock from 07:00 run
 def lock_dra_in_stations_from_result(stations: list[dict], res: dict, kv_list: list[float]) -> list[dict]:


### PR DESCRIPTION
## Summary
- Trigger Streamlit rerun after selecting a daily interval so optimization tabs render immediately

## Testing
- `python -m py_compile pipeline_optimization_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6898c8bead9483319e754ef62a9e2264