### PR TITLE
Persist schedule inputs and support pump names

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -565,6 +565,7 @@ def solve_pipeline_multi_origin(
             for n in range(count):
                 unit = {
                     'name': f"{name_base}_{ptype}{n + 1}",
+                    'pump_name': pdata.get('name', f'Type {ptype}') if pdata else f'Type {ptype}',
                     'elev': origin_station.get('elev', 0.0),
                     'D': origin_station.get('D'),
                     't': origin_station.get('t'),


### PR DESCRIPTION
## Summary
- Save and restore operating mode, volumetric linefill, and daily pumping plan data in case JSON
- Allow entering pump names for origin pump types and other pumping stations and display them in schedules
- Propagate pump names through the optimisation model

## Testing
- `python -m py_compile pipeline_optimization_app.py pipeline_model.py`


------
https://chatgpt.com/codex/tasks/task_e_689c83ac19988331936b81a3acb1e69c