### PR TITLE
fix: include pump and input data in case JSON

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -731,6 +731,8 @@ def solve_pipeline_with_types(
                 units[0]['min_residual'] = stn.get('min_residual', min_res)
                 units[-1]['L'] = stn.get('L', 0.0)
                 units[-1]['max_dr'] = stn.get('max_dr', 0.0)
+                if stn.get('loopline'):
+                    units[-1]['loopline'] = copy.deepcopy(stn['loopline'])
                 expand_all(pos + 1, stn_acc + units, kv_acc + [kv] * len(units), rho_acc + [rho] * len(units))
         else:
             expand_all(pos + 1, stn_acc + [copy.deepcopy(stn)], kv_acc + [kv], rho_acc + [rho])

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -184,25 +184,26 @@ def restore_case_dict(loaded_data):
             st.session_state[f"eff_data_{i+1}"] = pd.DataFrame(eff_data)
         if peak_data is not None:
             st.session_state[f"peak_data_{i+1}"] = pd.DataFrame(peak_data)
-# Handle pump type data for originating station
-headA = loaded_data.get("head_data_1A", None)
-effA  = loaded_data.get("eff_data_1A", None)
-peakA = loaded_data.get("peak_data_1A", None)
-headB = loaded_data.get("head_data_1B", None)
-effB  = loaded_data.get("eff_data_1B", None)
-peakB = loaded_data.get("peak_data_1B", None)
-if headA is not None:
-    st.session_state["head_data_1A"] = pd.DataFrame(headA)
-if effA is not None:
-    st.session_state["eff_data_1A"] = pd.DataFrame(effA)
-if peakA is not None:
-    st.session_state["peak_data_1A"] = pd.DataFrame(peakA)
-if headB is not None:
-    st.session_state["head_data_1B"] = pd.DataFrame(headB)
-if effB is not None:
-    st.session_state["eff_data_1B"] = pd.DataFrame(effB)
-if peakB is not None:
-    st.session_state["peak_data_1B"] = pd.DataFrame(peakB)
+
+    # Handle pump type data for originating station
+    headA = loaded_data.get("head_data_1A", None)
+    effA  = loaded_data.get("eff_data_1A", None)
+    peakA = loaded_data.get("peak_data_1A", None)
+    headB = loaded_data.get("head_data_1B", None)
+    effB  = loaded_data.get("eff_data_1B", None)
+    peakB = loaded_data.get("peak_data_1B", None)
+    if headA is not None:
+        st.session_state["head_data_1A"] = pd.DataFrame(headA)
+    if effA is not None:
+        st.session_state["eff_data_1A"] = pd.DataFrame(effA)
+    if peakA is not None:
+        st.session_state["peak_data_1A"] = pd.DataFrame(peakA)
+    if headB is not None:
+        st.session_state["head_data_1B"] = pd.DataFrame(headB)
+    if effB is not None:
+        st.session_state["eff_data_1B"] = pd.DataFrame(effB)
+    if peakB is not None:
+        st.session_state["peak_data_1B"] = pd.DataFrame(peakB)
 
 uploaded_case = st.sidebar.file_uploader("🔁 Load Case", type="json", key="casefile")
 if uploaded_case is not None and not st.session_state.get("case_loaded", False):
@@ -1489,7 +1490,7 @@ if not auto_batch:
                         avail = int(pdata.get('available', 0))
                         names = pdata.get('names', [])
                         if len(names) < avail:
-                            names += [f"Pump {len(names)+i+1}" for i in range(avail - len(names))]
+                            names += [f"Pump {len(names_all)+i+1}" for i in range(avail - len(names))]
                         names_all.extend(names[:avail])
                     stn['pump_names'] = names_all
                     if names_all:
@@ -1610,7 +1611,7 @@ if not auto_batch:
                         avail = int(pdata.get('available', 0))
                         names = pdata.get('names', [])
                         if len(names) < avail:
-                            names += [f"Pump {len(names)+i+1}" for i in range(avail - len(names))]
+                            names += [f"Pump {len(names_all)+i+1}" for i in range(avail - len(names))]
                         names_all.extend(names[:avail])
                     stn['pump_names'] = names_all
                     if names_all:

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -184,19 +184,25 @@ def restore_case_dict(loaded_data):
             st.session_state[f"eff_data_{i+1}"] = pd.DataFrame(eff_data)
         if peak_data is not None:
             st.session_state[f"peak_data_{i+1}"] = pd.DataFrame(peak_data)
-    # Handle pump type data for originating station
-    headA = loaded_data.get("head_data_1A", None)
-    effA = loaded_data.get("eff_data_1A", None)
-    headB = loaded_data.get("head_data_1B", None)
-    effB = loaded_data.get("eff_data_1B", None)
-    if headA is not None:
-        st.session_state["head_data_1A"] = pd.DataFrame(headA)
-    if effA is not None:
-        st.session_state["eff_data_1A"] = pd.DataFrame(effA)
-    if headB is not None:
-        st.session_state["head_data_1B"] = pd.DataFrame(headB)
-    if effB is not None:
-        st.session_state["eff_data_1B"] = pd.DataFrame(effB)
+# Handle pump type data for originating station
+headA = loaded_data.get("head_data_1A", None)
+effA  = loaded_data.get("eff_data_1A", None)
+peakA = loaded_data.get("peak_data_1A", None)
+headB = loaded_data.get("head_data_1B", None)
+effB  = loaded_data.get("eff_data_1B", None)
+peakB = loaded_data.get("peak_data_1B", None)
+if headA is not None:
+    st.session_state["head_data_1A"] = pd.DataFrame(headA)
+if effA is not None:
+    st.session_state["eff_data_1A"] = pd.DataFrame(effA)
+if peakA is not None:
+    st.session_state["peak_data_1A"] = pd.DataFrame(peakA)
+if headB is not None:
+    st.session_state["head_data_1B"] = pd.DataFrame(headB)
+if effB is not None:
+    st.session_state["eff_data_1B"] = pd.DataFrame(effB)
+if peakB is not None:
+    st.session_state["peak_data_1B"] = pd.DataFrame(peakB)
 
 uploaded_case = st.sidebar.file_uploader("🔁 Load Case", type="json", key="casefile")
 if uploaded_case is not None and not st.session_state.get("case_loaded", False):
@@ -662,40 +668,54 @@ def get_full_case_dict():
         "proj_flow": proj_flow,
         "proj_plan": proj_plan,
         "planner_days": st.session_state.get('planner_days', 1.0),
+        # --- Pump curve data ---
         **{
             f"head_data_{i+1}": (
                 st.session_state.get(f"head_data_{i+1}").to_dict(orient="records")
-                if isinstance(st.session_state.get(f"head_data_{i+1}"), pd.DataFrame) else None
+                if isinstance(st.session_state.get(f"head_data_{i+1}"), pd.DataFrame)
+                else st.session_state.get('stations', [{}])[i].get('head_data') if i < len(st.session_state.get('stations', [])) else None
             )
             for i in range(len(st.session_state.get('stations', [])))
         },
         **{
             f"head_data_{1}{ptype}": (
                 st.session_state.get(f"head_data_{1}{ptype}").to_dict(orient="records")
-                if isinstance(st.session_state.get(f"head_data_{1}{ptype}"), pd.DataFrame) else None
+                if isinstance(st.session_state.get(f"head_data_{1}{ptype}"), pd.DataFrame)
+                else st.session_state.get('stations', [{}])[0].get('pump_types', {}).get(ptype, {}).get('head_data')
             )
             for ptype in ['A', 'B']
         },
         **{
             f"eff_data_{i+1}": (
                 st.session_state.get(f"eff_data_{i+1}").to_dict(orient="records")
-                if isinstance(st.session_state.get(f"eff_data_{i+1}"), pd.DataFrame) else None
+                if isinstance(st.session_state.get(f"eff_data_{i+1}"), pd.DataFrame)
+                else st.session_state.get('stations', [{}])[i].get('eff_data') if i < len(st.session_state.get('stations', [])) else None
             )
             for i in range(len(st.session_state.get('stations', [])))
         },
         **{
             f"eff_data_{1}{ptype}": (
                 st.session_state.get(f"eff_data_{1}{ptype}").to_dict(orient="records")
-                if isinstance(st.session_state.get(f"eff_data_{1}{ptype}"), pd.DataFrame) else None
+                if isinstance(st.session_state.get(f"eff_data_{1}{ptype}"), pd.DataFrame)
+                else st.session_state.get('stations', [{}])[0].get('pump_types', {}).get(ptype, {}).get('eff_data')
             )
             for ptype in ['A', 'B']
         },
         **{
             f"peak_data_{i+1}": (
                 st.session_state.get(f"peak_data_{i+1}").to_dict(orient="records")
-                if isinstance(st.session_state.get(f"peak_data_{i+1}"), pd.DataFrame) else None
+                if isinstance(st.session_state.get(f"peak_data_{i+1}"), pd.DataFrame)
+                else st.session_state.get('stations', [{}])[i].get('peak_data') if i < len(st.session_state.get('stations', [])) else None
             )
             for i in range(len(st.session_state.get('stations', [])))
+        },
+        **{
+            f"peak_data_{1}{ptype}": (
+                st.session_state.get(f"peak_data_{1}{ptype}").to_dict(orient="records")
+                if isinstance(st.session_state.get(f"peak_data_{1}{ptype}"), pd.DataFrame)
+                else st.session_state.get('stations', [{}])[0].get('pump_types', {}).get(ptype, {}).get('peak_data')
+            )
+            for ptype in ['A', 'B']
         }
     }
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1588,6 +1588,17 @@ if not auto_batch:
                 file_name="daily_schedule_results.csv",
             )
 
+            # Display total cost per time slice and global sum
+            cost_rows = [
+                {"Time": f"{rec['time']:02d}:00", "Total Cost (INR)": rec["result"].get("total_cost", 0.0)}
+                for rec in reports
+            ]
+            df_cost = pd.DataFrame(cost_rows).round(2)
+            st.dataframe(df_cost, use_container_width=True, hide_index=True)
+            st.markdown(
+                f"**Total Optimized Cost (24h): {df_cost['Total Cost (INR)'].sum():,.2f} INR**"
+            )
+
             combined = []
             for idx, df_line in enumerate(linefill_snaps):
                 hr = hours[idx] % 24
@@ -1731,6 +1742,20 @@ if not auto_batch:
                 "Download Dynamic Plan Output data",
                 df_plan.to_csv(index=False, float_format="%.2f"),
                 file_name="dynamic_plan_results.csv",
+            )
+
+            # Display total cost per interval and overall sum
+            cost_rows = [
+                {
+                    "Time": rec["time"].strftime("%d/%m %H:%M"),
+                    "Total Cost (INR)": rec["result"].get("total_cost", 0.0),
+                }
+                for rec in reports
+            ]
+            df_cost = pd.DataFrame(cost_rows).round(2)
+            st.dataframe(df_cost, use_container_width=True, hide_index=True)
+            st.markdown(
+                f"**Total Optimized Cost: {df_cost['Total Cost (INR)'].sum():,.2f} INR**"
             )
 
             combined = []

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -917,10 +917,11 @@ def build_summary_dataframe(res: dict, stations_data: list[dict], linefill_df: p
         station_ppm[key] = get_ppm_for_dr(viscosity, dr_use)
 
     segment_flows = [res.get(f"pipeline_flow_{k}", np.nan) for k in keys]
+    loop_flows = [res.get(f"loopline_flow_{k}", np.nan) for k in keys]
     pump_flows = [res.get(f"pump_flow_{k}", np.nan) for k in keys]
 
     params = [
-        "Pipeline Flow (m³/hr)", "Pump Flow (m³/hr)", "Power & Fuel Cost (INR)", "DRA Cost (INR)",
+        "Pipeline Flow (m³/hr)", "Loopline Flow (m³/hr)", "Pump Flow (m³/hr)", "Power & Fuel Cost (INR)", "DRA Cost (INR)",
         "DRA PPM", "No. of Pumps", "Pump Speed (rpm)", "Pump Eff (%)", "Pump BKW (kW)",
         "Motor Input (kW)", "Reynolds No.", "Head Loss (m)", "Head Loss (kg/cm²)", "Vel (m/s)",
         "Residual Head (m)", "Residual Head (kg/cm²)", "SDH (m)", "SDH (kg/cm²)",
@@ -932,6 +933,7 @@ def build_summary_dataframe(res: dict, stations_data: list[dict], linefill_df: p
         key = keys[idx]
         summary[nm] = [
             segment_flows[idx],
+            loop_flows[idx],
             pump_flows[idx] if idx < len(pump_flows) and not pd.isna(pump_flows[idx]) else np.nan,
             res.get(f"power_cost_{key}", 0.0),
             res.get(f"dra_cost_{key}", 0.0),
@@ -1007,6 +1009,7 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             'Station': station_display,
             'Pump Name': pump_name,
             'Pipeline Flow (m³/hr)': float(res.get(f"pipeline_flow_{key}", 0.0) or 0.0),
+            'Loopline Flow (m³/hr)': float(res.get(f"loopline_flow_{key}", 0.0) or 0.0),
             'Pump Flow (m³/hr)': float(res.get(f"pump_flow_{key}", 0.0) or 0.0),
             'Power & Fuel Cost (INR)': float(res.get(f"power_cost_{key}", 0.0) or 0.0),
             'DRA Cost (INR)': float(res.get(f"dra_cost_{key}", 0.0) or 0.0),

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -3215,7 +3215,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     viscosity = kv_list[idx]
                     dr_use = min(dr_opt, dr_max)
                     ppm = get_ppm_for_dr(viscosity, dr_use)
-                    seg_flow = res.get(f"pipeline_flow_{key}", FLOW)
+                    seg_flow = res.get(f"pump_flow_{key}", res.get(f"pipeline_flow_{key}", FLOW))
                     dra_cost = ppm * (seg_flow * 1000.0 * 24.0 / 1e6) * RateDRA
                     power_cost = float(res.get(f"power_cost_{key}", 0.0) or 0.0)
                     velocity = res.get(f"velocity_{key}", 0.0) or 0.0
@@ -3276,12 +3276,15 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     viscosity = kv_list[idx]
                     dr_use = min(dr_opt, dr_max)
                     ppm = get_ppm_for_dr(viscosity, dr_use)
-                    seg_flow = st.session_state["last_res"].get(f"pipeline_flow_{key}", FLOW)
+                    seg_flow = st.session_state["last_res"].get(
+                        f"pump_flow_{key}",
+                        st.session_state["last_res"].get(f"pipeline_flow_{key}", FLOW),
+                    )
                     dra_cost = ppm * (seg_flow * 1000.0 * 24.0 / 1e6) * RateDRA
                     power_cost = float(st.session_state["last_res"].get(f"power_cost_{key}", 0.0) or 0.0)
                     total_cost += dra_cost + power_cost
                     dr_opt2 = res2.get(f"drag_reduction_{key}", 0.0)
-                    seg_flow2 = res2.get(f"pipeline_flow_{key}", new_FLOW)
+                    seg_flow2 = res2.get(f"pump_flow_{key}", res2.get(f"pipeline_flow_{key}", new_FLOW))
                     ppm2 = get_ppm_for_dr(viscosity, min(dr_opt2, dr_max))
                     dra_cost2 = ppm2 * (seg_flow2 * 1000.0 * 24.0 / 1e6) * new_RateDRA
                     power_cost2 = float(res2.get(f"power_cost_{key}", 0.0) or 0.0)

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -652,8 +652,10 @@ def get_full_case_dict():
     else:
         proj_plan = []
 
+    stations = st.session_state.get('stations', [])
+    first_station = stations[0] if stations else {}
     return {
-        "stations": st.session_state.get('stations', []),
+        "stations": stations,
         "terminal": {
             "name": st.session_state.get('terminal_name', 'Terminal'),
             "elev": st.session_state.get('terminal_elev', 0.0),
@@ -674,15 +676,15 @@ def get_full_case_dict():
             f"head_data_{i+1}": (
                 st.session_state.get(f"head_data_{i+1}").to_dict(orient="records")
                 if isinstance(st.session_state.get(f"head_data_{i+1}"), pd.DataFrame)
-                else st.session_state.get('stations', [{}])[i].get('head_data') if i < len(st.session_state.get('stations', [])) else None
+                else stations[i].get('head_data')
             )
-            for i in range(len(st.session_state.get('stations', [])))
+            for i in range(len(stations))
         },
         **{
             f"head_data_{1}{ptype}": (
                 st.session_state.get(f"head_data_{1}{ptype}").to_dict(orient="records")
                 if isinstance(st.session_state.get(f"head_data_{1}{ptype}"), pd.DataFrame)
-                else st.session_state.get('stations', [{}])[0].get('pump_types', {}).get(ptype, {}).get('head_data')
+                else first_station.get('pump_types', {}).get(ptype, {}).get('head_data')
             )
             for ptype in ['A', 'B']
         },
@@ -690,15 +692,15 @@ def get_full_case_dict():
             f"eff_data_{i+1}": (
                 st.session_state.get(f"eff_data_{i+1}").to_dict(orient="records")
                 if isinstance(st.session_state.get(f"eff_data_{i+1}"), pd.DataFrame)
-                else st.session_state.get('stations', [{}])[i].get('eff_data') if i < len(st.session_state.get('stations', [])) else None
+                else stations[i].get('eff_data')
             )
-            for i in range(len(st.session_state.get('stations', [])))
+            for i in range(len(stations))
         },
         **{
             f"eff_data_{1}{ptype}": (
                 st.session_state.get(f"eff_data_{1}{ptype}").to_dict(orient="records")
                 if isinstance(st.session_state.get(f"eff_data_{1}{ptype}"), pd.DataFrame)
-                else st.session_state.get('stations', [{}])[0].get('pump_types', {}).get(ptype, {}).get('eff_data')
+                else first_station.get('pump_types', {}).get(ptype, {}).get('eff_data')
             )
             for ptype in ['A', 'B']
         },
@@ -706,15 +708,15 @@ def get_full_case_dict():
             f"peak_data_{i+1}": (
                 st.session_state.get(f"peak_data_{i+1}").to_dict(orient="records")
                 if isinstance(st.session_state.get(f"peak_data_{i+1}"), pd.DataFrame)
-                else st.session_state.get('stations', [{}])[i].get('peak_data') if i < len(st.session_state.get('stations', [])) else None
+                else stations[i].get('peak_data')
             )
-            for i in range(len(st.session_state.get('stations', [])))
+            for i in range(len(stations))
         },
         **{
             f"peak_data_{1}{ptype}": (
                 st.session_state.get(f"peak_data_{1}{ptype}").to_dict(orient="records")
                 if isinstance(st.session_state.get(f"peak_data_{1}{ptype}"), pd.DataFrame)
-                else st.session_state.get('stations', [{}])[0].get('pump_types', {}).get(ptype, {}).get('peak_data')
+                else first_station.get('pump_types', {}).get(ptype, {}).get('peak_data')
             )
             for ptype in ['A', 'B']
         }


### PR DESCRIPTION
## Summary
- ensure pump head/efficiency/peak curves always saved to case JSON
- restore pump type peak/head/efficiency data when uploading case

## Testing
- `python -m py_compile pipeline_optimization_app.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a2d40e37348331a266e10448cf5912