### PR TITLE
fix: persist pump curves and handle empty pump combos

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -716,6 +716,11 @@ def solve_pipeline_with_types(
                 stn['pump_types'].get('A', {}).get('available', 0),
                 stn['pump_types'].get('B', {}).get('available', 0),
             )
+            if not combos:
+                stn_copy = copy.deepcopy(stn)
+                stn_copy.pop('pump_types', None)
+                stn_copy['is_pump'] = False
+                expand_all(pos + 1, stn_acc + [stn_copy], kv_acc + [kv], rho_acc + [rho])
             for numA, numB in combos:
                 units: list[dict] = []
                 name_base = stn['name']


### PR DESCRIPTION
## Summary
- persist head/efficiency/peak curve data for pump types at every station
- include pump curve data for all pump types when saving cases
- treat stations with zero available pumps as non-pump segments to avoid false "no feasible combination" errors

## Testing
- `python -m py_compile pipeline_optimization_app.py pipeline_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae90ca7fac8331a18b5becb02ed424