### PR TITLE
Optimize downstream flow updates

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -647,6 +647,33 @@ def _downstream_requirement(
 
 
 # ---------------------------------------------------------------------------
+# Flow utilities
+# ---------------------------------------------------------------------------
+
+def _update_segment_flows(
+    segment_flows: list[float],
+    stations: list[dict],
+    idx: int,
+    next_flow: float,
+) -> list[float]:
+    """Return segment flows with downstream values recomputed from ``idx``.
+
+    Only the affected suffix starting immediately after ``idx`` is recalculated,
+    leaving the preceding portion unchanged.  ``segment_flows`` itself is not
+    modified.
+    """
+
+    # Copy the unaffected prefix once and rebuild the downstream suffix.
+    flows = segment_flows[: idx + 1]
+    flows.append(next_flow)
+    for j in range(idx + 1, len(stations)):
+        delivery_j = float(stations[j].get("delivery", 0.0))
+        supply_j = float(stations[j].get("supply", 0.0))
+        flows.append(flows[-1] - delivery_j + supply_j)
+    return flows
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -1425,21 +1452,13 @@ def solve_pipeline(
                     # Compute downstream residual head after segment loss and elevation
                     residual_next = sdh - sc['head_loss'] - stn_data['elev_delta']
 
-                    # Recompute downstream flows if bypassing the next station; the flow
-                    # through the mainline changes only for a bypass.  ``seg_flows_tmp``
-                    # holds the flow after each station.
-                    seg_flows_tmp = segment_flows.copy()
-                    # When bypassing the next station, only the mainline flow enters that station; the
-                    # loopline flow bypasses the pumps and rejoins downstream.  Therefore the flow for
-                    # downstream segments should reflect either the mainline-only flow (in bypass) or the
-                    # total flow (in parallel or loop-only modes).  This ensures head requirements are
-                    # computed against the proper volumetric flow in each pipe.
+                    # Recompute downstream flows; the mainline flow changes only for a
+                    # bypass.  ``seg_flows_tmp`` holds the flow after each station and
+                    # updates only the affected suffix.
                     next_flow = sc['flow_main'] if sc.get('bypass_next') else flow_total
-                    seg_flows_tmp[stn_data['idx'] + 1] = next_flow
-                    for j in range(stn_data['idx'] + 1, N):
-                        delivery_j = float(stations[j].get('delivery', 0.0))
-                        supply_j = float(stations[j].get('supply', 0.0))
-                        seg_flows_tmp[j + 1] = seg_flows_tmp[j] - delivery_j + supply_j
+                    seg_flows_tmp = _update_segment_flows(
+                        segment_flows, stations, stn_data['idx'], next_flow
+                    )
 
                     # Compute minimum downstream requirement and skip infeasible states
                     if sc.get('bypass_next') and stn_data['idx'] + 1 < N:

--- a/tests/test_flow_updates.py
+++ b/tests/test_flow_updates.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pipeline_model as pm
+
+
+def _old_update(segment_flows, stations, idx, next_flow):
+    flows = segment_flows.copy()
+    flows[idx + 1] = next_flow
+    for j in range(idx + 1, len(stations)):
+        delivery_j = float(stations[j].get('delivery', 0.0))
+        supply_j = float(stations[j].get('supply', 0.0))
+        flows[j + 1] = flows[j] - delivery_j + supply_j
+    return flows
+
+
+def _sample_data():
+    stations = [
+        {'delivery': 100, 'supply': 0},
+        {'delivery': 0, 'supply': 50},
+        {'delivery': 0, 'supply': 0},
+    ]
+    flows = [1000.0]
+    for stn in stations:
+        prev = flows[-1]
+        flows.append(prev - stn.get('delivery', 0.0) + stn.get('supply', 0.0))
+    return stations, flows
+
+
+def test_update_segment_flows_non_bypass():
+    stations, segment_flows = _sample_data()
+    idx = 0
+    next_flow = 920.0
+    expected = _old_update(segment_flows, stations, idx, next_flow)
+    updated = pm._update_segment_flows(segment_flows, stations, idx, next_flow)
+    assert updated == expected
+    assert segment_flows == [1000.0, 900.0, 950.0, 950.0]
+
+
+def test_update_segment_flows_bypass():
+    stations, segment_flows = _sample_data()
+    idx = 0
+    next_flow = 800.0
+    expected = _old_update(segment_flows, stations, idx, next_flow)
+    updated = pm._update_segment_flows(segment_flows, stations, idx, next_flow)
+    assert updated == expected
+    assert segment_flows == [1000.0, 900.0, 950.0, 950.0]


### PR DESCRIPTION
## Summary
- add `_update_segment_flows` helper to rebuild flows only for affected segments
- use helper in `solve_pipeline` instead of copying and recomputing all flows
- test bypass and non-bypass flow updates against previous method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67b4edc5483318a44549d1db2f180