### PR TITLE
Reload solver module before optimisation

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1637,6 +1637,12 @@ def invalidate_results():
 def run_all_updates():
     """Invalidate caches, rebuild station data and solve for the global optimum."""
     invalidate_results()
+    # Reload the optimisation core to pick up any recent code changes and to
+    # ensure the latest function signatures are available.  This avoids
+    # ``TypeError`` issues when new keyword arguments are introduced.
+    import importlib
+    importlib.reload(pipeline_model)
+
     stations_data = st.session_state.stations
     term_data = {
         "name": st.session_state.get("terminal_name", "Terminal"),


### PR DESCRIPTION
## Summary
- Reload optimisation module in `run_all_updates` so new keyword arguments like `loop_usage_by_station` are recognised
- Ensure loopline editor presents mixing option when loop and mainline diameters differ
- Solver enumerates loop scenarios respecting diameter equality and mixing flags

## Testing
- `python -m py_compile pipeline_optimization_app.py pipeline_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68b722cf168c8331afa0d8824280c8dc