### PR TITLE
Handle bypass flow recombination and downstream pump head

### DIFF
--- a/tests/test_bolpur_bypass.py
+++ b/tests/test_bolpur_bypass.py
@@ -1,0 +1,44 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from pipeline_model import solve_pipeline
+
+
+def test_bolpur_bypass_feasible():
+    stations = [
+        {
+            "name": "Origin",
+            "L": 0.0,
+            "d": 0.7,
+            "loopline": {"L": 0.0, "d": 0.7},
+            "is_pump": False,
+            "min_residual": 0,
+        },
+        {
+            "name": "Bolpur",
+            "L": 0.0,
+            "d": 0.7,
+            "is_pump": False,
+            "min_residual": 0,
+        },
+    ]
+    terminal = {"min_residual": 0}
+    kv = [1.0, 1.0]
+    rho = [850.0, 850.0]
+    result = solve_pipeline(
+        stations,
+        terminal,
+        1900.0,
+        kv,
+        rho,
+        RateDRA=0.0,
+        Price_HSD=0.0,
+        Fuel_density=0.0,
+        Ambient_temp=25.0,
+        loop_usage_by_station=[2, 0],
+        enumerate_loops=False,
+    )
+    assert not result.get("error")
+    assert result.get("bypass_next_origin") == 1
+


### PR DESCRIPTION
## Summary
- Recombine loop and mainline flow after bypass so downstream segments use total flow
- Preserve downstream pump contributions by passing pump flow overrides into `_downstream_requirement`
- Add regression test verifying feasible 1900 m³/hr operation with Bolpur bypass

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7edb5f37083318fdb005909a1652e