### PR TITLE
Add adaptive RPM/DRA refinement and 4h cost reporting

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -215,12 +215,30 @@ def _generate_loop_cases_by_flags(flags: list[bool]) -> list[list[int]]:
             unique.append(c)
     return unique
 
+
+def _generate_loop_cases_exhaustive(num_loops: int) -> list[list[int]]:
+    """Return all possible loop usage combinations for ``num_loops`` segments."""
+
+    if num_loops <= 0:
+        return [[]]
+    from itertools import product
+
+    states = [0, 1, 2, 3]
+    return [list(p) for p in product(states, repeat=num_loops)]
+
 # ---------------------------------------------------------------------------
 # Core calculations
 # ---------------------------------------------------------------------------
 
+# Finest resolution used for RPM and DRA enumeration
 RPM_STEP = 100
 DRA_STEP = 5
+# Coarser steps for the initial adaptive sweep.  These values were chosen to
+# reduce the number of combinations explored while still covering the global
+# search space.  Subsequent refinement will shrink the grid down to
+# ``RPM_STEP``/``DRA_STEP`` around the most promising coarse point.
+RPM_STEP_COARSE = 500
+DRA_STEP_COARSE = 20
 # Residual head precision (decimal places) used when bucketing states during the
 # dynamic-programming search.  Using a modest precision keeps the state space
 # tractable while still providing near-global optimality.
@@ -235,10 +253,151 @@ _PARALLEL_CACHE: dict[tuple, tuple] = {}
 
 
 def _allowed_values(min_val: int, max_val: int, step: int) -> list[int]:
+    """Return a list of allowed values, including ``max_val`` when within range.
+
+    The helper now guards against invalid intervals (``min_val > max_val``) or
+    non-positive ``step`` sizes by returning an empty list.  Callers must be
+    prepared to handle the empty case and skip option generation accordingly.
+    """
+
+    if step <= 0 or min_val > max_val:
+        return []
+
     vals = list(range(min_val, max_val + 1, step))
-    if vals[-1] != max_val:
+    if not vals or vals[-1] != max_val:
         vals.append(max_val)
     return vals
+
+
+def build_opts(
+    rpm_step: int,
+    dra_step: int,
+    rpm_min: int,
+    rpm_max: int,
+    min_pumps: int,
+    max_pumps: int,
+    kv: float,
+    fixed_dr: int | None = None,
+    dra_main_min: int = 0,
+    dra_main_max: int = 0,
+    dra_loop_min: int = 0,
+    dra_loop_max: int = 0,
+) -> list[dict]:
+    """Enumerate pump/DRA options for a station.
+
+    ``kv`` is used to convert drag reduction percentages to PPM via
+    :func:`get_ppm_for_dr`.  The returned list contains dictionaries with the
+    keys ``nop`` (number of pumps), ``rpm`` and DRA-related fields.
+    ``fixed_dr`` may supply a single drag-reduction percentage that overrides
+    the mainline search range.
+    """
+
+    rpm_vals = _allowed_values(rpm_min, rpm_max, rpm_step)
+    if fixed_dr is not None:
+        dra_main_vals = [int(round(fixed_dr))]
+    else:
+        dra_main_vals = _allowed_values(dra_main_min, dra_main_max, dra_step)
+    dra_loop_vals = (
+        _allowed_values(dra_loop_min, dra_loop_max, dra_step)
+        if dra_loop_max > 0
+        else [0]
+    )
+
+    opts: list[dict] = []
+    for nop in range(min_pumps, max_pumps + 1):
+        rpm_options = [0] if nop == 0 else rpm_vals
+        for rpm in rpm_options or [0]:
+            for dra_main in dra_main_vals or [0]:
+                for dra_loop in dra_loop_vals or [0]:
+                    ppm_main = get_ppm_for_dr(kv, dra_main) if dra_main > 0 else 0.0
+                    ppm_loop = get_ppm_for_dr(kv, dra_loop) if dra_loop > 0 else 0.0
+                    opts.append(
+                        {
+                            "nop": nop,
+                            "rpm": rpm,
+                            "dra_main": dra_main,
+                            "dra_loop": dra_loop,
+                            "dra_ppm_main": ppm_main,
+                            "dra_ppm_loop": ppm_loop,
+                        }
+                    )
+
+    # Ensure the option where the station is idle exists so that bypass or
+    # shutdown scenarios remain available even when no explicit combination
+    # produced ``nop == 0``.
+    if not any(o["nop"] == 0 for o in opts):
+        opts.insert(
+            0,
+            {
+                "nop": 0,
+                "rpm": 0,
+                "dra_main": 0,
+                "dra_loop": 0,
+                "dra_ppm_main": 0.0,
+                "dra_ppm_loop": 0.0,
+            },
+        )
+
+    return opts
+
+
+def _adaptive_enum(
+    stn: dict,
+    coarse_steps: tuple[int, int],
+    fine_steps: tuple[int, int],
+) -> list[dict]:
+    """Return a refined set of options using a coarse-to-fine sweep."""
+
+    rpm_step_c, dra_step_c = coarse_steps
+    rpm_step_f, dra_step_f = fine_steps
+
+    # Build coarse options across the full range
+    coarse_opts = build_opts(
+        rpm_step_c,
+        dra_step_c,
+        stn["rpm_min"],
+        stn["rpm_max"],
+        stn["min_pumps"],
+        stn["max_pumps"],
+        stn["kv"],
+        stn.get("fixed_dr"),
+        0,
+        stn["max_dr_main"],
+        0,
+        stn["max_dr_loop"],
+    )
+    if not coarse_opts:
+        return []
+
+    # Select the most promising coarse option using a simple heuristic that
+    # favours fewer pumps, lower RPM and lower drag-reduction dosage.
+    best_coarse = min(
+        coarse_opts,
+        key=lambda o: (o["nop"], o["rpm"], o["dra_main"] + o["dra_loop"]),
+    )
+
+    rpm_min_ref = max(stn["rpm_min"], best_coarse["rpm"] - rpm_step_c)
+    rpm_max_ref = min(stn["rpm_max"], best_coarse["rpm"] + rpm_step_c)
+    dra_main_min_ref = max(0, best_coarse["dra_main"] - dra_step_c)
+    dra_main_max_ref = min(stn["max_dr_main"], best_coarse["dra_main"] + dra_step_c)
+    dra_loop_min_ref = max(0, best_coarse["dra_loop"] - dra_step_c)
+    dra_loop_max_ref = min(stn["max_dr_loop"], best_coarse["dra_loop"] + dra_step_c)
+
+    refined_opts = build_opts(
+        rpm_step_f,
+        dra_step_f,
+        rpm_min_ref,
+        rpm_max_ref,
+        stn["min_pumps"],
+        stn["max_pumps"],
+        stn["kv"],
+        stn.get("fixed_dr"),
+        dra_main_min_ref,
+        dra_main_max_ref,
+        dra_loop_min_ref,
+        dra_loop_max_ref,
+    )
+    return refined_opts
 
 
 def _segment_hydraulics(
@@ -473,6 +632,8 @@ def _pump_head(stn: dict, flow_m3h: float, rpm: float, nop: int) -> list[dict]:
                     "eff": eff_single,
                     "count": count,
                     "power_type": pdata.get("power_type", stn.get("power_type")),
+                    "rpm": rpm,
+                    "ptype": ptype,
                     "data": pdata,
                 }
             )
@@ -500,6 +661,7 @@ def _pump_head(stn: dict, flow_m3h: float, rpm: float, nop: int) -> list[dict]:
             "eff": eff,
             "count": nop,
             "power_type": stn.get("power_type"),
+            "rpm": rpm,
             "data": stn,
         }
     )
@@ -696,6 +858,7 @@ def solve_pipeline(
     *,
     loop_usage_by_station: list[int] | None = None,
     enumerate_loops: bool = True,
+    adaptive: bool = True,
 ) -> dict:
     """Enumerate feasible options across all stations to find the lowest-cost
     operating strategy.
@@ -745,6 +908,7 @@ def solve_pipeline(
                 hours,
                 loop_usage_by_station=[],
                 enumerate_loops=False,
+                adaptive=adaptive,
             )
         # Determine per-loop diameter equality flags.  For each looped
         # segment compute whether the inner diameters of the mainline and
@@ -798,6 +962,7 @@ def solve_pipeline(
                 hours,
                 loop_usage_by_station=usage,
                 enumerate_loops=False,
+                adaptive=adaptive,
             )
             if res.get('error'):
                 continue
@@ -805,6 +970,43 @@ def solve_pipeline(
                 # Track which loop usage produced the best result.  Store a
                 # copy to avoid mutating the result of nested calls.  Users
                 # can inspect this field to derive human‑friendly names.
+                res_with_usage = res.copy()
+                res_with_usage['loop_usage'] = usage.copy()
+                best_res = res_with_usage
+        if best_res:
+            return best_res
+
+        # Fallback: try exhaustive loop combinations without adaptive refinement
+        exhaustive = _generate_loop_cases_exhaustive(num_loops)
+        best_res = None
+        for case in exhaustive:
+            usage = [0] * len(stations)
+            for pos, val in zip(loop_positions, case):
+                usage[pos] = val
+            res = solve_pipeline(
+                stations,
+                terminal,
+                FLOW,
+                KV_list,
+                rho_list,
+                RateDRA,
+                Price_HSD,
+                Fuel_density,
+                Ambient_temp,
+                linefill,
+                dra_reach_km,
+                mop_kgcm2,
+                hours,
+                loop_usage_by_station=usage,
+                enumerate_loops=False,
+                adaptive=False,
+            )
+            if res.get('error'):
+                continue
+            if (
+                best_res is None
+                or res.get('total_cost', float('inf')) < best_res.get('total_cost', float('inf'))
+            ):
                 res_with_usage = res.copy()
                 res_with_usage['loop_usage'] = usage.copy()
                 best_res = res_with_usage
@@ -967,38 +1169,58 @@ def solve_pipeline(
                 min_p = max(1, min_p)
                 origin_enforced = True
             max_p = stn.get('max_pumps', 2)
-            rpm_vals = _allowed_values(int(stn.get('MinRPM', 0)), int(stn.get('DOL', 0)), RPM_STEP)
+            rpm_min = int(stn.get('MinRPM', 0))
+            rpm_max = int(stn.get('DOL', 0))
             fixed_dr = stn.get('fixed_dra_perc', None)
             max_dr_main = int(stn.get('max_dr', 0))
-            if fixed_dr is not None:
-                dra_main_vals = [int(round(fixed_dr))]
+            max_dr_loop = int(loop_dict.get('max_dr', 0)) if loop_dict else 0
+
+            if adaptive:
+                stn_enum = {
+                    'min_pumps': min_p,
+                    'max_pumps': max_p,
+                    'kv': kv,
+                    'fixed_dr': fixed_dr,
+                    'max_dr_main': max_dr_main,
+                    'max_dr_loop': max_dr_loop,
+                    'rpm_min': rpm_min,
+                    'rpm_max': rpm_max,
+                }
+                opts = _adaptive_enum(
+                    stn_enum,
+                    (RPM_STEP_COARSE, DRA_STEP_COARSE),
+                    (RPM_STEP, DRA_STEP),
+                )
+                if not opts:
+                    opts = build_opts(
+                        RPM_STEP,
+                        DRA_STEP,
+                        rpm_min,
+                        rpm_max,
+                        min_p,
+                        max_p,
+                        kv,
+                        fixed_dr,
+                        0,
+                        max_dr_main,
+                        0,
+                        max_dr_loop,
+                    )
             else:
-                dra_main_vals = _allowed_values(0, max_dr_main, DRA_STEP)
-            dra_loop_vals = _allowed_values(0, int(loop_dict.get('max_dr', 0)), DRA_STEP) if loop_dict else [0]
-            for nop in range(min_p, max_p + 1):
-                rpm_opts = [0] if nop == 0 else rpm_vals
-                for rpm in rpm_opts:
-                    for dra_main in dra_main_vals:
-                        for dra_loop in dra_loop_vals:
-                            ppm_main = get_ppm_for_dr(kv, dra_main) if dra_main > 0 else 0.0
-                            ppm_loop = get_ppm_for_dr(kv, dra_loop) if dra_loop > 0 else 0.0
-                            opts.append({
-                                'nop': nop,
-                                'rpm': rpm,
-                                'dra_main': dra_main,
-                                'dra_loop': dra_loop,
-                                'dra_ppm_main': ppm_main,
-                                'dra_ppm_loop': ppm_loop,
-                            })
-            if not any(o['nop'] == 0 for o in opts):
-                opts.insert(0, {
-                    'nop': 0,
-                    'rpm': 0,
-                    'dra_main': 0,
-                    'dra_loop': 0,
-                    'dra_ppm_main': 0.0,
-                    'dra_ppm_loop': 0.0,
-                })
+                opts = build_opts(
+                    RPM_STEP,
+                    DRA_STEP,
+                    rpm_min,
+                    rpm_max,
+                    min_p,
+                    max_p,
+                    kv,
+                    fixed_dr,
+                    0,
+                    max_dr_main,
+                    0,
+                    max_dr_loop,
+                )
         else:
             # Non-pump stations can inject DRA independently whenever a
             # facility exists (max_dr > 0).  If no injection is available the
@@ -1770,6 +1992,10 @@ def solve_pipeline_with_types(
     dra_reach_km: float = 0.0,
     mop_kgcm2: float | None = None,
     hours: float = 24.0,
+    *,
+    loop_usage_by_station: list[int] | None = None,
+    enumerate_loops: bool = True,
+    adaptive: bool = True,
 ) -> dict:
     """Enumerate pump type combinations at all stations and call ``solve_pipeline``."""
 
@@ -1781,13 +2007,36 @@ def solve_pipeline_with_types(
     def expand_all(pos: int, stn_acc: list[dict], kv_acc: list[float], rho_acc: list[float]):
         nonlocal best_result, best_cost, best_stations
         if pos >= N:
-            # When all stations have been expanded into individual pump units,
-            # perform loop-case enumeration explicitly.  We determine the
-            # positions of units with looplines (typically the last unit of each
-            # physical station) and then build loop usage directives for each
-            # representative case.  This avoids relying on the internal
-            # loop-enumeration of ``solve_pipeline``, which can behave
-            # unpredictably when stations are split into multiple units.
+            # When all stations have been expanded into individual pump units
+            if loop_usage_by_station is not None:
+                # Use the provided loop usage directly
+                result = solve_pipeline(
+                    stn_acc,
+                    terminal,
+                    FLOW,
+                    kv_acc,
+                    rho_acc,
+                    RateDRA,
+                    Price_HSD,
+                    Fuel_density,
+                    Ambient_temp,
+                    linefill,
+                    dra_reach_km,
+                    mop_kgcm2,
+                    hours,
+                    loop_usage_by_station=loop_usage_by_station,
+                    enumerate_loops=enumerate_loops,
+                    adaptive=adaptive,
+                )
+                if not result.get("error"):
+                    cost = result.get("total_cost", float('inf'))
+                    if cost < best_cost:
+                        best_cost = cost
+                        best_result = result
+                        best_stations = stn_acc
+                return
+
+            # No explicit loop usage → enumerate representative cases
             loop_positions = [idx for idx, u in enumerate(stn_acc) if u.get('loopline')]
             # Always run at least once even if no loops exist
             if not loop_positions:
@@ -1798,7 +2047,6 @@ def solve_pipeline_with_types(
                 flags_expanded: list[bool] = []
                 for pidx in loop_positions:
                     stn_e = stn_acc[pidx]
-                    # Inner diameter of the mainline segment
                     if stn_e.get('D') is not None:
                         d_main_outer = stn_e['D']
                         t_main = stn_e.get('t', default_t_local)
@@ -1816,15 +2064,11 @@ def solve_pipeline_with_types(
                     else:
                         d_inner_loop = d_inner_main
                     flags_expanded.append(abs(d_inner_main - d_inner_loop) <= 1e-6)
-                # Generate loop-case combinations based on flags
                 cases = _generate_loop_cases_by_flags(flags_expanded)
             for case in cases:
                 usage = [0] * len(stn_acc)
                 for pidx, val in zip(loop_positions, case):
                     usage[pidx] = val
-                # Call solve_pipeline with explicit loop usage and disable
-                # internal enumeration.  This ensures the provided directives
-                # are respected even for split stations.
                 result = solve_pipeline(
                     stn_acc,
                     terminal,
@@ -1841,12 +2085,12 @@ def solve_pipeline_with_types(
                     hours,
                     loop_usage_by_station=usage,
                     enumerate_loops=False,
+                    adaptive=adaptive,
                 )
                 if result.get("error"):
                     continue
                 cost = result.get("total_cost", float('inf'))
                 if cost < best_cost:
-                    # Preserve usage directive for later labelling
                     result_with_usage = result.copy()
                     result_with_usage['loop_usage'] = usage.copy()
                     best_cost = cost

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -293,22 +293,28 @@ def build_opts(
     """
 
     rpm_vals = _allowed_values(rpm_min, rpm_max, rpm_step)
+    if not rpm_vals and max_pumps > 0:
+        return []
+
     if fixed_dr is not None:
         dra_main_vals = [int(round(fixed_dr))]
     else:
-        dra_main_vals = _allowed_values(dra_main_min, dra_main_max, dra_step)
+        dra_main_vals = _allowed_values(dra_main_min, dra_main_max, dra_step) or [0]
+
     dra_loop_vals = (
-        _allowed_values(dra_loop_min, dra_loop_max, dra_step)
+        _allowed_values(dra_loop_min, dra_loop_max, dra_step) or [0]
         if dra_loop_max > 0
         else [0]
     )
 
     opts: list[dict] = []
     for nop in range(min_pumps, max_pumps + 1):
+        if nop > 0 and not rpm_vals:
+            continue
         rpm_options = [0] if nop == 0 else rpm_vals
-        for rpm in rpm_options or [0]:
-            for dra_main in dra_main_vals or [0]:
-                for dra_loop in dra_loop_vals or [0]:
+        for rpm in rpm_options:
+            for dra_main in dra_main_vals:
+                for dra_loop in dra_loop_vals:
                     ppm_main = get_ppm_for_dr(kv, dra_main) if dra_main > 0 else 0.0
                     ppm_loop = get_ppm_for_dr(kv, dra_loop) if dra_loop > 0 else 0.0
                     opts.append(

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1756,6 +1756,13 @@ def solve_pipeline(
 
                     # Compute downstream residual head after segment loss and elevation
                     residual_next = sdh - sc['head_loss'] - stn_data['elev_delta']
+                    sdh_kgcm2 = head_to_kgcm2(sdh, stn_data['rho'])
+                    rh_kgcm2 = head_to_kgcm2(residual_next, stn_data['rho'])
+                    for p in pump_details:
+                        p['sdh'] = sdh
+                        p['sdh_kgcm2'] = sdh_kgcm2
+                        p['rh'] = residual_next
+                        p['rh_kgcm2'] = rh_kgcm2
 
                     # Recompute downstream flows if bypassing the next station; the flow
                     # through the mainline changes only for a bypass.  ``seg_flows_tmp``
@@ -1806,12 +1813,16 @@ def solve_pipeline(
                     # an injection is made.
                     dra_cost = 0.0
                     if inj_ppm_main > 0:
-                        dra_cost += inj_ppm_main * (sc['flow_main'] * 1000.0 * hours / 1e6) * RateDRA
+                        inj_kg_main = inj_ppm_main * (sc['flow_main'] * 1000.0 * hours / 1e6)
+                        inj_l_main = inj_kg_main  # assume 1 kg/L for DRA
+                        dra_cost += inj_l_main * RateDRA
                     # Loopline injection uses ``inj_ppm_loop`` computed
-                    # earlier.  Charge cost only when an actual injection is
+                    # earlier. Charge cost only when an actual injection is
                     # performed at this station.
                     if sc['flow_loop'] > 0 and inj_loop_current > 0:
-                        dra_cost += inj_ppm_loop * (sc['flow_loop'] * 1000.0 * hours / 1e6) * RateDRA
+                        inj_kg_loop = inj_ppm_loop * (sc['flow_loop'] * 1000.0 * hours / 1e6)
+                        inj_l_loop = inj_kg_loop  # assume 1 kg/L for DRA
+                        dra_cost += inj_l_loop * RateDRA
 
                     total_cost = power_cost + dra_cost
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1107,7 +1107,7 @@ def build_summary_dataframe(
 
     params = [
         "Pipeline Flow (m³/hr)", "Loopline Flow (m³/hr)", "Pump Flow (m³/hr)", "Bypass Next?",
-        "Power & Fuel Cost (INR)", "DRA Cost (INR)", "DRA PPM", "No. of Pumps", "Pump Speed (rpm)",
+        "Power & Fuel Cost 4h (INR)", "DRA Cost 4h (INR)", "DRA PPM", "No. of Pumps", "Pump Speed (rpm)",
         "Pump Eff (%)", "Pump BKW (kW)", "Motor Input (kW)", "Reynolds No.", "Head Loss (m)",
         "Head Loss (kg/cm²)", "Vel (m/s)", "Residual Head (m)", "Residual Head (kg/cm²)",
         "SDH (m)", "SDH (kg/cm²)", "MAOP (m)", "MAOP (kg/cm²)", "Drag Reduction (%)"
@@ -1217,8 +1217,8 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             'Pipeline Flow (m³/hr)': float(res.get(f"pipeline_flow_{key}", 0.0) or 0.0),
             'Loopline Flow (m³/hr)': float(res.get(f"loopline_flow_{key}", 0.0) or 0.0),
             'Pump Flow (m³/hr)': float(res.get(f"pump_flow_{key}", 0.0) or 0.0),
-            'Power & Fuel Cost (INR)': float(res.get(f"power_cost_{key}", 0.0) or 0.0),
-            'DRA Cost (INR)': float(res.get(f"dra_cost_{key}", 0.0) or 0.0),
+            'Power & Fuel Cost 4h (INR)': float(res.get(f"power_cost_{key}", 0.0) or 0.0),
+            'DRA Cost 4h (INR)': float(res.get(f"dra_cost_{key}", 0.0) or 0.0),
             'DRA PPM': float(res.get(f"dra_ppm_{key}", 0.0) or 0.0),
             'Loop DRA PPM': float(res.get(f"dra_ppm_loop_{key}", 0.0) or 0.0),
             'No. of Pumps': n_pumps,
@@ -1240,7 +1240,16 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             'Loop Drag Reduction (%)': float(res.get(f"drag_reduction_loop_{key}", 0.0) or 0.0),
         }
 
-        row['Total Cost (INR)'] = row['Power & Fuel Cost (INR)'] + row['DRA Cost (INR)']
+        # Include per-pump-type speed and efficiency when available
+        details = res.get(f"pump_details_{key}", [])
+        for pinfo in details:
+            ptype = pinfo.get('ptype')
+            if not ptype:
+                continue
+            row[f"Pump {ptype} Speed (rpm)"] = float(pinfo.get('rpm', row['Pump Speed (rpm)']) or 0.0)
+            row[f"Pump {ptype} Eff (%)"] = float(pinfo.get('eff', 0.0) or 0.0)
+
+        row['Total Cost 4h (INR)'] = row['Power & Fuel Cost 4h (INR)'] + row['DRA Cost 4h (INR)']
 
         # Available suction head only needs to be reported at the origin suction
         if idx == 0:
@@ -1297,6 +1306,8 @@ def solve_pipeline(
     dra_reach_km: float = 0.0,
     mop_kgcm2: float | None = None,
     hours: float = 24.0,
+    loop_usage_by_station: list[int] | None = None,
+    enumerate_loops: bool = True,
 ):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
@@ -1331,6 +1342,8 @@ def solve_pipeline(
                 dra_reach_km,
                 mop_kgcm2,
                 hours,
+                loop_usage_by_station=loop_usage_by_station,
+                enumerate_loops=enumerate_loops,
             )
         else:
             res = pipeline_model.solve_pipeline(
@@ -1347,6 +1360,8 @@ def solve_pipeline(
                 dra_reach_km,
                 mop_kgcm2,
                 hours,
+                loop_usage_by_station=loop_usage_by_station,
+                enumerate_loops=enumerate_loops,
             )
         # Append a human-readable flow pattern name based on loop usage
         if not res.get("error"):
@@ -1794,64 +1809,91 @@ if not auto_batch:
         error_msg = None
 
         with st.spinner("Running 6 optimizations (07:00 to 03:00)..."):
-            for ti, hr in enumerate(hours):
-                linefill_snaps.append(current_vol.copy())
-                sdh_hourly = []
-                res = {}
-                block_cost = 0.0
-                for sub in range(4):
-                    pumped_tmp = FLOW_sched * 1.0
-                    future_vol, future_plan = shift_vol_linefill(
-                        current_vol.copy(), pumped_tmp, plan_df.copy() if plan_df is not None else None
-                    )
-                    # Determine worst-case fluid properties over this 1h window
-                    kv_now, rho_now = kv_rho_from_vol(current_vol)
-                    kv_next, rho_next = kv_rho_from_vol(future_vol)
-                    kv_list = [max(a, b) for a, b in zip(kv_now, kv_next)]
-                    rho_list = [max(a, b) for a, b in zip(rho_now, rho_next)]
+                for ti, hr in enumerate(hours):
+                    linefill_snaps.append(current_vol.copy())
+                    sdh_hourly = []
+                    res = {}
+                    block_cost = 0.0
+                    cost_acc: dict[str, float] = {}
+                    pump_details_acc: dict[str, dict[str, dict]] = {}
+                    for sub in range(4):
+                        pumped_tmp = FLOW_sched * 1.0
+                        future_vol, future_plan = shift_vol_linefill(
+                            current_vol.copy(), pumped_tmp, plan_df.copy() if plan_df is not None else None
+                        )
+                        # Determine worst-case fluid properties over this 1h window
+                        kv_now, rho_now = kv_rho_from_vol(current_vol)
+                        kv_next, rho_next = kv_rho_from_vol(future_vol)
+                        kv_list = [max(a, b) for a, b in zip(kv_now, kv_next)]
+                        rho_list = [max(a, b) for a, b in zip(rho_now, rho_next)]
 
-                    stns_run = copy.deepcopy(stations_base)
+                        stns_run = copy.deepcopy(stations_base)
 
-                    res = solve_pipeline(
-                        stns_run,
-                        term_data,
-                        FLOW_sched,
-                        kv_list,
-                        rho_list,
-                        RateDRA,
-                        Price_HSD,
-                        st.session_state.get("Fuel_density", 820.0),
-                        st.session_state.get("Ambient_temp", 25.0),
-                        dra_linefill,
-                        dra_reach_km,
-                        st.session_state.get("MOP_kgcm2"),
-                        hours=1.0,
-                    )
+                        res_hour = solve_pipeline(
+                            stns_run,
+                            term_data,
+                            FLOW_sched,
+                            kv_list,
+                            rho_list,
+                            RateDRA,
+                            Price_HSD,
+                            st.session_state.get("Fuel_density", 820.0),
+                            st.session_state.get("Ambient_temp", 25.0),
+                            dra_linefill,
+                            dra_reach_km,
+                            st.session_state.get("MOP_kgcm2"),
+                            hours=1.0,
+                        )
 
-                    block_cost += res.get("total_cost", 0.0)
+                        block_cost += res_hour.get("total_cost", 0.0)
 
-                    if res.get("error"):
-                        cur_hr = (hr + sub) % 24
-                        error_msg = f"Optimization failed at {cur_hr:02d}:00 -> {res.get('message','')}"
+                        # accumulate station-wise costs and pump details over the 4h block
+                        for k, v in res_hour.items():
+                            if k.startswith("power_cost_") or k.startswith("dra_cost_"):
+                                cost_acc[k] = cost_acc.get(k, 0.0) + (v or 0.0)
+                            elif k.startswith("pump_details_"):
+                                st_key = k[len("pump_details_") :]
+                                acc = pump_details_acc.setdefault(st_key, {})
+                                for info in v:
+                                    ptype = info.get("ptype")
+                                    if not ptype:
+                                        continue
+                                    if info.get("rpm", 0) > 0:
+                                        acc[ptype] = {
+                                            "ptype": ptype,
+                                            "rpm": info.get("rpm"),
+                                            "eff": info.get("eff"),
+                                        }
+
+                        res = res_hour
+
+                        if res_hour.get("error"):
+                            cur_hr = (hr + sub) % 24
+                            error_msg = f"Optimization failed at {cur_hr:02d}:00 -> {res_hour.get('message','')}"
+                            break
+
+                        # Record SDH for objective calculation
+                        term_key = term_data["name"].lower().replace(" ", "_")
+                        keys = [s['name'].lower().replace(' ', '_') for s in stns_run]
+                        sdh_vals = [float(res.get(f"sdh_{k}", 0.0) or 0.0) for k in keys]
+                        sdh_vals.append(float(res.get(f"sdh_{term_key}", 0.0) or 0.0))
+                        sdh_hourly.append(max(sdh_vals))
+
+                        dra_linefill = res.get("linefill", dra_linefill)
+                        current_vol, plan_df = future_vol, future_plan
+                        current_vol = apply_dra_ppm(current_vol, dra_linefill)
+                        dra_reach_km = 0.0
+
+                    if error_msg:
                         break
 
-                    # Record SDH for objective calculation
-                    term_key = term_data["name"].lower().replace(" ", "_")
-                    keys = [s['name'].lower().replace(' ', '_') for s in stns_run]
-                    sdh_vals = [float(res.get(f"sdh_{k}", 0.0) or 0.0) for k in keys]
-                    sdh_vals.append(float(res.get(f"sdh_{term_key}", 0.0) or 0.0))
-                    sdh_hourly.append(max(sdh_vals))
-
-                    dra_linefill = res.get("linefill", dra_linefill)
-                    current_vol, plan_df = future_vol, future_plan
-                    current_vol = apply_dra_ppm(current_vol, dra_linefill)
-                    dra_reach_km = 0.0
-
-                if error_msg:
-                    break
-
-                res["total_cost"] = block_cost
-                reports.append({"time": hr % 24, "result": res, "sdh_hourly": sdh_hourly, "sdh_max": max(sdh_hourly) if sdh_hourly else 0.0})
+                    # overwrite per-station costs with 4h aggregates and attach pump details
+                    for k, v in cost_acc.items():
+                        res[k] = v
+                    for st_key, pdata in pump_details_acc.items():
+                        res[f"pump_details_{st_key}"] = list(pdata.values())
+                    res["total_cost"] = block_cost
+                    reports.append({"time": hr % 24, "result": res, "sdh_hourly": sdh_hourly, "sdh_max": max(sdh_hourly) if sdh_hourly else 0.0})
 
         if error_msg:
             st.error(error_msg)
@@ -1894,15 +1936,15 @@ if not auto_batch:
             {
                 "Time": f"{rec['time']:02d}:00",
                 "Pattern": rec["result"].get("flow_pattern_name", ""),
-                "Total Cost (INR)": rec["result"].get("total_cost", 0.0),
+                "Total Cost 4h (INR)": rec["result"].get("total_cost", 0.0),
             }
             for rec in reports
         ]
         df_cost = pd.DataFrame(cost_rows).round(2)
-        df_cost_style = df_cost.style.format({"Total Cost (INR)": "{:.2f}"})
+        df_cost_style = df_cost.style.format({"Total Cost 4h (INR)": "{:.2f}"})
         st.dataframe(df_cost_style, width='stretch', hide_index=True)
         st.markdown(
-            f"**Total Optimized Cost (24h): {df_cost['Total Cost (INR)'].sum():,.2f} INR**"
+            f"**Total Optimized Cost (24h): {df_cost['Total Cost 4h (INR)'].sum():,.2f} INR**"
         )
 
         combined = []
@@ -2074,15 +2116,15 @@ if not auto_batch:
                 {
                     "Time": rec["time"].strftime("%d/%m %H:%M"),
                     "Pattern": rec["result"].get("flow_pattern_name", ""),
-                    "Total Cost (INR)": rec["result"].get("total_cost", 0.0),
+                    "Total Cost 4h (INR)": rec["result"].get("total_cost", 0.0),
                 }
                 for rec in reports
             ]
             df_cost = pd.DataFrame(cost_rows).round(2)
-            df_cost_style = df_cost.style.format({"Total Cost (INR)": "{:.2f}"})
+            df_cost_style = df_cost.style.format({"Total Cost 4h (INR)": "{:.2f}"})
             st.dataframe(df_cost_style, width='stretch', hide_index=True)
             st.markdown(
-                f"**Total Optimized Cost: {df_cost['Total Cost (INR)'].sum():,.2f} INR**"
+                f"**Total Optimized Cost: {df_cost['Total Cost 4h (INR)'].sum():,.2f} INR**"
             )
 
             combined = []

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -464,6 +464,7 @@ if "stations" not in st.session_state:
         'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
         'max_pumps': 1, 'MinRPM': 1200.0, 'DOL': 1500.0,
         'max_dr': 0.0,
+        'min_dr': 0.0,
         'delivery': 0.0,
         'supply': 0.0
     }]
@@ -479,6 +480,7 @@ with st.sidebar:
             'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
             'max_pumps': 1, 'MinRPM': 1000.0, 'DOL': 1500.0,
             'max_dr': 0.0,
+            'min_dr': 0.0,
             'delivery': 0.0,
             'supply': 0.0
         }
@@ -496,6 +498,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
             stn['elev'] = st.number_input("Elevation (m)", value=stn['elev'], step=0.1, key=f"elev{idx}")
             stn['is_pump'] = st.checkbox("Pumping Station?", value=stn['is_pump'], key=f"pump{idx}")
             stn['L'] = st.number_input("Length to next Station (km)", value=stn['L'], step=1.0, key=f"L{idx}")
+            stn['min_dr'] = st.number_input("Min Drag Reduction (%)", value=stn.get('min_dr', 0.0), key=f"mindr{idx}")
             stn['max_dr'] = st.number_input("Max achievable Drag Reduction (%)", value=stn.get('max_dr', 0.0), key=f"mdr{idx}")
             if idx == 1:
                 stn['min_residual'] = st.number_input("Available Suction Head (m)", value=stn.get('min_residual',50.0), step=0.1, key=f"res{idx}")
@@ -528,6 +531,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                 loop['SMYS'] = st.number_input("SMYS (psi)", value=loop.get('SMYS', stn['SMYS']), step=1000.0, key=f"loopSMYS{idx}")
             with lcol3:
                 loop['rough'] = st.number_input("Pipe Roughness (m)", value=loop.get('rough', 0.00004), format="%.7f", step=0.0000001, key=f"looprough{idx}")
+                loop['min_dr'] = st.number_input("Min Drag Reduction (%)", value=loop.get('min_dr', 0.0), key=f"loopmindr{idx}")
                 loop['max_dr'] = st.number_input("Max Drag Reduction (%)", value=loop.get('max_dr', 0.0), key=f"loopmdr{idx}")
                 loop['elev'] = st.number_input("Elevation (m)", value=loop.get('elev', stn.get('elev',0.0)), step=0.1, key=f"loopelev{idx}")
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1111,8 +1111,8 @@ def build_summary_dataframe(
 
     params = [
         "Pipeline Flow (m³/hr)", "Loopline Flow (m³/hr)", "Pump Flow (m³/hr)", "Bypass Next?",
-        "Power & Fuel Cost 4h (INR)", "DRA Cost 4h (INR)", "DRA PPM", "No. of Pumps", "Pump Speed (rpm)",
-        "Pump Eff (%)", "Pump BKW (kW)", "Motor Input (kW)", "Reynolds No.", "Head Loss (m)",
+        "Power & Fuel Cost 4h (INR)", "DRA Cost 4h (INR)", "DRA PPM", "No. of Pumps",
+        "Pump BKW (kW)", "Motor Input (kW)", "Reynolds No.", "Head Loss (m)",
         "Head Loss (kg/cm²)", "Vel (m/s)", "Residual Head (m)", "Residual Head (kg/cm²)",
         "SDH (m)", "SDH (kg/cm²)", "MAOP (m)", "MAOP (kg/cm²)", "Drag Reduction (%)"
     ]
@@ -1226,8 +1226,6 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             'DRA PPM': float(res.get(f"dra_ppm_{key}", 0.0) or 0.0),
             'Loop DRA PPM': float(res.get(f"dra_ppm_loop_{key}", 0.0) or 0.0),
             'No. of Pumps': n_pumps,
-            'Pump Speed (rpm)': float(res.get(f"speed_{key}", 0.0) or 0.0),
-            'Pump Eff (%)': float(res.get(f"efficiency_{key}", 0.0) or 0.0),
             'Pump BKW (kW)': float(res.get(f"pump_bkw_{key}", 0.0) or 0.0),
             'Motor Input (kW)': float(res.get(f"motor_kw_{key}", 0.0) or 0.0),
             'Reynolds No.': float(res.get(f"reynolds_{key}", 0.0) or 0.0),
@@ -1250,8 +1248,10 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             ptype = pinfo.get('ptype')
             if not ptype:
                 continue
-            row[f"Pump {ptype} Speed (rpm)"] = float(pinfo.get('rpm', row['Pump Speed (rpm)']) or 0.0)
+            row[f"Pump {ptype} Speed (rpm)"] = float(pinfo.get('rpm', 0.0) or 0.0)
             row[f"Pump {ptype} Eff (%)"] = float(pinfo.get('eff', 0.0) or 0.0)
+            row[f"Pump {ptype} RH (m)"] = float(pinfo.get('rh', row['Residual Head (m)']) or 0.0)
+            row[f"Pump {ptype} SDH (m)"] = float(pinfo.get('sdh', row['SDH (m)']) or 0.0)
 
         row['Total Cost 4h (INR)'] = row['Power & Fuel Cost 4h (INR)'] + row['DRA Cost 4h (INR)']
 
@@ -1927,8 +1927,12 @@ if not auto_batch:
         df_day_style = (
             df_day_numeric.style.format(fmt_dict)
             .background_gradient(cmap="Blues", subset=num_cols)
+            .set_table_styles([
+                {"selector": "th", "props": [("text-align", "center")]},
+                {"selector": "td", "props": [("text-align", "center")]},
+            ])
         )
-        st.dataframe(df_day_style, width='stretch', hide_index=True)
+        st.dataframe(df_day_style, use_container_width=True, hide_index=True)
         st.download_button(
             "Download Daily Optimizer Output data",
             df_day.to_csv(index=False, float_format="%.2f"),


### PR DESCRIPTION
## Summary
- guard `_allowed_values` against invalid ranges and introduce coarse-step constants for adaptive searches
- add `build_opts`/`_adaptive_enum` helpers and `adaptive` flag in `solve_pipeline` with exhaustive loop fallback
- aggregate station costs over 4-hour blocks and accumulate per-pump-type details in frontend tables

## Testing
- `python -m py_compile pipeline_model.py pipeline_optimization_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2642380708331925d2294e2e8e1ec