### PR TITLE
Record run duration and refine schedule cost scaling

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1804,6 +1804,11 @@ def solve_pipeline(
     result[f"maop_{term_name}"] = last_maop_head
     result[f"maop_kgcm2_{term_name}"] = last_maop_kg
     result['total_cost'] = total_cost
+    # Propagate the run duration so callers can scale costs consistently.
+    # ``solve_pipeline`` may be invoked for arbitrary intervals (e.g. <4 hours)
+    # and downstream consumers need the actual duration to compute
+    # per‑interval costs.  Record it on the result before returning.
+    result['hours'] = hours
     result['dra_front_km'] = best_state.get('reach', 0.0)
     result['error'] = False
     return result

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1302,7 +1302,7 @@ def solve_pipeline(
                     pump_details = []
                     tdh = 0.0
 
-                eff = (
+                eff_pct = (
                     sum(p['eff'] * p['count'] for p in pump_details) / opt['nop']
                     if pump_details and opt['nop'] > 0
                     else 0.0
@@ -1351,8 +1351,8 @@ def solve_pipeline(
                     pinfo['power_cost'] = cost_i
                     power_cost += cost_i
 
-                pump_bkw = pump_bkw_total / opt['nop'] if opt['nop'] > 0 else 0.0
-                motor_kw = prime_kw_total / opt['nop'] if opt['nop'] > 0 else 0.0
+                pump_bkw = pump_bkw_total
+                motor_kw = prime_kw_total
 
                 # Filter candidate scenarios based on explicit loop-usage directives.
                 filtered_scenarios = []
@@ -1662,8 +1662,8 @@ def solve_pipeline(
                             f"num_pumps_{stn_data['name']}": opt['nop'],
                             f"speed_{stn_data['name']}": opt['rpm'],
                             # Store efficiency as a fraction on the raw key and as a percentage on a dedicated key.
-                            f"efficiency_{stn_data['name']}": eff,
-                            f"pump_efficiency_pct_{stn_data['name']}": eff * 100.0,
+                            f"efficiency_{stn_data['name']}": eff_pct / 100.0,
+                            f"pump_efficiency_pct_{stn_data['name']}": eff_pct,
                             f"pump_bkw_{stn_data['name']}": pump_bkw,
                             f"motor_kw_{stn_data['name']}": motor_kw,
                             f"power_cost_{stn_data['name']}": power_cost,


### PR DESCRIPTION
## Summary
- track run duration in `solve_pipeline` results
- scale per-interval costs only when needed and improve 4‑hour table assembly
- include run hours and 4‑hour costs in generated schedule records

## Testing
- `python -m py_compile pipeline_model.py pipeline_optimization_app.py`
- `python -W ignore - <<'PY' > /tmp/verify.log
from pipeline_optimization_app import build_4h_table, _per_interval_cost

schedule_results = [
    {"result": {"total_cost": 100.0, "hours": 4}},
    {"result": {"total_cost": 200.0, "hours": 2}},
    {"result": {"total_cost": 150.0, "hours": 1}},
]

df = build_4h_table(schedule_results, [])
print(df)
print('Table sum:', df['Cost (4h)'].sum())
print('Expected sum:', sum(_per_interval_cost(r['result'], 4.0) for r in schedule_results))
PY
 tail -n 20 /tmp/verify.log`

------
https://chatgpt.com/codex/tasks/task_e_68c32abc8db483318430a11a6c937a8b