### PR TITLE
Display per-type pump details

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -221,6 +221,7 @@ def _generate_loop_cases_by_flags(flags: list[bool]) -> list[list[int]]:
 
 RPM_STEP = 150
 DRA_STEP = 10
+MAX_DRA_KM = 200.0
 # Residual head precision (decimal places) used when bucketing states during the
 # dynamic-programming search.  Using a modest precision keeps the state space
 # tractable while still providing near-global optimality.
@@ -1065,6 +1066,7 @@ def solve_pipeline(
             'dol': int(stn.get('DOL', 0)),
             'power_type': stn.get('power_type', 'Grid'),
             'rate': float(stn.get('rate', 0.0)),
+            'tariffs': stn.get('tariffs'),
             'sfc': float(stn.get('sfc', 0.0)),
             'sfc_mode': stn.get('sfc_mode', 'manual'),
             'engine_params': stn.get('engine_params', {}),
@@ -1102,6 +1104,7 @@ def solve_pipeline(
             'flow': segment_flows[0],
             'carry_loop_dra': 0.0,
             'prev_ppm_main': linefill_state[0]['dra_ppm'] if linefill_state else 0.0,
+            'reach': max(float(dra_reach_km), 0.0),
         }
     }
 
@@ -1121,23 +1124,31 @@ def solve_pipeline(
                     usage_prev = loop_usage_by_station[stn_data['idx'] - 1]
                     if usage_prev == 2 and opt.get('dra_loop') not in (0, None):
                         continue
-                # Determine the downstream PPM on the mainline.  When pumps run,
-                # any upstream DRA is discarded and the selected injection sets the
-                # new concentration.  If pumps are bypassed, a non-zero injection
-                # overwrites the upstream PPM; otherwise the previous concentration
-                # is carried forward.
+                reach_prev = state.get('reach', 0.0)
                 if stn_data['is_pump'] and opt['nop'] > 0:
-                    ppm_main = opt['dra_ppm_main']
+                    if opt['dra_ppm_main'] > 0:
+                        ppm_main = opt['dra_ppm_main']
+                        dra_len_main = min(stn_data['L'], MAX_DRA_KM)
+                        reach_after = max(0.0, MAX_DRA_KM - stn_data['L'])
+                    else:
+                        ppm_main = 0.0
+                        dra_len_main = 0.0
+                        reach_after = 0.0
                 else:
                     if opt['dra_ppm_main'] > 0:
                         ppm_main = opt['dra_ppm_main']
+                        dra_len_main = min(stn_data['L'], MAX_DRA_KM)
+                        reach_after = max(0.0, MAX_DRA_KM - stn_data['L'])
                     else:
                         ppm_main = state.get('prev_ppm_main', 0.0)
+                        if reach_prev > 0 and ppm_main > 0:
+                            dra_len_main = min(stn_data['L'], reach_prev)
+                            reach_after = max(0.0, reach_prev - stn_data['L'])
+                        else:
+                            dra_len_main = 0.0
+                            reach_after = 0.0
                 inj_ppm_main = opt['dra_ppm_main'] if opt['dra_ppm_main'] > 0 else 0.0
-                # Convert the PPM into an effective drag‑reduction percentage for
-                # hydraulic calculations.
                 eff_dra_main = get_dr_for_ppm(stn_data['kv'], ppm_main) if ppm_main > 0 else 0.0
-                dra_len_main = stn_data['L'] if eff_dra_main > 0 else 0.0
 
                 scenarios = []
                 # Base scenario: flow through mainline only
@@ -1315,7 +1326,21 @@ def solve_pipeline(
                         fuel_per_kWh = (sfc_val * 1.34102) / Fuel_density if sfc_val else 0.0
                         cost_i = prime_kw_i * hours * fuel_per_kWh * Price_HSD
                     else:
-                        cost_i = prime_kw_i * hours * stn_data.get('rate', 0.0)
+                        tariffs = stn_data.get('tariffs')
+                        if tariffs:
+                            remaining = hours
+                            cost_i = 0.0
+                            for tr in tariffs:
+                                if remaining <= 0:
+                                    break
+                                dur = min(float(tr.get('hours', 0.0)), remaining)
+                                rate = float(tr.get('rate', stn_data.get('rate', 0.0)))
+                                cost_i += prime_kw_i * dur * rate
+                                remaining -= dur
+                            if remaining > 0:
+                                cost_i += prime_kw_i * remaining * stn_data.get('rate', 0.0)
+                        else:
+                            cost_i = prime_kw_i * hours * stn_data.get('rate', 0.0)
                     cost_i = max(cost_i, 0.0)
                     pinfo['pump_bkw'] = pump_bkw_i
                     pinfo['prime_kw'] = prime_kw_i
@@ -1638,7 +1663,7 @@ def solve_pipeline(
                             f"power_cost_{stn_data['name']}": power_cost,
                             f"dra_cost_{stn_data['name']}": dra_cost,
                             f"pump_details_{stn_data['name']}": [p.copy() for p in pump_details],
-                            f"dra_ppm_{stn_data['name']}": ppm_main,
+                            f"dra_ppm_{stn_data['name']}": inj_ppm_main,
                             f"dra_ppm_loop_{stn_data['name']}": inj_ppm_loop,
                             f"drag_reduction_{stn_data['name']}": eff_dra_main,
                             f"drag_reduction_loop_{stn_data['name']}": eff_dra_loop,
@@ -1654,7 +1679,7 @@ def solve_pipeline(
                             f"power_cost_{stn_data['name']}": 0.0,
                             f"dra_cost_{stn_data['name']}": dra_cost,
                             f"pump_details_{stn_data['name']}": [],
-                            f"dra_ppm_{stn_data['name']}": ppm_main,
+                            f"dra_ppm_{stn_data['name']}": inj_ppm_main,
                             f"dra_ppm_loop_{stn_data['name']}": inj_ppm_loop,
                             f"drag_reduction_{stn_data['name']}": eff_dra_main,
                             f"drag_reduction_loop_{stn_data['name']}": eff_dra_loop,
@@ -1683,11 +1708,10 @@ def solve_pipeline(
                             'records': new_record_list,
                             'last_maop': stn_data['maop_head'],
                             'last_maop_kg': stn_data['maop_kgcm2'],
-                            # ``reach`` removed because DRA advancement is no longer tracked
                             'flow': flow_next,
                             'carry_loop_dra': new_carry,
-                            # Propagate the resulting mainline PPM for downstream stations.
                             'prev_ppm_main': ppm_main,
+                            'reach': reach_after,
                         }
 
         if not new_states:
@@ -1895,6 +1919,7 @@ def solve_pipeline_with_types(
                             unit['DOL'] = pdata.get('DOL', unit.get('DOL', 0.0))
                             unit['power_type'] = pdata.get('power_type', unit.get('power_type', 'Grid'))
                             unit['rate'] = pdata.get('rate', unit.get('rate', 0.0))
+                            unit['tariffs'] = pdata.get('tariffs', unit.get('tariffs'))
                             unit['sfc'] = pdata.get('sfc', unit.get('sfc', 0.0))
                             unit['sfc_mode'] = pdata.get('sfc_mode', unit.get('sfc_mode', 'manual'))
                             unit['engine_params'] = pdata.get('engine_params', unit.get('engine_params', {}))
@@ -1909,6 +1934,7 @@ def solve_pipeline_with_types(
                             )
                             unit['power_type'] = pdataA.get('power_type', unit.get('power_type', 'Grid'))
                             unit['rate'] = pdataA.get('rate', unit.get('rate', 0.0))
+                            unit['tariffs'] = pdataA.get('tariffs', unit.get('tariffs'))
                             unit['sfc'] = pdataA.get('sfc', unit.get('sfc', 0.0))
                             unit['sfc_mode'] = pdataA.get('sfc_mode', unit.get('sfc_mode', 'manual'))
                             unit['engine_params'] = pdataA.get('engine_params', unit.get('engine_params', {}))

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -426,9 +426,11 @@ def _pump_head(stn: dict, flow_m3h: float, rpm: float, nop: int) -> list[dict]:
     The return value is a list of dictionaries with keys ``tdh`` (total head
     contributed by that pump type), ``eff`` (efficiency at the operating
     point), ``count`` (number of pumps of that type), ``power_type`` and the
-    original pump-type data under ``data``.  This allows callers to compute
-    power and cost contributions for each pump type individually instead of
-    relying on an averaged efficiency across all running pumps.
+    original pump-type data under ``data``.  The pump ``ptype`` identifier and
+    operating ``rpm`` are also included so callers can display detailed
+    information for each pump type.  This allows callers to compute power and
+    cost contributions for each pump type individually instead of relying on
+    an averaged efficiency across all running pumps.
     """
 
     if nop <= 0:
@@ -473,6 +475,8 @@ def _pump_head(stn: dict, flow_m3h: float, rpm: float, nop: int) -> list[dict]:
                     "eff": eff_single,
                     "count": count,
                     "power_type": pdata.get("power_type", stn.get("power_type")),
+                    "ptype": ptype,
+                    "rpm": rpm,
                     "data": pdata,
                 }
             )
@@ -500,6 +504,8 @@ def _pump_head(stn: dict, flow_m3h: float, rpm: float, nop: int) -> list[dict]:
             "eff": eff,
             "count": nop,
             "power_type": stn.get("power_type"),
+            "ptype": stn.get("pump_type", "type1"),
+            "rpm": rpm,
             "data": stn,
         }
     )

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -170,6 +170,7 @@ def restore_case_dict(loaded_data):
     st.session_state['terminal_head'] = loaded_data.get('terminal', {}).get('min_residual', 50.0)
     st.session_state['FLOW'] = loaded_data.get('FLOW', 1000.0)
     st.session_state['RateDRA'] = loaded_data.get('RateDRA', 500.0)
+    st.session_state['InitDRAppm'] = loaded_data.get('InitDRAppm', 4.0)
     st.session_state['Price_HSD'] = loaded_data.get('Price_HSD', 70.0)
     st.session_state['Fuel_density'] = loaded_data.get('Fuel_density', 820.0)
     st.session_state['Ambient_temp'] = loaded_data.get('Ambient_temp', 25.0)
@@ -270,6 +271,7 @@ with st.sidebar:
         with st.form("global_params"):
             FLOW = st.number_input("Flow rate (m³/hr)", value=st.session_state.get("FLOW", 1000.0), step=10.0, key="FLOW_input")
             RateDRA = st.number_input("DRA Cost (INR/L)", value=st.session_state.get("RateDRA", 500.0), step=1.0, key="RateDRA_input")
+            InitDRAppm = st.number_input("Initial Linefill DRA (ppm)", value=st.session_state.get("InitDRAppm", 4.0), step=0.5, key="InitDRAppm_input")
             Price_HSD = st.number_input("Fuel Price (INR/L)", value=st.session_state.get("Price_HSD", 70.0), step=0.5, key="Price_HSD_input")
             Fuel_density = st.number_input("Fuel density (kg/m³)", value=st.session_state.get("Fuel_density", 820.0), step=1.0, key="Fuel_density_input")
             Ambient_temp = st.number_input("Ambient temperature (°C)", value=st.session_state.get("Ambient_temp", 25.0), step=1.0, key="Ambient_temp_input")
@@ -278,12 +280,14 @@ with st.sidebar:
         if submitted_glob:
             st.session_state["FLOW"] = FLOW
             st.session_state["RateDRA"] = RateDRA
+            st.session_state["InitDRAppm"] = InitDRAppm
             st.session_state["Price_HSD"] = Price_HSD
             st.session_state["Fuel_density"] = Fuel_density
             st.session_state["Ambient_temp"] = Ambient_temp
             st.session_state["MOP_kgcm2"] = MOP_val
         FLOW = st.session_state.get("FLOW", 1000.0)
         RateDRA = st.session_state.get("RateDRA", 500.0)
+        InitDRAppm = st.session_state.get("InitDRAppm", 4.0)
         Price_HSD = st.session_state.get("Price_HSD", 70.0)
         Fuel_density = st.session_state.get("Fuel_density", 820.0)
         Ambient_temp = st.session_state.get("Ambient_temp", 25.0)
@@ -623,7 +627,23 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                                 dol = st.number_input(rated_label, value=pdata.get('DOL', 1500.0), key=f"dol{idx}{ptype}")
                             with pcol3:
                                 if ptype_sel == "Grid":
-                                    rate = st.number_input("Elec Rate (INR/kWh)", value=pdata.get('rate', 9.0), key=f"rate{idx}{ptype}")
+                                    tariff_mode = st.radio(
+                                        "Tariff",
+                                        ["Fixed", "Varying"],
+                                        index=0 if not pdata.get('tariffs') else 1,
+                                        key=f"tmode{idx}{ptype}"
+                                    )
+                                    if tariff_mode == "Fixed":
+                                        rate = st.number_input("Elec Rate (INR/kWh)", value=pdata.get('rate', 9.0), key=f"rate{idx}{ptype}")
+                                        tariffs = []
+                                    else:
+                                        tdf = st.data_editor(
+                                            pd.DataFrame(pdata.get('tariffs', [{'rate': 9.0, 'hours': 1.0}])),
+                                            num_rows="dynamic",
+                                            key=f"tariff{idx}{ptype}",
+                                        )
+                                        tariffs = tdf.to_dict(orient="records")
+                                        rate = 0.0
                                     sfc_mode = "none"
                                     sfc = 0.0
                                     engine_params = {}
@@ -667,6 +687,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                                             'sfc100': sfc100,
                                         }
                                     rate = 0.0
+                                    tariffs = []
 
                             stn.setdefault('pump_types', {})[ptype] = {
                                 'names': names,
@@ -677,6 +698,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                                 'MinRPM': minrpm,
                                 'DOL': dol,
                                 'rate': rate,
+                                'tariffs': tariffs,
                                 'sfc_mode': 'manual' if sfc_mode == "Enter manually" else ('iso' if ptype_sel == 'Diesel' else 'none'),
                                 'sfc': sfc,
                                 'engine_params': engine_params,
@@ -792,6 +814,7 @@ def get_full_case_dict():
         },
         "FLOW": st.session_state.get('FLOW', 1000.0),
         "RateDRA": st.session_state.get('RateDRA', 500.0),
+        "InitDRAppm": st.session_state.get('InitDRAppm', 4.0),
         "Price_HSD": st.session_state.get('Price_HSD', 70.0),
         "Fuel_density": st.session_state.get('Fuel_density', 820.0),
         "Ambient_temp": st.session_state.get('Ambient_temp', 25.0),
@@ -1044,11 +1067,12 @@ def df_to_dra_linefill(df: pd.DataFrame) -> list[dict]:
     col_vol = "Volume (m³)" if "Volume (m³)" in df.columns else "Volume"
     col_ppm = "DRA ppm" if "DRA ppm" in df.columns else "dra_ppm"
     batches: list[dict] = []
+    default_ppm = st.session_state.get("InitDRAppm", 4.0)
     for _, r in df.iterrows():
         vol = float(r.get(col_vol, 0.0) or 0.0)
         if vol <= 0:
             continue
-        ppm = float(r.get(col_ppm, 0.0) or 0.0)
+        ppm = float(r.get(col_ppm, default_ppm) or default_ppm)
         batches.append({"volume": vol, "dra_ppm": ppm})
     return batches
 
@@ -1158,7 +1182,15 @@ def build_summary_dataframe(
                     drop_cols.append(stn['name'])
         if drop_cols:
             df_sum.drop(columns=drop_cols, inplace=True, errors='ignore')
-    return df_sum.round(2)
+    df_sum = df_sum.round(2)
+    if 'DRA PPM' in df_sum['Parameters'].values:
+        idx = df_sum[df_sum['Parameters'] == 'DRA PPM'].index[0]
+        for col in df_sum.columns:
+            if col == 'Parameters':
+                continue
+            val = df_sum.at[idx, col]
+            df_sum.at[idx, col] = val if float(val or 0) > 0 else 'NIL'
+    return df_sum
 
 
 def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
@@ -1225,8 +1257,8 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             'Pump Flow (m³/hr)': float(res.get(f"pump_flow_{key}", 0.0) or 0.0),
             'Power & Fuel Cost (INR)': float(res.get(f"power_cost_{key}", 0.0) or 0.0),
             'DRA Cost (INR)': float(res.get(f"dra_cost_{key}", 0.0) or 0.0),
-            'DRA PPM': float(res.get(f"dra_ppm_{key}", 0.0) or 0.0),
-            'Loop DRA PPM': float(res.get(f"dra_ppm_loop_{key}", 0.0) or 0.0),
+            'DRA PPM': res.get(f"dra_ppm_{key}", 0.0),
+            'Loop DRA PPM': res.get(f"dra_ppm_loop_{key}", 0.0),
             'No. of Pumps': n_pumps,
             'Pump Speed (rpm)': float(res.get(f"speed_{key}", 0.0) or 0.0),
             'Pump Eff (%)': float(res.get(f"efficiency_{key}", 0.0) or 0.0),
@@ -1259,7 +1291,13 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
         rows.append(row)
 
     df = pd.DataFrame(rows)
-    return df.round(2)
+    num_cols = df.select_dtypes(include='number').columns
+    df[num_cols] = df[num_cols].round(2)
+    if 'DRA PPM' in df.columns:
+        df['DRA PPM'] = df['DRA PPM'].apply(lambda x: x if float(x or 0) > 0 else 'NIL')
+    if 'Loop DRA PPM' in df.columns:
+        df['Loop DRA PPM'] = df['Loop DRA PPM'].apply(lambda x: x if float(x or 0) > 0 else 'NIL')
+    return df
 
 
 def display_pump_type_details(res: dict, stations: list[dict], heading: str | None = None) -> bool:
@@ -1520,7 +1558,8 @@ if auto_batch:
                         row[f"Speed {stn['name']}"] = res.get(f"speed_{key}", "")
                         row[f"SDH {stn['name']}"] = fmt_pressure(res, f"sdh_{key}", f"sdh_kgcm2_{key}")
                         row[f"RH {stn['name']}"] = fmt_pressure(res, f"residual_head_{key}", f"rh_kgcm2_{key}")
-                        row[f"DRA PPM {stn['name']}"] = res.get(f"dra_ppm_{key}", "")
+                        _ppm = res.get(f"dra_ppm_{key}", 0.0)
+                        row[f"DRA PPM {stn['name']}"] = _ppm if float(_ppm or 0) > 0 else "NIL"
                         row[f"Power Cost {stn['name']}"] = res.get(f"power_cost_{key}", "")
                         row[f"Drag Reduction {stn['name']}"] = res.get(f"drag_reduction_{key}", "")
                     row["Total Cost"] = res.get("total_cost", "")
@@ -1540,7 +1579,8 @@ if auto_batch:
                         row[f"Speed {stn['name']}"] = res.get(f"speed_{key}", "")
                         row[f"SDH {stn['name']}"] = fmt_pressure(res, f"sdh_{key}", f"sdh_kgcm2_{key}")
                         row[f"RH {stn['name']}"] = fmt_pressure(res, f"residual_head_{key}", f"rh_kgcm2_{key}")
-                        row[f"DRA PPM {stn['name']}"] = res.get(f"dra_ppm_{key}", "")
+                        _ppm = res.get(f"dra_ppm_{key}", 0.0)
+                        row[f"DRA PPM {stn['name']}"] = _ppm if float(_ppm or 0) > 0 else "NIL"
                         row[f"Power Cost {stn['name']}"] = res.get(f"power_cost_{key}", "")
                         row[f"Drag Reduction {stn['name']}"] = res.get(f"drag_reduction_{key}", "")
                     row["Total Cost"] = res.get("total_cost", "")
@@ -1571,7 +1611,8 @@ if auto_batch:
                             row[f"Speed {stn['name']}"] = res.get(f"speed_{key}", "")
                             row[f"SDH {stn['name']}"] = fmt_pressure(res, f"sdh_{key}", f"sdh_kgcm2_{key}")
                             row[f"RH {stn['name']}"] = fmt_pressure(res, f"residual_head_{key}", f"rh_kgcm2_{key}")
-                            row[f"DRA PPM {stn['name']}"] = res.get(f"dra_ppm_{key}", "")
+                            _ppm = res.get(f"dra_ppm_{key}", 0.0)
+                            row[f"DRA PPM {stn['name']}"] = _ppm if float(_ppm or 0) > 0 else "NIL"
                             row[f"Power Cost {stn['name']}"] = res.get(f"power_cost_{key}", "")
                             row[f"Drag Reduction {stn['name']}"] = res.get(f"drag_reduction_{key}", "")
                         row["Total Cost"] = res.get("total_cost", "")
@@ -1595,7 +1636,8 @@ if auto_batch:
                             row[f"Speed {stn['name']}"] = res.get(f"speed_{key}", "")
                             row[f"SDH {stn['name']}"] = fmt_pressure(res, f"sdh_{key}", f"sdh_kgcm2_{key}")
                             row[f"RH {stn['name']}"] = fmt_pressure(res, f"residual_head_{key}", f"rh_kgcm2_{key}")
-                            row[f"DRA PPM {stn['name']}"] = res.get(f"dra_ppm_{key}", "")
+                            _ppm = res.get(f"dra_ppm_{key}", 0.0)
+                            row[f"DRA PPM {stn['name']}"] = _ppm if float(_ppm or 0) > 0 else "NIL"
                             row[f"Power Cost {stn['name']}"] = res.get(f"power_cost_{key}", "")
                             row[f"Drag Reduction {stn['name']}"] = res.get(f"drag_reduction_{key}", "")
                         row["Total Cost"] = res.get("total_cost", "")
@@ -1633,7 +1675,8 @@ if auto_batch:
                                 row[f"Speed {stn['name']}"] = res.get(f"speed_{key}", "")
                                 row[f"SDH {stn['name']}"] = fmt_pressure(res, f"sdh_{key}", f"sdh_kgcm2_{key}")
                                 row[f"RH {stn['name']}"] = fmt_pressure(res, f"residual_head_{key}", f"rh_kgcm2_{key}")
-                                row[f"DRA PPM {stn['name']}"] = res.get(f"dra_ppm_{key}", "")
+                                _ppm = res.get(f"dra_ppm_{key}", 0.0)
+                                row[f"DRA PPM {stn['name']}"] = _ppm if float(_ppm or 0) > 0 else "NIL"
                                 row[f"Power Cost {stn['name']}"] = res.get(f"power_cost_{key}", "")
                                 row[f"Drag Reduction {stn['name']}"] = res.get(f"drag_reduction_{key}", "")
                             row["Total Cost"] = res.get("total_cost", "")
@@ -1744,8 +1787,8 @@ def run_all_updates():
             st.session_state.get("Price_HSD", 70.0),
             st.session_state.get("Fuel_density", 820.0),
             st.session_state.get("Ambient_temp", 25.0),
-            linefill_df.to_dict(),
-            0.0,
+            df_to_dra_linefill(linefill_df),
+            200.0,
             st.session_state.get("MOP_kgcm2"),
             24.0,
         )
@@ -1825,7 +1868,7 @@ if not auto_batch:
         reports = []
         linefill_snaps = []
         total_length = sum(stn.get('L', 0.0) for stn in stations_base)
-        dra_reach_km = 0.0
+        dra_reach_km = 200.0
 
         current_vol = vol_df.copy()
         if "DRA ppm" not in current_vol.columns:
@@ -1886,7 +1929,7 @@ if not auto_batch:
                     dra_linefill = res.get("linefill", dra_linefill)
                     current_vol, plan_df = future_vol, future_plan
                     current_vol = apply_dra_ppm(current_vol, dra_linefill)
-                    dra_reach_km = 0.0
+                    dra_reach_km = res.get("dra_front_km", dra_reach_km)
 
                 if error_msg:
                     break
@@ -2024,7 +2067,7 @@ if not auto_batch:
             current_vol = apply_dra_ppm(current_vol, dra_linefill)
             reports = []
             linefill_snaps = []
-            dra_reach_km = 0.0
+            dra_reach_km = 200.0
 
             for _, row in flow_df.iterrows():
                 flow = float(row.get("Flow (m³/h)", row.get("Flow", 0.0)) or 0.0)
@@ -2075,7 +2118,7 @@ if not auto_batch:
                     current_vol = apply_dra_ppm(future_vol, dra_linefill)
                     # In the revised model DRA does not propagate downstream over time.
                     # Keep the DRA reach constant (zero).
-                    dra_reach_km = 0.0
+                    dra_reach_km = res.get("dra_front_km", dra_reach_km)
                     seg_start = seg_end
 
             if not reports:
@@ -3190,6 +3233,11 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
         kv_list, rho_list = map_linefill_to_segments(linefill_df, stations_data)
         rho = rho_list[pump_idx]
         rate = stn.get('rate', 9.0)
+        tariffs = stn.get('tariffs')
+        if tariffs:
+            hrs = sum(t.get('hours', 0.0) for t in tariffs)
+            if hrs > 0:
+                rate = sum(t.get('rate', 0.0) * t.get('hours', 0.0) for t in tariffs) / hrs
         g = 9.81
     
         def get_head(q, n): return (A*q**2 + B*q + Cc)*(n/DOL)**2


### PR DESCRIPTION
## Summary
- Include pump `ptype` and `rpm` in optimizer pump detail output
- Show per-pump-type table with speed, efficiency, BKW, and motor input in the app when multiple pump types run

## Testing
- `python -m py_compile pipeline_model.py pipeline_optimization_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3a295e6f48331b34d99ff2f01214c