### PR TITLE
Accumulate mainline DRA ppm across stations

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1127,7 +1127,7 @@ def solve_pipeline(
                 reach_prev = state.get('reach', 0.0)
                 if stn_data['is_pump'] and opt['nop'] > 0:
                     if opt['dra_ppm_main'] > 0:
-                        ppm_main = opt['dra_ppm_main']
+                        ppm_main = state.get('prev_ppm_main', 0.0) + opt['dra_ppm_main']
                         dra_len_main = min(stn_data['L'], MAX_DRA_KM)
                         reach_after = max(0.0, MAX_DRA_KM - stn_data['L'])
                     else:
@@ -1136,7 +1136,7 @@ def solve_pipeline(
                         reach_after = 0.0
                 else:
                     if opt['dra_ppm_main'] > 0:
-                        ppm_main = opt['dra_ppm_main']
+                        ppm_main = state.get('prev_ppm_main', 0.0) + opt['dra_ppm_main']
                         dra_len_main = min(stn_data['L'], MAX_DRA_KM)
                         reach_after = max(0.0, MAX_DRA_KM - stn_data['L'])
                     else:


### PR DESCRIPTION
## Summary
- Sum upstream DRA concentration with new injection to determine mainline ppm
- Carry cumulative DRA ppm downstream via `prev_ppm_main` state

## Testing
- `python -m py_compile pipeline_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68c44bf487d8833184e02a2c7cc6b627