### PR TITLE
Handle empty tariff list with default row

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -638,7 +638,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                                         tariffs = []
                                     else:
                                         tdf = st.data_editor(
-                                            pd.DataFrame(pdata.get('tariffs', [{'rate': 9.0, 'hours': 1.0}])),
+                                            pd.DataFrame(pdata.get('tariffs') or [{'rate': 9.0, 'hours': 1.0}]),
                                             num_rows="dynamic",
                                             key=f"tariff{idx}{ptype}",
                                         )


### PR DESCRIPTION
## Summary
- Ensure varying tariff editor always displays default rate and hours row

## Testing
- `python -m py_compile pipeline_optimization_app.py`
- `timeout 5 streamlit run pipeline_optimization_app.py --server.headless true`
- `python - <<'PY'
import pandas as pd
pdata={'tariffs': []}
df = pd.DataFrame(pdata.get('tariffs') or [{'rate': 9.0, 'hours': 1.0}])
df.loc[len(df)] = {'rate': 5.0, 'hours': 2.0}
print(df)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c4682e4c308331a234b1f3825ceb84