### PR TITLE
Add Numba-compatible hydraulic functions

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -350,15 +350,19 @@ def _segment_hydraulics(
     else:
         f = np.float64(0.0)
 
-    if dra_length is None or dra_length >= L:
+    if dra_length is None:
         hl_dra = f * ((L * np.float64(1000.0)) / d_inner) * (v ** np.float64(2.0) / (np.float64(2.0) * g)) * (1 - dra_perc / np.float64(100.0))
         head_loss = hl_dra
-    elif dra_length <= np.float64(0.0):
-        head_loss = f * ((L * np.float64(1000.0)) / d_inner) * (v ** np.float64(2.0) / (np.float64(2.0) * g))
     else:
-        hl_dra = f * (((dra_length) * np.float64(1000.0)) / d_inner) * (v ** np.float64(2.0) / (np.float64(2.0) * g)) * (1 - dra_perc / np.float64(100.0))
-        hl_nodra = f * (((L - dra_length) * np.float64(1000.0)) / d_inner) * (v ** np.float64(2.0) / (np.float64(2.0) * g))
-        head_loss = hl_dra + hl_nodra
+        if dra_length >= L:
+            hl_dra = f * ((L * np.float64(1000.0)) / d_inner) * (v ** np.float64(2.0) / (np.float64(2.0) * g)) * (1 - dra_perc / np.float64(100.0))
+            head_loss = hl_dra
+        elif dra_length <= np.float64(0.0):
+            head_loss = f * ((L * np.float64(1000.0)) / d_inner) * (v ** np.float64(2.0) / (np.float64(2.0) * g))
+        else:
+            hl_dra = f * (((dra_length) * np.float64(1000.0)) / d_inner) * (v ** np.float64(2.0) / (np.float64(2.0) * g)) * (1 - dra_perc / np.float64(100.0))
+            hl_nodra = f * (((L - dra_length) * np.float64(1000.0)) / d_inner) * (v ** np.float64(2.0) / (np.float64(2.0) * g))
+            head_loss = hl_dra + hl_nodra
 
     return head_loss, v, Re, f
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ kaleido>=0.2.1
 scipy
 matplotlib
 streamlit-agraph
+numba


### PR DESCRIPTION
## Summary
- prepare pipeline hydraulics helpers for Numba JIT
- convert math functions to numpy and enforce float64 inputs
- add numba requirement

## Testing
- `python -m py_compile pipeline_model.py`
- `python - <<'PY'
import time
import pipeline_model as pm
n=2000
start=time.time()
for i in range(n):
    pm._segment_hydraulics(100+i, 10.0, 0.5, 1e-5, 1e-6, 0.0, None)
end=time.time()
print('segment', end-start)
start=time.time()
for i in range(1000):
    pm._parallel_segment_hydraulics(200.0+i*0.1, 10.0, 0.5, 1e-5, 0.0, 0.0, 10.0, 0.5, 1e-5, 0.0, 0.0, 1e-6)
end=time.time()
print('parallel', end-start)
PY`
- ⚠️ `pip install numba` (failed: ProxyError, 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c4dcc135b08331ae970ba55aa04366