### PR TITLE
Handle zero pump cases during pipeline refinement

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -245,6 +245,8 @@ STATE_TOP_K = 50
 STATE_COST_MARGIN = 5000.0
 
 def _allowed_values(min_val: int, max_val: int, step: int) -> list[int]:
+    if min_val > max_val:
+        return [min_val]
     vals = list(range(min_val, max_val + 1, step))
     if vals[-1] != max_val:
         vals.append(max_val)
@@ -972,10 +974,14 @@ def solve_pipeline(
         for idx, stn in enumerate(stations):
             name = stn["name"].strip().lower().replace(" ", "_")
             if stn.get("is_pump", False):
-                coarse_rpm = int(coarse_res.get(f"speed_{name}", stn.get("MinRPM", 0)))
+                coarse_nop = int(coarse_res.get(f"num_pumps_{name}", 0))
                 coarse_dr_main = int(coarse_res.get(f"drag_reduction_{name}", 0))
-                rmin = max(int(stn.get("MinRPM", 0)), coarse_rpm - rpm_step)
-                rmax = min(int(stn.get("DOL", 0)), coarse_rpm + rpm_step)
+                if coarse_nop == 0:
+                    rmin = rmax = 0
+                else:
+                    coarse_rpm = int(coarse_res.get(f"speed_{name}", stn.get("MinRPM", 0)))
+                    rmin = max(int(stn.get("MinRPM", 0)), coarse_rpm - rpm_step)
+                    rmax = min(int(stn.get("DOL", 0)), coarse_rpm + rpm_step)
                 dmin = max(0, coarse_dr_main - dra_step)
                 dmax = min(int(stn.get("max_dr", 0)), coarse_dr_main + dra_step)
                 entry: dict[str, tuple[int, int]] = {


### PR DESCRIPTION
## Summary
- Return a single bound when `_allowed_values` receives a reversed range
- Clamp RPM range to `(0,0)` in refinement when coarse pass uses zero pumps

## Testing
- `python -m pytest`
- `python - <<'PY'
from pipeline_model import solve_pipeline
stations=[{"name":"S1","is_pump":True,"L":0.0,"d":0.7,"MinRPM":900,"DOL":1800,"min_pumps":1,"max_pumps":1,"max_dr":0},{"name":"S2","is_pump":True,"L":0.0,"d":0.7,"MinRPM":900,"DOL":1800,"min_pumps":0,"max_pumps":1,"max_dr":0}]
terminal={"elev":0}
FLOW=1000
KV_list=[1.0,1.0]
rho_list=[850.0,850.0]
RateDRA=100.0
Price_HSD=1.0
Fuel_density=850.0
Ambient_temp=25.0
res=solve_pipeline(stations,terminal,FLOW,KV_list,rho_list,RateDRA,Price_HSD,Fuel_density,Ambient_temp,linefill=[],dra_reach_km=0.0,mop_kgcm2=None,hours=24.0,start_time="00:00",loop_usage_by_station=[0,0],enumerate_loops=False)
print({k: res[k] for k in ['num_pumps_s1','speed_s1','num_pumps_s2','speed_s2','error']})
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c4e2e77a8883318117f526a06c3b99