### PR TITLE
refactor: simplify global parameter inputs

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -269,30 +269,48 @@ if st.session_state.get("should_rerun", False):
 with st.sidebar:
     st.title("🔧 Pipeline Inputs")
     with st.expander("Global Fluid & Cost Parameters", expanded=True):
-        with st.form("global_params"):
-            FLOW = st.number_input("Flow rate (m³/hr)", value=st.session_state.get("FLOW", 1000.0), step=10.0, key="FLOW_input")
-            RateDRA = st.number_input("DRA Cost (INR/L)", value=st.session_state.get("RateDRA", 500.0), step=1.0, key="RateDRA_input")
-            InitDRAppm = st.number_input("Initial Linefill DRA (ppm)", value=st.session_state.get("InitDRAppm", 4.0), step=0.5, key="InitDRAppm_input")
-            Price_HSD = st.number_input("Fuel Price (INR/L)", value=st.session_state.get("Price_HSD", 70.0), step=0.5, key="Price_HSD_input")
-            Fuel_density = st.number_input("Fuel density (kg/m³)", value=st.session_state.get("Fuel_density", 820.0), step=1.0, key="Fuel_density_input")
-            Ambient_temp = st.number_input("Ambient temperature (°C)", value=st.session_state.get("Ambient_temp", 25.0), step=1.0, key="Ambient_temp_input")
-            MOP_val = st.number_input("MOP (kg/cm²)", value=st.session_state.get("MOP_kgcm2", 100.0), step=1.0, key="MOP_input")
-            submitted_glob = st.form_submit_button("Apply")
-        if submitted_glob:
-            st.session_state["FLOW"] = FLOW
-            st.session_state["RateDRA"] = RateDRA
-            st.session_state["InitDRAppm"] = InitDRAppm
-            st.session_state["Price_HSD"] = Price_HSD
-            st.session_state["Fuel_density"] = Fuel_density
-            st.session_state["Ambient_temp"] = Ambient_temp
-            st.session_state["MOP_kgcm2"] = MOP_val
-        FLOW = st.session_state.get("FLOW", 1000.0)
-        RateDRA = st.session_state.get("RateDRA", 500.0)
-        InitDRAppm = st.session_state.get("InitDRAppm", 4.0)
-        Price_HSD = st.session_state.get("Price_HSD", 70.0)
-        Fuel_density = st.session_state.get("Fuel_density", 820.0)
-        Ambient_temp = st.session_state.get("Ambient_temp", 25.0)
-        MOP_val = st.session_state.get("MOP_kgcm2", 100.0)
+        FLOW = st.number_input(
+            "Flow rate (m³/hr)",
+            value=st.session_state.get("FLOW", 1000.0),
+            step=10.0,
+            key="FLOW",
+        )
+        RateDRA = st.number_input(
+            "DRA Cost (INR/L)",
+            value=st.session_state.get("RateDRA", 500.0),
+            step=1.0,
+            key="RateDRA",
+        )
+        InitDRAppm = st.number_input(
+            "Initial Linefill DRA (ppm)",
+            value=st.session_state.get("InitDRAppm", 4.0),
+            step=0.5,
+            key="InitDRAppm",
+        )
+        Price_HSD = st.number_input(
+            "Fuel Price (INR/L)",
+            value=st.session_state.get("Price_HSD", 70.0),
+            step=0.5,
+            key="Price_HSD",
+        )
+        Fuel_density = st.number_input(
+            "Fuel density (kg/m³)",
+            value=st.session_state.get("Fuel_density", 820.0),
+            step=1.0,
+            key="Fuel_density",
+        )
+        Ambient_temp = st.number_input(
+            "Ambient temperature (°C)",
+            value=st.session_state.get("Ambient_temp", 25.0),
+            step=1.0,
+            key="Ambient_temp",
+        )
+        st.number_input(
+            "MOP (kg/cm²)",
+            value=st.session_state.get("MOP_kgcm2", 100.0),
+            step=1.0,
+            key="MOP_kgcm2",
+        )
 
     st.subheader("Operating Mode")
     if "linefill_df" not in st.session_state:


### PR DESCRIPTION
## Summary
- Remove form wrapper around global fluid & cost parameters
- Bind sidebar number inputs directly to `st.session_state`

## Testing
- `python -m py_compile pipeline_optimization_app.py`
- `python - <<'PY'
from streamlit.testing.v1 import AppTest
import tempfile, os
code = '''
import streamlit as st
if 'FLOW' not in st.session_state:
    st.session_state['FLOW'] = 1000.0
st.number_input("Flow rate (m³/hr)", step=10.0, key="FLOW")
'''
with tempfile.NamedTemporaryFile('w', delete=False, suffix='.py') as f:
    f.write(code)
    path = f.name
at = AppTest.from_file(path, default_timeout=5)
res = at.run()
print('initial FLOW:', res.session_state['FLOW'])
widget = at.number_input[0]
res2 = widget.set_value(1500.0).run()
print('updated FLOW:', res2.session_state['FLOW'])
os.unlink(path)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c689a395a08331bedacd8459181fb3