### PR TITLE
Avoid duplicate active pump expansions

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2417,6 +2417,7 @@ def solve_pipeline_with_types(
             availA = stn['pump_types'].get('A', {}).get('available', 0)
             availB = stn['pump_types'].get('B', {}).get('available', 0)
             combos = generate_type_combinations(availA, availB)
+            seen_active: set[tuple[int, int]] = set()
             for numA, numB in combos:
                 total_units = numA + numB
                 if total_units <= 0:
@@ -2427,8 +2428,12 @@ def solve_pipeline_with_types(
                     for actB in range(numB + 1):
                         if actA + actB <= 0:
                             continue
+                        active_key = (actA, actB)
+                        if active_key in seen_active:
+                            continue
+                        seen_active.add(active_key)
                         unit = copy.deepcopy(stn)
-                        unit['pump_combo'] = {'A': numA, 'B': numB}
+                        unit['pump_combo'] = {'A': availA, 'B': availB}
                         unit['active_combo'] = {'A': actA, 'B': actB}
                         if actA > 0 and actB == 0:
                             pdata = pdataA


### PR DESCRIPTION
## Summary
- avoid expanding duplicate active pump configurations in `solve_pipeline_with_types` by tracking seen `(actA, actB)` counts per station
- keep `pump_combo` metadata aligned with the station's available pump counts so downstream consumers receive consistent availability data

## Testing
- python -m compileall pipeline_model.py

------
https://chatgpt.com/codex/tasks/task_e_68c9af5800ac8331aff798b3ac2e2aa9