### PR TITLE
Handle Excel writer engine availability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scipy
 matplotlib
 streamlit-agraph
 numba
+xlsxwriter


### PR DESCRIPTION
## Summary
- guard the Excel export flow in `pipeline_optimization_app.py` so it falls back to pandas' default writer when `xlsxwriter` is unavailable and surfaces a friendly Streamlit error instead of a crash
- add `xlsxwriter` to the application requirements so the preferred engine is installed in supported environments

## Testing
- `python -m compileall pipeline_optimization_app.py`
- `python - <<'PY'
import pandas as pd
from io import BytesIO

def export():
    export_df = pd.DataFrame({'a':[1]})
    excel_buffer = BytesIO()
    try:
        writer = pd.ExcelWriter(excel_buffer, engine="xlsxwriter")
    except ModuleNotFoundError:
        excel_buffer = BytesIO()
        try:
            writer = pd.ExcelWriter(excel_buffer)
        except ModuleNotFoundError:
            writer = None
    if writer is None:
        print("no engine available")
    else:
        with writer:
            export_df.to_excel(writer, index=False, sheet_name="Schedule")
        excel_buffer.seek(0)
        print("wrote", len(excel_buffer.getvalue()))

export()
PY`
- ⚠️ `pip install xlsxwriter` *(fails in this environment because the proxy blocks package downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68caf4cd927c8331b4912db6c870ebc3