### PR TITLE
Refine segment viscosity handling

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -446,6 +446,139 @@ def _segment_hydraulics(
     return head_loss, v, Re, f
 
 
+def _segment_profile_hydraulics(
+    flow_m3h: float,
+    L: float,
+    d_inner: float,
+    rough: float,
+    kv_default: float,
+    dra_perc: float,
+    dra_length: float | None,
+    profile: list[dict[str, float]] | None,
+) -> tuple[float, float, float, float]:
+    """Evaluate segment hydraulics across ``profile`` slices when provided."""
+
+    if not profile:
+        return _segment_hydraulics(flow_m3h, L, d_inner, rough, kv_default, dra_perc, dra_length)
+
+    head_loss_total = 0.0
+    v_last = 0.0
+    Re_min = float("inf")
+    f_worst = 0.0
+
+    dra_remaining = None if dra_length is None else max(float(dra_length), 0.0)
+
+    for slice_data in profile:
+        length = float(slice_data.get("length_km", 0.0))
+        if length <= 1e-9:
+            continue
+        kv_local = float(slice_data.get("kv", kv_default)) if slice_data.get("kv") is not None else float(kv_default)
+        dra_len_local: float | None
+        if dra_remaining is None:
+            dra_len_local = dra_length
+        else:
+            dra_len_local = min(dra_remaining, length)
+        hl, v, Re, f = _segment_hydraulics(
+            flow_m3h,
+            length,
+            d_inner,
+            rough,
+            kv_local,
+            dra_perc,
+            dra_len_local,
+        )
+        head_loss_total += float(hl)
+        v_last = float(v)
+        Re_min = min(Re_min, float(Re))
+        f_worst = max(f_worst, float(f))
+        if dra_remaining is not None:
+            dra_remaining = max(dra_remaining - length, 0.0)
+
+    if Re_min == float("inf"):
+        Re_min = 0.0
+
+    return head_loss_total, v_last, Re_min, f_worst
+
+
+def _scale_profile(profile: list[dict[str, float]] | None, scale: float) -> list[dict[str, float]]:
+    """Return ``profile`` with lengths multiplied by ``scale`` (non-negative)."""
+
+    if not profile or scale <= 0:
+        return []
+    return [
+        {
+            "length_km": float(slice_data.get("length_km", 0.0)) * scale,
+            "kv": float(slice_data.get("kv", 0.0)),
+            "rho": float(slice_data.get("rho", 0.0)),
+        }
+        for slice_data in profile
+        if float(slice_data.get("length_km", 0.0)) > 1e-9
+    ]
+
+
+def _parallel_segment_hydraulics_profile(
+    flow_m3h: float,
+    main_props: tuple[float, float, float, float, float],
+    loop_props: tuple[float, float, float, float, float],
+    kv_default: float,
+    profile: list[dict[str, float]] | None,
+) -> tuple[float, tuple[float, float, float, float], tuple[float, float, float, float]]:
+    """Parallel hydraulics solver aware of viscosity profiles."""
+
+    main_L, main_d_inner, main_rough, main_dra, main_dra_len = main_props
+    loop_L, loop_d_inner, loop_rough, loop_dra, loop_dra_len = loop_props
+
+    scale = loop_L / main_L if main_L > 0 else 0.0
+    loop_profile = _scale_profile(profile, scale) if profile else None
+
+    lo = 0.0
+    hi = float(max(flow_m3h, 0.0))
+    best = (
+        0.0,
+        (0.0, 0.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0, 0.0),
+    )
+
+    for _ in range(25):
+        mid = (lo + hi) / 2.0
+        q_loop = mid
+        q_main = flow_m3h - q_loop
+        hl_main, v_main, Re_main, f_main = _segment_profile_hydraulics(
+            q_main,
+            main_L,
+            main_d_inner,
+            main_rough,
+            kv_default,
+            main_dra,
+            main_dra_len,
+            profile,
+        )
+        hl_loop, v_loop, Re_loop, f_loop = _segment_profile_hydraulics(
+            q_loop,
+            loop_L,
+            loop_d_inner,
+            loop_rough,
+            kv_default,
+            loop_dra,
+            loop_dra_len,
+            loop_profile,
+        )
+        diff = hl_main - hl_loop
+        best = (
+            hl_main,
+            (v_main, Re_main, f_main, q_main),
+            (v_loop, Re_loop, f_loop, q_loop),
+        )
+        if abs(diff) < 1e-6:
+            break
+        if diff > 0:
+            lo = mid
+        else:
+            hi = mid
+
+    return best
+
+
 @njit(cache=True, fastmath=True)
 def _parallel_segment_hydraulics(
     flow_m3h: float,
@@ -911,6 +1044,7 @@ def solve_pipeline(
     hours: float = 24.0,
     start_time: str = "00:00",
     *,
+    segment_profiles: list[list[dict[str, float]]] | None = None,
     loop_usage_by_station: list[int] | None = None,
     enumerate_loops: bool = True,
     _internal_pass: bool = False,
@@ -973,6 +1107,7 @@ def solve_pipeline(
                 mop_kgcm2,
                 hours,
                 start_time,
+                segment_profiles=segment_profiles,
                 loop_usage_by_station=[],
                 enumerate_loops=False,
                 rpm_step=rpm_step,
@@ -1029,6 +1164,7 @@ def solve_pipeline(
                 mop_kgcm2,
                 hours,
                 start_time,
+                segment_profiles=segment_profiles,
                 loop_usage_by_station=usage,
                 enumerate_loops=False,
                 rpm_step=rpm_step,
@@ -1234,6 +1370,7 @@ def solve_pipeline(
             rpm_step=rpm_step,
             dra_step=dra_step,
             narrow_ranges=ranges,
+            segment_profiles=segment_profiles,
         )
 
     # -----------------------------------------------------------------------
@@ -1500,12 +1637,43 @@ def solve_pipeline(
                 })
             opts.extend(non_pump_opts)
 
+        profile_data: list[dict[str, float]] | None = None
+        if segment_profiles and i - 1 < len(segment_profiles):
+            raw_profile = segment_profiles[i - 1] or []
+            cleaned: list[dict[str, float]] = []
+            for slice_data in raw_profile:
+                try:
+                    length_val = float(slice_data.get('length_km', 0.0))
+                except (TypeError, ValueError):
+                    continue
+                if length_val <= 1e-9:
+                    continue
+                kv_val = float(slice_data.get('kv', kv)) if slice_data.get('kv') is not None else float(kv)
+                rho_val = float(slice_data.get('rho', rho)) if slice_data.get('rho') is not None else float(rho)
+                cleaned.append({'length_km': length_val, 'kv': kv_val, 'rho': rho_val})
+            if cleaned:
+                profile_data = cleaned
+
+        if profile_data:
+            total_len = sum(item['length_km'] for item in profile_data)
+            if total_len > 0:
+                kv_display = sum(item['kv'] * item['length_km'] for item in profile_data) / total_len
+                rho_display = sum(item['rho'] * item['length_km'] for item in profile_data) / total_len
+            else:
+                kv_display = float(kv)
+                rho_display = float(rho)
+        else:
+            kv_display = float(kv)
+            rho_display = float(rho)
+
         station_opts.append({
             'name': name,
             'orig_name': stn['name'],
             'idx': i - 1,
             'kv': kv,
+            'kv_display': kv_display,
             'rho': rho,
+            'rho_display': rho_display,
             'L': L,
             'd_inner': d_inner,
             'rough': rough,
@@ -1536,6 +1704,7 @@ def solve_pipeline(
             'sfc_mode': stn.get('sfc_mode', 'manual'),
             'engine_params': stn.get('engine_params', {}),
             'elev': float(stn.get('elev', 0.0)),
+            'profile': profile_data,
         })
         cum_dist += L
     # Cache the baseline downstream head requirement for each station using the
@@ -1617,7 +1786,7 @@ def solve_pipeline(
 
                 scenarios = []
                 # Base scenario: flow through mainline only
-                hl_single, v_single, Re_single, f_single = _segment_hydraulics(
+                hl_single, v_single, Re_single, f_single = _segment_profile_hydraulics(
                     flow_total,
                     stn_data['L'],
                     stn_data['d_inner'],
@@ -1625,6 +1794,7 @@ def solve_pipeline(
                     stn_data['kv'],
                     eff_dra_main,
                     dra_len_main,
+                    stn_data.get('profile'),
                 )
                 scenarios.append({
                     'head_loss': hl_single,
@@ -1646,20 +1816,41 @@ def solve_pipeline(
                     eff_dra_loop = opt['dra_loop']
                     dra_len_loop = loop['L'] if eff_dra_loop > 0 else 0.0
                     # Parallel scenario (main + loop split by equal head)
-                    hl_par, main_stats, loop_stats = _parallel_segment_hydraulics(
-                        flow_total,
-                        stn_data['L'],
-                        stn_data['d_inner'],
-                        stn_data['rough'],
-                        eff_dra_main,
-                        dra_len_main,
-                        loop['L'],
-                        loop['d_inner'],
-                        loop['rough'],
-                        eff_dra_loop,
-                        dra_len_loop,
-                        stn_data['kv'],
-                    )
+                    if stn_data.get('profile'):
+                        hl_par, main_stats, loop_stats = _parallel_segment_hydraulics_profile(
+                            flow_total,
+                            (
+                                stn_data['L'],
+                                stn_data['d_inner'],
+                                stn_data['rough'],
+                                eff_dra_main,
+                                dra_len_main,
+                            ),
+                            (
+                                loop['L'],
+                                loop['d_inner'],
+                                loop['rough'],
+                                eff_dra_loop,
+                                dra_len_loop,
+                            ),
+                            stn_data['kv'],
+                            stn_data.get('profile'),
+                        )
+                    else:
+                        hl_par, main_stats, loop_stats = _parallel_segment_hydraulics(
+                            flow_total,
+                            stn_data['L'],
+                            stn_data['d_inner'],
+                            stn_data['rough'],
+                            eff_dra_main,
+                            dra_len_main,
+                            loop['L'],
+                            loop['d_inner'],
+                            loop['rough'],
+                            eff_dra_loop,
+                            dra_len_loop,
+                            stn_data['kv'],
+                        )
                     v_m, Re_m, f_m, q_main = main_stats
                     v_l, Re_l, f_l, q_loop = loop_stats
                     # Parallel scenario without bypass
@@ -1696,7 +1887,8 @@ def solve_pipeline(
                     # Only include when diameters differ; otherwise the parallel
                     # scenario already captures equal pipes.
                     if abs(stn_data['d_inner'] - loop['d_inner']) > 1e-6:
-                        hl_loop, v_loop_only, Re_loop_only, f_loop_only = _segment_hydraulics(
+                        loop_profile = _scale_profile(stn_data.get('profile'), loop['L'] / stn_data['L'] if stn_data['L'] > 0 else 0.0)
+                        hl_loop, v_loop_only, Re_loop_only, f_loop_only = _segment_profile_hydraulics(
                             flow_total,
                             loop['L'],
                             loop['d_inner'],
@@ -1704,6 +1896,7 @@ def solve_pipeline(
                             stn_data['kv'],
                             eff_dra_loop,
                             dra_len_loop,
+                            loop_profile,
                         )
                         scenarios.append({
                             'head_loss': hl_loop,
@@ -2127,6 +2320,8 @@ def solve_pipeline(
                             sdh if stn_data['is_pump'] else state['residual'], stn_data['rho']
                         ),
                         f"rho_{stn_data['name']}": stn_data['rho'],
+                        f"density_display_{stn_data['name']}": stn_data.get('rho_display', stn_data['rho']),
+                        f"viscosity_{stn_data['name']}": stn_data.get('kv_display', stn_data['kv']),
                         f"maop_{stn_data['name']}": stn_data['maop_head'],
                         f"maop_kgcm2_{stn_data['name']}": stn_data['maop_kgcm2'],
                         f"velocity_{stn_data['name']}": sc['v'],
@@ -2312,6 +2507,8 @@ def solve_pipeline(
     result[f"rh_kgcm2_{term_name}"] = head_to_kgcm2(residual, rho_term)
     result[f"sdh_kgcm2_{term_name}"] = 0.0
     result[f"rho_{term_name}"] = rho_term
+    result[f"density_display_{term_name}"] = rho_term
+    result[f"viscosity_{term_name}"] = KV_list[-1] if KV_list else 0.0
     result[f"maop_{term_name}"] = last_maop_head
     result[f"maop_kgcm2_{term_name}"] = last_maop_kg
     result['total_cost'] = total_cost
@@ -2335,6 +2532,8 @@ def solve_pipeline_with_types(
     mop_kgcm2: float | None = None,
     hours: float = 24.0,
     start_time: str = "00:00",
+    *,
+    segment_profiles: list[list[dict[str, float]]] | None = None,
 ) -> dict:
     """Enumerate pump type combinations at all stations and call ``solve_pipeline``."""
 
@@ -2343,7 +2542,13 @@ def solve_pipeline_with_types(
     best_stations = None
     N = len(stations)
 
-    def expand_all(pos: int, stn_acc: list[dict], kv_acc: list[float], rho_acc: list[float]):
+    def expand_all(
+        pos: int,
+        stn_acc: list[dict],
+        kv_acc: list[float],
+        rho_acc: list[float],
+        profile_acc: list[list[dict[str, float]] | None],
+    ):
         nonlocal best_result, best_cost, best_stations
         if pos >= N:
             # When all stations have been expanded into individual pump units,
@@ -2405,6 +2610,7 @@ def solve_pipeline_with_types(
                     mop_kgcm2,
                     hours,
                     start_time,
+                    segment_profiles=[p or [] for p in profile_acc],
                     loop_usage_by_station=usage,
                     enumerate_loops=False,
                 )
@@ -2423,6 +2629,7 @@ def solve_pipeline_with_types(
         stn = stations[pos]
         kv = KV_list[pos]
         rho = rho_list[pos]
+        profile = segment_profiles[pos] if segment_profiles and pos < len(segment_profiles) else []
 
         if stn.get('pump_types'):
             # Determine available counts for each type
@@ -2499,11 +2706,11 @@ def solve_pipeline_with_types(
                             unit['engine_params'] = pdataA.get('engine_params', unit.get('engine_params', {}))
                         unit['max_pumps'] = actA + actB
                         unit['min_pumps'] = actA + actB
-                        expand_all(pos + 1, stn_acc + [unit], kv_acc + [kv], rho_acc + [rho])
+                expand_all(pos + 1, stn_acc + [unit], kv_acc + [kv], rho_acc + [rho], profile_acc + [profile])
         else:
-            expand_all(pos + 1, stn_acc + [copy.deepcopy(stn)], kv_acc + [kv], rho_acc + [rho])
+            expand_all(pos + 1, stn_acc + [copy.deepcopy(stn)], kv_acc + [kv], rho_acc + [rho], profile_acc + [profile])
 
-    expand_all(0, [], [], [])
+    expand_all(0, [], [], [], [])
 
     if best_result is None:
         return {

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -991,7 +991,8 @@ def map_linefill_to_segments(linefill_df, stations):
     # delegate to volumetric mapper and return directly.
     if "Start (km)" not in cols or "End (km)" not in cols:
         if "Volume (m³)" in cols or "Volume" in cols:
-            return map_vol_linefill_to_segments(linefill_df, stations)
+            seg_kv, seg_rho, _ = map_vol_linefill_to_segments(linefill_df, stations)
+            return seg_kv, seg_rho
         # Fallback: assume uniform properties from the last row
         kv = float(linefill_df.iloc[-1].get("Viscosity (cSt)", 0.0))
         rho = float(linefill_df.iloc[-1].get("Density (kg/m³)", 0.0))
@@ -1027,8 +1028,17 @@ def pipe_cross_section_area_m2(stations: list[dict]) -> float:
     d_inner = max(D - 2.0*t, 0.0)
     return float((pi * d_inner**2) / 4.0)
 
-def map_vol_linefill_to_segments(vol_table: pd.DataFrame, stations: list[dict]) -> tuple[list[float], list[float]]:
-    """Convert a volumetric linefill table [Volume (m3), Visc, Density] to segment KV/rho.
+def map_vol_linefill_to_segments(
+    vol_table: pd.DataFrame, stations: list[dict]
+) -> tuple[list[float], list[float], list[list[dict[str, float]]]]:
+    """Convert a volumetric linefill table [Volume (m³), Visc, Density] to segment data.
+
+    The legacy behaviour—returning one viscosity and density per segment based on the
+    upstream batch—is preserved for backward compatibility via the first two
+    return values (``seg_kv`` and ``seg_rho``).  The third element provides the
+    detailed piecewise profile for each segment as an ordered list of slices of the
+    form ``{"length_km": L, "kv": KV, "rho": RHO}`` whose lengths exactly sum to the
+    segment length.
 
     Assumes uniform diameter along the pipeline (uses first station D & t).
     """
@@ -1049,7 +1059,9 @@ def map_vol_linefill_to_segments(vol_table: pd.DataFrame, stations: list[dict]) 
         batches.append({"len_km": length_km, "kv": visc, "rho": dens})
 
     # Map to segments (each station defines a segment length L)
-    seg_kv, seg_rho = [], []
+    seg_kv: list[float] = []
+    seg_rho: list[float] = []
+    seg_profiles: list[list[dict[str, float]]] = []
     seg_lengths = [s.get("L", 0.0) for s in stations]
     i_batch = 0
     remaining = batches[0]["len_km"] if batches else 0.0
@@ -1057,7 +1069,9 @@ def map_vol_linefill_to_segments(vol_table: pd.DataFrame, stations: list[dict]) 
     rho_cur = batches[0]["rho"] if batches else 0.0
 
     for L in seg_lengths:
-        need = L
+        need = float(L)
+        first_slice = True
+        slices: list[dict[str, float]] = []
         # Consume from batches until we cover this segment upstream-to-downstream
         while need > 1e-9:
             if remaining <= 1e-9:
@@ -1065,22 +1079,186 @@ def map_vol_linefill_to_segments(vol_table: pd.DataFrame, stations: list[dict]) 
                 if i_batch >= len(batches):
                     # If we ran out, extend with last known properties
                     remaining = need
-                    # kv_cur, rho_cur unchanged
+                    # kv_cur, rho_cur unchanged (carry-forward)
                 else:
                     remaining = batches[i_batch]["len_km"]
                     kv_cur = batches[i_batch]["kv"]
                     rho_cur = batches[i_batch]["rho"]
-            take = min(need, remaining)
-            # For per-segment properties, use the property of the upstream-most fluid in the segment.
-            # (Piecewise mixing could be done, but you asked to keep other logic unchanged.)
-            # So we only need the first batch's kv/rho per segment.
-            if need == L:
-                seg_kv.append(kv_cur)
-                seg_rho.append(rho_cur)
+            take = min(need, remaining if remaining > 0 else need)
+            if take <= 1e-9:
+                break
+            if first_slice:
+                seg_kv.append(float(kv_cur))
+                seg_rho.append(float(rho_cur))
+                first_slice = False
+            slices.append(
+                {
+                    "length_km": float(take),
+                    "kv": float(kv_cur),
+                    "rho": float(rho_cur),
+                }
+            )
             need -= take
-            remaining -= take
+            remaining = max(remaining - take, 0.0)
 
-    return seg_kv, seg_rho
+        if not slices:
+            # No explicit batches covered this segment; propagate the last known properties
+            seg_kv.append(float(kv_cur))
+            seg_rho.append(float(rho_cur))
+            slices.append(
+                {
+                    "length_km": float(L),
+                    "kv": float(kv_cur),
+                    "rho": float(rho_cur),
+                }
+            )
+
+        seg_profiles.append(slices)
+
+    return seg_kv, seg_rho, seg_profiles
+
+
+def _normalise_segment_profile(profile: list[dict[str, float]] | None) -> list[dict[str, float]]:
+    """Return ``profile`` stripped of zero-length slices with numeric fields."""
+
+    cleaned: list[dict[str, float]] = []
+    last_kv = 0.0
+    last_rho = 0.0
+    if not profile:
+        return cleaned
+    for slice_data in profile:
+        length = float(slice_data.get("length_km", 0.0))
+        if length <= 1e-9:
+            continue
+        kv = float(slice_data.get("kv", last_kv))
+        rho = float(slice_data.get("rho", last_rho))
+        cleaned.append({"length_km": length, "kv": kv, "rho": rho})
+        last_kv = kv
+        last_rho = rho
+    return cleaned
+
+
+def merge_segment_profiles(
+    profile_now: list[dict[str, float]] | None,
+    profile_next: list[dict[str, float]] | None,
+) -> list[dict[str, float]]:
+    """Merge two segment profiles into a common slice grid using per-slice maxima."""
+
+    clean_now = _normalise_segment_profile(profile_now)
+    clean_next = _normalise_segment_profile(profile_next)
+
+    total_len = sum(slice["length_km"] for slice in clean_now)
+    if total_len <= 0:
+        total_len = sum(slice["length_km"] for slice in clean_next)
+    if total_len <= 0:
+        return []
+
+    if not clean_now:
+        base_kv = clean_next[0]["kv"] if clean_next else 0.0
+        base_rho = clean_next[0]["rho"] if clean_next else 0.0
+        clean_now = [{"length_km": total_len, "kv": base_kv, "rho": base_rho}]
+    if not clean_next:
+        base_kv = clean_now[0]["kv"] if clean_now else 0.0
+        base_rho = clean_now[0]["rho"] if clean_now else 0.0
+        clean_next = [{"length_km": total_len, "kv": base_kv, "rho": base_rho}]
+
+    idx_now = idx_next = 0
+    rem_now = clean_now[0]["length_km"]
+    rem_next = clean_next[0]["length_km"]
+    kv_now = clean_now[0]["kv"]
+    rho_now = clean_now[0]["rho"]
+    kv_next = clean_next[0]["kv"]
+    rho_next = clean_next[0]["rho"]
+
+    merged: list[dict[str, float]] = []
+    processed = 0.0
+    tol = 1e-9
+
+    while processed + tol < total_len:
+        take = min(rem_now, rem_next, total_len - processed)
+        if take <= tol:
+            if rem_now <= tol:
+                if idx_now < len(clean_now) - 1:
+                    idx_now += 1
+                    rem_now = clean_now[idx_now]["length_km"]
+                    kv_now = clean_now[idx_now]["kv"]
+                    rho_now = clean_now[idx_now]["rho"]
+                else:
+                    rem_now = total_len - processed
+            if rem_next <= tol:
+                if idx_next < len(clean_next) - 1:
+                    idx_next += 1
+                    rem_next = clean_next[idx_next]["length_km"]
+                    kv_next = clean_next[idx_next]["kv"]
+                    rho_next = clean_next[idx_next]["rho"]
+                else:
+                    rem_next = total_len - processed
+            continue
+
+        merged.append(
+            {
+                "length_km": take,
+                "kv": max(kv_now, kv_next),
+                "rho": max(rho_now, rho_next),
+            }
+        )
+        processed += take
+        rem_now = max(rem_now - take, 0.0)
+        rem_next = max(rem_next - take, 0.0)
+
+        if rem_now <= tol and idx_now < len(clean_now) - 1:
+            idx_now += 1
+            rem_now = clean_now[idx_now]["length_km"]
+            kv_now = clean_now[idx_now]["kv"]
+            rho_now = clean_now[idx_now]["rho"]
+        if rem_next <= tol and idx_next < len(clean_next) - 1:
+            idx_next += 1
+            rem_next = clean_next[idx_next]["length_km"]
+            kv_next = clean_next[idx_next]["kv"]
+            rho_next = clean_next[idx_next]["rho"]
+
+    return merged
+
+
+def build_worst_case_profiles(
+    profiles_now: list[list[dict[str, float]]],
+    profiles_next: list[list[dict[str, float]]],
+) -> tuple[list[float], list[float], list[float], list[float], list[list[dict[str, float]]]]:
+    """Align two profile sets, returning solver maxima, display means, and merged slices."""
+
+    count = max(len(profiles_now), len(profiles_next))
+    kv_solver: list[float] = []
+    rho_solver: list[float] = []
+    kv_display: list[float] = []
+    rho_display: list[float] = []
+    merged_profiles: list[list[dict[str, float]]] = []
+
+    for idx in range(count):
+        prof_now = profiles_now[idx] if idx < len(profiles_now) else None
+        prof_next = profiles_next[idx] if idx < len(profiles_next) else None
+        merged = merge_segment_profiles(prof_now, prof_next)
+        merged_profiles.append(merged)
+        if merged:
+            total_len = sum(slice["length_km"] for slice in merged)
+            if total_len > 0:
+                kv_display.append(
+                    sum(slice["kv"] * slice["length_km"] for slice in merged) / total_len
+                )
+                rho_display.append(
+                    sum(slice["rho"] * slice["length_km"] for slice in merged) / total_len
+                )
+            else:
+                kv_display.append(0.0)
+                rho_display.append(0.0)
+            kv_solver.append(max(slice["kv"] for slice in merged))
+            rho_solver.append(max(slice["rho"] for slice in merged))
+        else:
+            kv_solver.append(0.0)
+            rho_solver.append(0.0)
+            kv_display.append(0.0)
+            rho_display.append(0.0)
+
+    return kv_solver, rho_solver, kv_display, rho_display, merged_profiles
 
 
 def shift_vol_linefill(
@@ -1319,7 +1497,7 @@ def build_summary_dataframe(
         if "Start (km)" in linefill_df.columns:
             kv_list, _ = map_linefill_to_segments(linefill_df, stations_data)
         else:
-            kv_list, _ = map_vol_linefill_to_segments(linefill_df, stations_data)
+            kv_list, _, _ = map_vol_linefill_to_segments(linefill_df, stations_data)
     else:
         kv_list = [0.0] * len(stations_data)
 
@@ -1490,6 +1668,8 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             'Pump Eff (%)': float(res.get(f"efficiency_{key}", 0.0) or 0.0),
             'Pump BKW (kW)': float(res.get(f"pump_bkw_{key}", 0.0) or 0.0),
             'Motor Input (kW)': float(res.get(f"motor_kw_{key}", 0.0) or 0.0),
+            'Viscosity (cSt)': float(res.get(f"viscosity_{key}", res.get(f"rho_{key}", 0.0)) or 0.0),
+            'Density (kg/m³)': float(res.get(f"density_display_{key}", res.get(f"rho_{key}", 0.0)) or 0.0),
             'Reynolds No.': float(res.get(f"reynolds_{key}", 0.0) or 0.0),
             'Head Loss (m)': float(res.get(f"head_loss_{key}", 0.0) or 0.0),
             'Head Loss (kg/cm²)': float(res.get(f"head_loss_kgcm2_{key}", 0.0) or 0.0),
@@ -1625,6 +1805,8 @@ def solve_pipeline(
     mop_kgcm2: float | None = None,
     hours: float = 24.0,
     start_time: str = "00:00",
+    *,
+    segment_profiles: list[list[dict[str, float]]] | None = None,
 ):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
@@ -1660,6 +1842,7 @@ def solve_pipeline(
                 mop_kgcm2,
                 hours,
                 start_time=start_time,
+                segment_profiles=segment_profiles,
             )
         else:
             res = pipeline_model.solve_pipeline(
@@ -1677,6 +1860,7 @@ def solve_pipeline(
                 mop_kgcm2,
                 hours,
                 start_time=start_time,
+                segment_profiles=segment_profiles,
             )
         # Append a human-readable flow pattern name based on loop usage
         if not res.get("error"):
@@ -2150,10 +2334,15 @@ if not auto_batch:
                         current_vol.copy(), pumped_tmp, plan_df.copy() if plan_df is not None else None
                     )
                     # Determine worst-case fluid properties over this 1h window
-                    kv_now, rho_now = kv_rho_from_vol(current_vol)
-                    kv_next, rho_next = kv_rho_from_vol(future_vol)
-                    kv_list = [max(a, b) for a, b in zip(kv_now, kv_next)]
-                    rho_list = [max(a, b) for a, b in zip(rho_now, rho_next)]
+                    kv_now, rho_now, prof_now = kv_rho_from_vol(current_vol)
+                    kv_next, rho_next, prof_next = kv_rho_from_vol(future_vol)
+                    (
+                        kv_list,
+                        rho_list,
+                        kv_display,
+                        rho_display,
+                        merged_profiles,
+                    ) = build_worst_case_profiles(prof_now, prof_next)
 
                     stns_run = copy.deepcopy(stations_base)
 
@@ -2172,6 +2361,7 @@ if not auto_batch:
                         st.session_state.get("MOP_kgcm2"),
                         hours=1.0,
                         start_time=start_str,
+                        segment_profiles=merged_profiles,
                     )
 
                     if res.get("error"):
@@ -2409,15 +2599,20 @@ if not auto_batch:
                     pumped_m3 = flow * duration_hr
 
                     try:
-                        kv_now, rho_now = map_vol_linefill_to_segments(current_vol, stations_base)
+                        kv_now, rho_now, prof_now = map_vol_linefill_to_segments(current_vol, stations_base)
                         future_vol, current_plan = shift_vol_linefill(current_vol.copy(), pumped_m3, current_plan)
-                        kv_next, rho_next = map_vol_linefill_to_segments(future_vol, stations_base)
+                        kv_next, rho_next, prof_next = map_vol_linefill_to_segments(future_vol, stations_base)
                     except ValueError as e:
                         st.error(str(e))
                         st.stop()
 
-                    kv_run = [max(a, b) for a, b in zip(kv_now, kv_next)]
-                    rho_run = [max(a, b) for a, b in zip(rho_now, rho_next)]
+                    (
+                        kv_run,
+                        rho_run,
+                        kv_display,
+                        rho_display,
+                        merged_profiles,
+                    ) = build_worst_case_profiles(prof_now, prof_next)
 
                     stns_run = copy.deepcopy(stations_base)
                     res = solve_pipeline(
@@ -2434,6 +2629,7 @@ if not auto_batch:
                         dra_reach_km,
                         st.session_state.get("MOP_kgcm2"),
                         hours=duration_hr,
+                        segment_profiles=merged_profiles,
                     )
                     if res.get("error"):
                         st.error(f"Optimization failed for interval starting {seg_start} -> {res.get('message','')}")


### PR DESCRIPTION
## Summary
- extend volumetric linefill mapping to emit per-segment slice profiles and merge current/future batches slice-by-slice when building hourly and projected schedules so the solver receives worst-case viscosity and density distributions.【F:pipeline_optimization_app.py†L1031-L1261】【F:pipeline_optimization_app.py†L2337-L2364】【F:pipeline_optimization_app.py†L2601-L2633】
- teach the hydraulic solver to accept optional segment profiles, evaluate head loss across each slice, propagate display-friendly viscosity/density averages, and update the type-expansion wrapper accordingly.【F:pipeline_model.py†L449-L520】【F:pipeline_model.py†L1031-L1054】【F:pipeline_model.py†L1640-L1677】【F:pipeline_model.py†L1760-L1880】【F:pipeline_model.py†L2310-L2340】【F:pipeline_model.py†L2520-L2560】
- surface the new viscosity and density figures in station tables for schedule reporting.【F:pipeline_optimization_app.py†L1601-L1684】

## Testing
- `python -m compileall .`【e45713†L1-L6】
- regression check showing smooth head-loss increase as a heavy slug advances.【8d523e†L125-L128】

------
https://chatgpt.com/codex/tasks/task_e_68cb17485a38833197a4305b866e736b