### PR TITLE
Refactor DRA tracking to slice queue and extend tests

### DIFF
--- a/tests/test_dra_slug_transition.py
+++ b/tests/test_dra_slug_transition.py
@@ -1,9 +1,37 @@
 from pathlib import Path
+import copy
+import math
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from pipeline_model import solve_pipeline
+
+
+def _dra_length_km(linefill: list[dict], diameter: float) -> float:
+    """Return the total treated length represented by ``linefill``."""
+
+    if diameter <= 0:
+        return 0.0
+    area = math.pi * (diameter ** 2) / 4.0
+    if area <= 0:
+        return 0.0
+    total = 0.0
+    for batch in linefill:
+        try:
+            ppm = int(batch.get("dra_ppm", 0) or 0)
+        except Exception:
+            ppm = 0
+        if ppm <= 0:
+            continue
+        try:
+            vol = float(batch.get("volume", 0.0))
+        except Exception:
+            vol = 0.0
+        if vol <= 0:
+            continue
+        total += vol / area / 1000.0
+    return total
 
 
 def test_sdh_varies_smoothly_with_downstream_slug():
@@ -64,4 +92,73 @@ def test_sdh_varies_smoothly_with_downstream_slug():
     assert sdh_values == sorted(sdh_values)
     diffs = [abs(b - a) for a, b in zip(sdh_values, sdh_values[1:])]
     assert diffs, "Expected at least one SDH difference"
+    assert max(diffs) <= 6.0
+
+
+def test_partial_slug_advances_with_positive_injection() -> None:
+    """A heavy slug should taper smoothly when new DRA is injected."""
+
+    station = {
+        "name": "Origin Pump",
+        "is_pump": True,
+        "min_pumps": 1,
+        "max_pumps": 1,
+        "MinRPM": 1000,
+        "DOL": 2800,
+        "pump_type": "type1",
+        "A": 0.0,
+        "B": 0.0,
+        "C": 190.0,
+        "P": 0.0,
+        "Q": 0.0,
+        "R": 0.0,
+        "S": 0.0,
+        "T": 82.0,
+        "L": 40.0,
+        "d": 0.7,
+        "rough": 0.00004,
+        "elev": 0.0,
+        "min_residual": 25,
+        "max_dr": 35,
+        "fixed_dra_perc": 18,
+        "power_type": "Grid",
+        "rate": 0.0,
+    }
+    terminal = {"name": "Terminal", "elev": 0.0, "min_residual": 25}
+
+    linefill_state = [
+        {"volume": 9000.0, "dra_ppm": 12},
+        {"volume": 6000.0, "dra_ppm": 0},
+    ]
+
+    sdh_progression: list[float] = []
+    hours = 1.0
+    for _ in range(4):
+        reach = _dra_length_km(linefill_state, station["d"])
+        result = solve_pipeline(
+            [copy.deepcopy(station)],
+            terminal,
+            FLOW=1600.0,
+            KV_list=[1.8],
+            rho_list=[845.0],
+            RateDRA=5.0,
+            Price_HSD=0.0,
+            Fuel_density=0.85,
+            Ambient_temp=25.0,
+            linefill=copy.deepcopy(linefill_state),
+            dra_reach_km=reach,
+            hours=hours,
+            start_time="00:00",
+            enumerate_loops=False,
+            rpm_step=50,
+            dra_step=1,
+        )
+        assert not result.get("error"), result.get("message")
+        assert result["dra_ppm_origin_pump"] > 0
+        sdh_progression.append(result["sdh_origin_pump"])
+        linefill_state = copy.deepcopy(result["linefill"])
+
+    assert all(b >= a for a, b in zip(sdh_progression, sdh_progression[1:]))
+    diffs = [b - a for a, b in zip(sdh_progression, sdh_progression[1:])]
+    assert diffs, "Expected SDH to change over successive hours"
     assert max(diffs) <= 6.0

--- a/tests/test_linefill_dra.py
+++ b/tests/test_linefill_dra.py
@@ -11,7 +11,7 @@ if str(ROOT) not in sys.path:
 from pipeline_model import solve_pipeline
 
 
-def _make_pump_station(name: str) -> dict:
+def _make_pump_station(name: str, *, max_dr: int = 0) -> dict:
     """Return a minimal pump-station definition for regression tests."""
 
     return {
@@ -37,7 +37,7 @@ def _make_pump_station(name: str) -> dict:
         "power_type": "Grid",
         "sfc_mode": "manual",
         "sfc": 0.0,
-        "max_dr": 0,
+        "max_dr": max_dr,
         "supply": 0.0,
         "delivery": 0.0,
         "elev": 0.0,
@@ -91,3 +91,75 @@ def test_linefill_dra_persists_through_running_pumps() -> None:
     # travelling through the line (positive downstream reach).
     assert dra_result["sdh_station_b"] < base_result["sdh_station_b"]
     assert dra_result["dra_front_km"] > 0
+
+
+def test_zero_injection_benefits_from_inherited_slug() -> None:
+    """Inherited DRA continues lowering SDH when no station injects."""
+
+    def _treated_length(linefill_state: list[dict], diameter: float) -> float:
+        if diameter <= 0:
+            return 0.0
+        area = 3.141592653589793 * (diameter ** 2) / 4.0
+        total = 0.0
+        for batch in linefill_state:
+            try:
+                ppm = int(batch.get("dra_ppm", 0) or 0)
+            except Exception:
+                ppm = 0
+            if ppm <= 0:
+                continue
+            try:
+                vol = float(batch.get("volume", 0.0))
+            except Exception:
+                vol = 0.0
+            if vol <= 0:
+                continue
+            total += vol / area / 1000.0
+        return total
+
+    stations = [_make_pump_station("Station A"), _make_pump_station("Station B")]
+    terminal = {"name": "Terminal", "min_residual": 30, "elev": 0.0}
+
+    common_kwargs = dict(
+        FLOW=2000.0,
+        KV_list=[3.0, 3.0, 3.0],
+        rho_list=[850.0, 850.0, 850.0],
+        RateDRA=5.0,
+        Price_HSD=0.0,
+        Fuel_density=0.85,
+        Ambient_temp=25.0,
+        hours=12.0,
+        start_time="00:00",
+        enumerate_loops=False,
+    )
+
+    base = solve_pipeline(
+        stations=copy.deepcopy(stations),
+        terminal=terminal,
+        linefill=[],
+        dra_reach_km=0.0,
+        **common_kwargs,
+    )
+    assert not base.get("error"), base.get("message")
+    base_sdh_b = base["sdh_station_b"]
+
+    linefill_state = [{"volume": 180000.0, "dra_ppm": 6}]
+    sdh_history: list[float] = []
+    for _ in range(3):
+        reach = _treated_length(linefill_state, stations[0]["d"])
+        result = solve_pipeline(
+            stations=copy.deepcopy(stations),
+            terminal=terminal,
+            linefill=copy.deepcopy(linefill_state),
+            dra_reach_km=reach,
+            **common_kwargs,
+        )
+        assert not result.get("error"), result.get("message")
+        assert result["dra_ppm_station_a"] == 0
+        assert result["dra_ppm_station_b"] == 0
+        sdh_history.append(result["sdh_station_b"])
+        linefill_state = copy.deepcopy(result["linefill"])
+
+    assert sdh_history[0] < base_sdh_b
+    assert all(b >= a for a, b in zip(sdh_history, sdh_history[1:]))
+    assert sdh_history[-1] <= base_sdh_b


### PR DESCRIPTION
## Summary
- replace scalar DRA reach bookkeeping with queue-based slice tracking, including helper utilities and dynamic-programming state updates
- derive downstream drag reduction coverage from the queued slices and report the remaining treated length via `dra_front_km`
- add regression tests covering inherited slug benefits with zero injection and gradual head loss growth when a new slug advances

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cbafed251083319d3fb1764543b177