### PR TITLE
Remove redundant pipeline model reload in app wrapper

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1842,12 +1842,6 @@ def solve_pipeline(
 ):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
-    import pipeline_model
-    import importlib
-    import copy
-
-    importlib.reload(pipeline_model)
-
     stations = copy.deepcopy(stations)
     first_pump = next((s for s in stations if s.get('is_pump')), None)
     if first_pump and first_pump.get('min_pumps', 0) < 1:


### PR DESCRIPTION
## Summary
- drop the per-call importlib.reload() in the Streamlit wrapper so the pipeline model is imported once at module import time
- rely on the existing deepcopy safeguards to clone station data before solving

## Testing
- `pytest` *(fails: test_daily_scheduler_path_completes_promptly exceeded 15s threshold, 17-18s on this runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cc280dfe7c833187f942e92b523fc1