### PR TITLE
Handle empty pump type availability gracefully

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2102,7 +2102,12 @@ def solve_pipeline(
                 dr_loop_max = min(max_dr_loop, rng['dra_loop'][1])
             dra_loop_vals = _allowed_values(dr_loop_min, dr_loop_max, dra_step) if loop_dict else [0]
             combo_options_built = False
-            if type_availability and len(type_availability) <= 2:
+            if not type_availability:
+                # No pump types remain after availability filtering; fall back to
+                # the generic enumeration below which covers the zero-availability
+                # case and produces a structured error when nothing is feasible.
+                pass
+            elif len(type_availability) <= 2:
                 ordered_types = sorted(type_availability)
                 primary = ordered_types[0]
                 secondary = ordered_types[1] if len(ordered_types) > 1 else None

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -111,6 +111,63 @@ def test_daily_scheduler_path_completes_promptly() -> None:
     assert duration < 15.0, f"Optimizer took too long: {duration:.2f}s"
 
 
+def test_no_available_pump_types_returns_structured_error() -> None:
+    """Stations with zero available pump units should not raise exceptions."""
+
+    stations = [
+        {
+            "name": "Origin Pump",
+            "is_pump": True,
+            "min_pumps": 0,
+            "max_pumps": 0,
+            "MinRPM": 1200,
+            "DOL": 1600,
+            "pump_types": {
+                "A": {
+                    "available": 0,
+                    "MinRPM": 1200,
+                    "DOL": 1600,
+                }
+            },
+            "A": 0.0,
+            "B": 0.0,
+            "C": 200.0,
+            "P": 0.0,
+            "Q": 0.0,
+            "R": 0.0,
+            "S": 0.0,
+            "T": 85.0,
+            "L": 10.0,
+            "d": 0.7,
+            "rough": 4.0e-05,
+            "elev": 0.0,
+            "min_residual": 30,
+            "max_dr": 0,
+            "power_type": "Grid",
+            "rate": 0.0,
+        }
+    ]
+    terminal = {"name": "Terminal", "elev": 0.0, "min_residual": 30}
+
+    result = solve_pipeline(
+        stations,
+        terminal,
+        FLOW=1200.0,
+        KV_list=[1.0],
+        rho_list=[850.0],
+        RateDRA=0.0,
+        Price_HSD=0.0,
+        Fuel_density=0.85,
+        Ambient_temp=25.0,
+        linefill=[],
+        dra_reach_km=0.0,
+        enumerate_loops=False,
+    )
+
+    assert result.get("error"), "Solver should return a structured error"
+    assert "Origin Pump" in (result.get("message") or "")
+
+
 def test_refine_recovers_lower_cost_when_coarse_hits_boundary() -> None:
     """Refinement should revisit the full DRA range when coarse hits an edge."""
 


### PR DESCRIPTION
## Summary
- guard combo enumeration in `solve_pipeline` so empty pump-type availability relies on the generic fallback logic
- add a regression test covering a station with zero available pump units to ensure the solver reports a structured error

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc3ae3770c83319886fa041684e7e9