### PR TITLE
Handle short viscosity profiles in downstream requirement

### DIFF
--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -189,6 +189,30 @@ def test_profile_cache_matches_baseline_and_improves_speed() -> None:
     )
 
 
+def test_solver_reports_error_for_short_profiles() -> None:
+    linefill = _load_linefill()
+    stations, terminal, kv_list, rho_list = _build_representative_pipeline()
+
+    result = solve_pipeline(
+        copy.deepcopy(stations),
+        terminal,
+        FLOW=1700.0,
+        KV_list=kv_list[:-1],
+        rho_list=rho_list[:-1],
+        RateDRA=5.0,
+        Price_HSD=0.0,
+        Fuel_density=820.0,
+        Ambient_temp=25.0,
+        linefill=copy.deepcopy(linefill),
+        dra_reach_km=40.0,
+        hours=4.0,
+        start_time="00:00",
+    )
+
+    assert result.get("error") is True
+    assert "viscosity" in (result.get("message") or "").lower()
+
+
 def test_refine_recovers_lower_cost_when_coarse_hits_boundary() -> None:
     """Refinement should revisit the full DRA range when coarse hits an edge."""
 


### PR DESCRIPTION
## Summary
- guard `_downstream_requirement` against short viscosity and flow profiles by raising a structured error
- ensure `solve_pipeline` surfaces profile length issues consistently and stops loop enumeration early
- add a regression test covering calls with too few viscosity/density entries

## Testing
- pytest tests/test_pipeline_performance.py

------
https://chatgpt.com/codex/tasks/task_e_68ccfde6304c8331abb8de44e36557ef