### PR TITLE
Handle idle pump DRA injections

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -658,15 +658,14 @@ def _update_mainline_dra(
 
     queue = _normalise_queue(dra_queue)
     inj_ppm_main = int(opt.get("dra_ppm_main", 0) or 0)
-    pump_running = bool(stn_data.get("is_pump")) and opt.get("nop", 0) > 0
+    pumped_volume = max(float(flow_m3h), 0.0) * max(float(hours), 0.0)
+    pumped_length = _km_from_volume(pumped_volume, float(stn_data.get("d_inner", 0.0)))
 
-    if pump_running:
-        pumped_volume = max(float(flow_m3h), 0.0) * max(float(hours), 0.0)
-        pumped_length = _km_from_volume(pumped_volume, float(stn_data.get("d_inner", 0.0)))
-        if pumped_length > 0:
-            queue = _advance_dra_queue(queue, pumped_length)
-            if inj_ppm_main > 0:
-                queue = _prepend_dra_slice(queue, pumped_length, inj_ppm_main)
+    if pumped_length > 1e-9:
+        queue = _advance_dra_queue(queue, pumped_length)
+
+    if inj_ppm_main > 0:
+        queue = _prepend_dra_slice(queue, pumped_length, inj_ppm_main)
 
     dra_segments, queue_after = _consume_segment_queue(queue, segment_length)
     return dra_segments, queue_after, inj_ppm_main

--- a/tests/test_linefill_dra.py
+++ b/tests/test_linefill_dra.py
@@ -4,11 +4,14 @@ import copy
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from pipeline_model import solve_pipeline
+from dra_utils import get_ppm_for_dr
+from pipeline_model import _km_from_volume, _update_mainline_dra, solve_pipeline
 
 
 def _make_pump_station(name: str, *, max_dr: int = 0) -> dict:
@@ -88,9 +91,14 @@ def test_linefill_dra_persists_through_running_pumps() -> None:
     assert dra_result["dra_ppm_station_b"] == 0
 
     # The carried slug reduces the SDH at the downstream station and continues
-    # travelling through the line (positive downstream reach).
+    # travelling through the line (positive treated volume remains).
     assert dra_result["sdh_station_b"] < base_result["sdh_station_b"]
-    assert dra_result["dra_front_km"] > 0
+    treated_volume = sum(
+        float(batch.get("volume", 0.0))
+        for batch in dra_result["linefill"]
+        if int(batch.get("dra_ppm", 0) or 0) > 0
+    )
+    assert treated_volume > 0.0
 
 
 def test_zero_injection_benefits_from_inherited_slug() -> None:
@@ -163,3 +171,91 @@ def test_zero_injection_benefits_from_inherited_slug() -> None:
     assert sdh_history[0] < base_sdh_b
     assert all(b >= a for a, b in zip(sdh_history, sdh_history[1:]))
     assert sdh_history[-1] <= base_sdh_b
+
+
+def test_update_mainline_dra_injects_when_pump_idle() -> None:
+    """Pump idle + injection should prepend a slug at the traversed length."""
+
+    initial_queue = [{"length_km": 12.0, "dra_ppm": 40}]
+    stn_data = {"is_pump": True, "d_inner": 0.7}
+    opt = {"nop": 0, "dra_ppm_main": 55}
+    flow_m3h = 3600.0
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, stn_data["d_inner"])
+    segment_length = pumped_length / 2.0
+
+    dra_segments, queue_after, inj_ppm = _update_mainline_dra(
+        initial_queue,
+        stn_data,
+        opt,
+        segment_length,
+        flow_m3h,
+        hours,
+    )
+
+    assert inj_ppm == opt["dra_ppm_main"]
+    assert dra_segments
+    assert dra_segments[0][1] == inj_ppm
+    assert dra_segments[0][0] == pytest.approx(segment_length, rel=1e-6)
+    assert queue_after
+    assert queue_after[0]["dra_ppm"] == inj_ppm
+    assert queue_after[0]["length_km"] == pytest.approx(
+        pumped_length - segment_length, rel=1e-6
+    )
+    assert queue_after[1]["dra_ppm"] == initial_queue[0]["dra_ppm"]
+    assert queue_after[1]["length_km"] == pytest.approx(
+        initial_queue[0]["length_km"] - pumped_length,
+        rel=1e-6,
+    )
+
+
+def test_idle_pump_injection_reflected_in_results() -> None:
+    """Idle pump injections should incur cost and appear in reporting."""
+
+    stations = [
+        _make_pump_station("Station A"),
+        _make_pump_station("Station B", max_dr=12),
+    ]
+    stations[1]["min_pumps"] = 0
+    stations[1]["max_pumps"] = 0
+
+    terminal = {"name": "Terminal", "min_residual": 5, "elev": 0.0}
+
+    hours = 12.0
+    rate_dra = 5.0
+    common_kwargs = dict(
+        FLOW=3000.0,
+        KV_list=[3.0, 3.0, 3.0],
+        rho_list=[850.0, 850.0, 850.0],
+        RateDRA=rate_dra,
+        Price_HSD=0.0,
+        Fuel_density=0.85,
+        Ambient_temp=25.0,
+        hours=hours,
+        start_time="00:00",
+        enumerate_loops=False,
+    )
+
+    narrow_ranges = {1: {"dra_main": (12, 12)}}
+
+    result = solve_pipeline(
+        stations=copy.deepcopy(stations),
+        terminal=terminal,
+        linefill=[],
+        dra_reach_km=0.0,
+        narrow_ranges=narrow_ranges,
+        _internal_pass=True,
+        **common_kwargs,
+    )
+
+    assert not result.get("error"), result.get("message")
+
+    expected_ppm = int(get_ppm_for_dr(3.0, 12))
+    flow_station_b = result["pipeline_flow_station_b"]
+    assert result["num_pumps_station_b"] == 0
+    assert result["dra_ppm_station_b"] == expected_ppm
+    assert result["drag_reduction_station_b"] > 0.0
+    assert result["dra_cost_station_b"] == pytest.approx(
+        expected_ppm * (flow_station_b * 1000.0 * hours / 1e6) * rate_dra,
+        rel=1e-6,
+    )


### PR DESCRIPTION
## Summary
- decouple mainline DRA queue advancement from pump status so flow-driven length is always tracked
- prepend idle-pump injections to the queue and expand the linefill test suite for pump idle coverage
- add regression coverage ensuring idle-pump injections affect both cost roll-up and reporting fields

## Testing
- pytest tests/test_linefill_dra.py

------
https://chatgpt.com/codex/tasks/task_e_68ce903c2ea48331a916a76a3bc8de48