### PR TITLE
Implement DRA shear factor handling for DRA queue updates

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1839,6 +1839,7 @@ def solve_pipeline(
     start_time: str = "00:00",
     *,
     segment_profiles: list[list[dict[str, float]]] | None = None,
+    dra_shear_factor: float = 0.0,
 ):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
@@ -1875,6 +1876,7 @@ def solve_pipeline(
                 hours,
                 start_time=start_time,
                 segment_profiles=segment_profiles,
+                dra_shear_factor=dra_shear_factor,
             )
         else:
             res = pipeline_model.solve_pipeline(
@@ -1893,6 +1895,7 @@ def solve_pipeline(
                 hours,
                 start_time=start_time,
                 segment_profiles=segment_profiles,
+                dra_shear_factor=dra_shear_factor,
             )
         # Append a human-readable flow pattern name based on loop usage
         if not res.get("error"):


### PR DESCRIPTION
## Summary
- add helper utilities and update `_update_mainline_dra` so running pumps shear existing and newly injected DRA slugs according to a global factor
- plumb a new `dra_shear_factor` argument through `solve_pipeline`, the pump-type wrapper, and the Streamlit wrapper so shear can be configured end-to-end
- extend DRA regression tests to cover shear effects on queue advancement and verify ppm-to-%DR conversion after repeated pump stages

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce9c50d5c0833191a0828c2f988e58