### PR TITLE
Fix DRA curve loading and ensure positive ppm outputs

### DIFF
--- a/dra_utils.py
+++ b/dra_utils.py
@@ -6,7 +6,7 @@ Adds inverse interpolation (ppm_to_dr) and keeps get_ppm_for_dr API.
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 from typing import Dict, Tuple
 
 import numpy as np
@@ -30,12 +30,16 @@ DRA_CSV_FILES: Dict[float, str] = {
     40: "40 cst.csv",
 }
 
+# Directory containing CSV lookup tables distributed with the module
+DATA_DIR = Path(__file__).resolve().parent
+
 # Load the drag-reducer curves lazily at import time
 DRA_CURVE_DATA: Dict[float, pd.DataFrame | None] = {}
 for cst, fname in DRA_CSV_FILES.items():
-    if os.path.exists(fname):
+    csv_path = DATA_DIR / fname
+    if csv_path.exists():
         try:
-            df = pd.read_csv(fname)
+            df = pd.read_csv(csv_path)
             # Ensure required columns exist
             if "%Drag Reduction" in df.columns and "PPM" in df.columns:
                 df = df[["%Drag Reduction", "PPM"]].dropna().sort_values("%Drag Reduction")

--- a/tests/test_linefill_dra.py
+++ b/tests/test_linefill_dra.py
@@ -47,6 +47,14 @@ def _make_pump_station(name: str, *, max_dr: int = 0) -> dict:
     }
 
 
+def test_get_ppm_for_known_drag_reduction_positive() -> None:
+    """Lookup tables should return positive PPM for known drag reductions."""
+
+    ppm = get_ppm_for_dr(3.0, 12.0)
+    assert ppm > 0
+    assert ppm == pytest.approx(1.0)
+
+
 def test_linefill_dra_persists_through_running_pumps() -> None:
     """Initial linefill DRA should reduce SDH even without new injections."""
 
@@ -314,9 +322,11 @@ def test_idle_pump_injection_reflected_in_results() -> None:
     assert not result.get("error"), result.get("message")
 
     expected_ppm = int(get_ppm_for_dr(3.0, 12))
+    assert expected_ppm > 0
     flow_station_b = result["pipeline_flow_station_b"]
     assert result["num_pumps_station_b"] == 0
     assert result["dra_ppm_station_b"] == expected_ppm
+    assert result["dra_ppm_station_b"] > 0
     assert result["drag_reduction_station_b"] > 0.0
     assert result["dra_cost_station_b"] == pytest.approx(
         expected_ppm * (flow_station_b * 1000.0 * hours / 1e6) * rate_dra,


### PR DESCRIPTION
## Summary
- resolve drag-reducer CSV paths relative to the module so packaged installs can load lookup data reliably
- add regression checks confirming drag-reduction lookups yield positive ppm values and optimiser injections remain positive when DRA is requested

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf71b9df80833190d2043f6728fb5c