### PR TITLE
Fix solve_pipeline call formatting

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1921,7 +1921,9 @@ def solve_pipeline(
                 start_time=start_time,
                 segment_profiles=segment_profiles,
                 dra_shear_factor=dra_shear_factor,
-            , V_MIN=st.session_state.get(\"V_MIN\", 0.0), V_MAX=st.session_state.get(\"V_MAX\", 4.0))
+                V_MIN=st.session_state.get("V_MIN", 0.0),
+                V_MAX=st.session_state.get("V_MAX", 4.0),
+            )
         # Append a human-readable flow pattern name based on loop usage
         if not res.get("error"):
             usage = res.get("loop_usage", [])


### PR DESCRIPTION
## Summary
- move the V_MIN and V_MAX keyword arguments inside the solve_pipeline call for proper formatting
- place the closing parenthesis on its own line to prevent syntax errors

## Testing
- streamlit run pipeline_optimization_app.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68cfc4da1f6c8331a53c41bf15189239