### PR TITLE
Add shared helpers for volume-length conversions

### DIFF
--- a/linefill_utils.py
+++ b/linefill_utils.py
@@ -9,7 +9,6 @@ parts-per-million for that batch.
 
 from __future__ import annotations
 
-from math import pi
 from typing import List, Dict
 
 
@@ -35,12 +34,14 @@ def linefill_lengths(linefill: List[Dict], diameter: float) -> List[Dict]:
     """
     if diameter <= 0:
         raise ValueError("Pipe diameter must be positive")
-    area = pi * (diameter ** 2) / 4.0
+    from pipeline_model import _km_from_volume
+
+    km_from_volume = _km_from_volume
     result = []
     cum_len = 0.0
     for entry in linefill:
         vol = float(entry.get("volume", 0.0))
-        length_km = vol / area / 1000.0
+        length_km = km_from_volume(vol, diameter)
         new_entry = entry.copy()
         new_entry.update(
             {

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -6,6 +6,7 @@ import copy
 import datetime as dt
 from collections.abc import Mapping
 from itertools import product
+import math
 
 import numpy as np
 
@@ -27,6 +28,44 @@ from linefill_utils import advance_linefill
 def head_to_kgcm2(head_m: float, rho: float) -> float:
     """Convert a head value in metres to kg/cm²."""
     return head_m * rho / 10000.0
+
+
+def _km_from_volume(volume_m3: float, diameter_m: float) -> float:
+    """Return the pipeline length in kilometres occupied by ``volume_m3``."""
+
+    try:
+        volume = float(volume_m3)
+    except (TypeError, ValueError):
+        return 0.0
+    try:
+        diameter = float(diameter_m)
+    except (TypeError, ValueError):
+        return 0.0
+    if diameter <= 0:
+        return 0.0
+    area = math.pi * (diameter ** 2) / 4.0
+    if area <= 0:
+        return 0.0
+    return volume / area / 1000.0
+
+
+def _volume_from_km(length_km: float, diameter_m: float) -> float:
+    """Return the volume in cubic metres for ``length_km`` of pipe."""
+
+    try:
+        length = float(length_km)
+    except (TypeError, ValueError):
+        return 0.0
+    try:
+        diameter = float(diameter_m)
+    except (TypeError, ValueError):
+        return 0.0
+    if diameter <= 0:
+        return 0.0
+    area = math.pi * (diameter ** 2) / 4.0
+    if area <= 0:
+        return 0.0
+    return length * 1000.0 * area
 
 
 def generate_type_combinations(maxA: int = 3, maxB: int = 3) -> list[tuple[int, int]]:
@@ -2513,3 +2552,8 @@ def solve_pipeline_with_types(
 
     best_result['stations_used'] = best_stations
     return best_result
+
+
+_exported_names = [name for name in globals() if not name.startswith('_')]
+_exported_names.extend(['_km_from_volume', '_volume_from_km'])
+__all__ = list(dict.fromkeys(_exported_names))

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -33,7 +33,7 @@ import pandas as pd
 import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
-from math import pi
+from math import pi, sqrt
 import hashlib
 import uuid
 import json
@@ -1035,6 +1035,8 @@ def map_vol_linefill_to_segments(vol_table: pd.DataFrame, stations: list[dict]) 
     A = pipe_cross_section_area_m2(stations)
     if A <= 0:
         raise ValueError("Invalid pipe area (check D and t).")
+    d_inner = sqrt((4.0 * A) / pi)
+    km_from_volume = pipeline_model._km_from_volume
 
     # Compute lengths occupied by each batch
     # Expected columns: Product, Volume (m³), Viscosity (cSt), Density (kg/m³)
@@ -1043,7 +1045,7 @@ def map_vol_linefill_to_segments(vol_table: pd.DataFrame, stations: list[dict]) 
         vol = float(r.get("Volume (m³)", 0.0) or r.get("Volume", 0.0) or 0.0)
         if vol <= 0:
             continue
-        length_km = (vol / A) / 1000.0  # m / 1000 => km
+        length_km = km_from_volume(vol, d_inner)
         visc = float(r.get("Viscosity (cSt)", 0.0))
         dens = float(r.get("Density (kg/m³)", 0.0))
         batches.append({"len_km": length_km, "kv": visc, "rho": dens})


### PR DESCRIPTION
## Summary
- add reusable helpers in `pipeline_model` to convert between pipeline volume and length
- export the new helper and update related utilities to rely on it instead of ad-hoc math

## Testing
- pytest *(fails: existing `_update_mainline_dra` signature and `_build_pump_option_cache` expectations in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ad23feac8331bffbf7c6ae67eeef