### PR TITLE
Adjust idle pump DRA mixing

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -524,8 +524,13 @@ def _update_mainline_dra(
     pumped_slices: list[tuple[float, float]] = []
 
     if not pump_running:
-        if inj_ppm_main > 0 and pumped_length > 0:
-            pumped_slices.append((pumped_length, float(inj_ppm_main)))
+        inj_effective = float(inj_ppm_main)
+        if inj_effective > 0:
+            for length, base_ppm in incoming_slices:
+                length = float(length)
+                if length <= 0:
+                    continue
+                pumped_slices.append((length, float(base_ppm) + inj_effective))
         else:
             pumped_slices.extend(incoming_slices)
     else:


### PR DESCRIPTION
## Summary
* adjust idle pump injection handling so local ppm augments each incoming slice instead of replacing the slug
* extend idle pump tests to assert the downstream queue reflects upstream plus local injection ppm and covers multi-slice scenarios

## Testing
* pytest tests/test_linefill_dra.py

------
https://chatgpt.com/codex/tasks/task_e_68d0cd8c82208331addbc7471ab0a6e2