### PR TITLE
Clamp pumped DRA length for zero flow

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -373,8 +373,29 @@ def _prepare_dra_queue_consumption(
 ) -> tuple[float, tuple[tuple[float, float], ...], tuple[tuple[float, float], ...]]:
     """Return pumped length along with consumed slices and downstream remainder."""
 
+    try:
+        segment_length = float(segment_length)
+    except (TypeError, ValueError):
+        segment_length = 0.0
+    if segment_length < 0:
+        segment_length = 0.0
+    try:
+        flow_m3h = float(flow_m3h)
+    except (TypeError, ValueError):
+        flow_m3h = 0.0
+    try:
+        hours = float(hours)
+    except (TypeError, ValueError):
+        hours = 0.0
+    if hours < 0:
+        hours = 0.0
+    try:
+        d_inner = float(d_inner)
+    except (TypeError, ValueError):
+        d_inner = 0.0
+
     pumped_length_calc = _km_from_volume(flow_m3h * hours, d_inner) if d_inner > 0 else 0.0
-    pumped_length = pumped_length_calc if pumped_length_calc > 0 else segment_length
+    pumped_length = max(0.0, pumped_length_calc)
 
     current_queue: list[tuple[float, float]] = []
     key_entries: list[tuple[float, float]] = []

--- a/tests/test_linefill_dra.py
+++ b/tests/test_linefill_dra.py
@@ -392,6 +392,54 @@ def test_downstream_station_waits_for_advancing_front() -> None:
     assert first_treated["length_km"] == pytest.approx(pumped_length, rel=1e-6)
 
 
+def test_zero_flow_still_delivers_initial_slug_downstream() -> None:
+    """Station B should retain the inherited slug even when no flow is pumped."""
+
+    diameter = 0.5
+    flow_m3h = 0.0
+    hours = 1.0
+    segment_a = 5.0
+    segment_b = 20.0
+    initial_queue = [
+        {"length_km": segment_a, "dra_ppm": 10},
+        {"length_km": segment_b, "dra_ppm": 0},
+    ]
+    opt_idle = {"nop": 0, "dra_ppm_main": 0}
+
+    precomputed_b = _prepare_dra_queue_consumption(
+        initial_queue,
+        segment_b,
+        flow_m3h,
+        hours,
+        diameter,
+    )
+    pumped_length_b = float(precomputed_b[0])
+    assert pumped_length_b == pytest.approx(0.0, abs=1e-9)
+
+    dra_segments_b, queue_after_b, inj_ppm_b = _update_mainline_dra(
+        initial_queue,
+        {"idx": 1, "is_pump": True, "d_inner": diameter},
+        opt_idle,
+        segment_b,
+        flow_m3h,
+        hours,
+        precomputed=precomputed_b,
+    )
+
+    assert inj_ppm_b == 0
+    assert dra_segments_b
+    assert dra_segments_b[0][1] == 10
+    assert dra_segments_b[0][0] == pytest.approx(segment_a, rel=1e-6)
+
+    first_treated = next(
+        (batch for batch in queue_after_b if int(batch.get("dra_ppm", 0) or 0) > 0),
+        None,
+    )
+    assert first_treated is not None
+    assert first_treated["dra_ppm"] == 10
+    assert first_treated["length_km"] == pytest.approx(segment_a, rel=1e-6)
+
+
 def test_running_pump_shears_trimmed_slug() -> None:
     """Shear factor should attenuate the slug passing through an active pump."""
 


### PR DESCRIPTION
## Summary
- sanitize inputs in `_prepare_dra_queue_consumption` and clamp the computed pumped distance to zero when throughput is absent
- add regression coverage ensuring the downstream station still receives the inherited slug when mainline flow is zero on the 5 km + 20 km layout

## Testing
- pytest tests/test_linefill_dra.py

------
https://chatgpt.com/codex/tasks/task_e_68d1007c7c148331a4b4f9ea169987f2