### PR TITLE
Add brute-force search mode for pipeline solver

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1742,6 +1742,7 @@ def solve_pipeline(
     hours: float = 24.0,
     start_time: str = "00:00",
     pump_shear_rate: float | None = None,
+    brute_force: bool = False,
 ):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
@@ -1782,6 +1783,7 @@ def solve_pipeline(
                 hours,
                 start_time=start_time,
                 pump_shear_rate=pump_shear_rate,
+                brute_force=brute_force,
                 **search_kwargs,
             )
         else:
@@ -1801,6 +1803,7 @@ def solve_pipeline(
                 hours,
                 start_time=start_time,
                 pump_shear_rate=pump_shear_rate,
+                brute_force=brute_force,
                 **search_kwargs,
             )
         # Append a human-readable flow pattern name based on loop usage


### PR DESCRIPTION
## Summary
- add an optional `brute_force` flag to the pipeline solver so callers can bypass the coarse pass and retain every feasible state, while tracking enumeration counts
- thread the new flag through the pump-type expansion helper and Streamlit wrapper so UIs can opt into exhaustive search
- add a regression test that patches the hydraulics to confirm brute-force exploration keeps all combinations whereas the default run still prunes

## Testing
- pytest tests/test_pipeline_performance.py

------
https://chatgpt.com/codex/tasks/task_e_68d14856ee5c8331a9212bde6c359417