### PR TITLE
Ensure run_all_updates passes segment slices

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -2458,8 +2458,20 @@ def run_all_updates():
         "elev": st.session_state.get("terminal_elev", 0.0),
         "min_residual": st.session_state.get("terminal_head", 10.0),
     }
-    linefill_df = st.session_state.get("linefill_df", pd.DataFrame())
-    kv_list, rho_list, segment_slices = derive_segment_profiles(linefill_df, stations_data)
+    linefill_df = st.session_state.get("linefill_df")
+    if not isinstance(linefill_df, pd.DataFrame):
+        linefill_df = pd.DataFrame()
+
+    vol_linefill = st.session_state.get("linefill_vol_df")
+    if isinstance(vol_linefill, pd.DataFrame) and len(vol_linefill) > 0:
+        kv_list, rho_list, segment_slices = map_vol_linefill_to_segments(
+            vol_linefill, stations_data
+        )
+        linefill_df = vol_linefill
+    else:
+        kv_list, rho_list, segment_slices = derive_segment_profiles(
+            linefill_df, stations_data
+        )
 
     for idx, stn in enumerate(stations_data, start=1):
         if stn.get("is_pump", False):

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -130,6 +130,7 @@ def test_run_all_updates_passes_segment_slices(monkeypatch):
         ]
     )
     session["linefill_df"] = vol_df
+    session["linefill_vol_df"] = vol_df
 
     captured: dict[str, list] = {}
 
@@ -161,6 +162,7 @@ def test_run_all_updates_passes_segment_slices(monkeypatch):
 
         assert "segment_slices" in captured
         segment_slices = captured["segment_slices"]
+        assert segment_slices is not None
         assert isinstance(segment_slices, list)
         assert len(segment_slices) == len(session["stations"])
         assert all(isinstance(entry, list) for entry in segment_slices)


### PR DESCRIPTION
## Summary
- prefer volumetric linefill data in `run_all_updates` when building segment property lists and fall back to default slices otherwise
- extend the regression test to capture volumetric linefill state and verify the solver receives non-null segment slices

## Testing
- pytest tests/test_pipeline_performance.py

------
https://chatgpt.com/codex/tasks/task_e_68d26329ad6883319941aa4f90818040