### PR TITLE
Preserve heterogeneous segment properties in merged profiles

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1375,8 +1375,8 @@ def _merge_segment_profiles(
         if step <= tol:
             break
 
-        kv_entry = max(kv_now, kv_next, kv_max)
-        rho_entry = max(rho_now, rho_next, rho_max)
+        kv_entry = max(kv_now, kv_next)
+        rho_entry = max(rho_now, rho_next)
         merged.append({"length_km": step, "kv": kv_entry, "rho": rho_entry})
         rem_now -= step
         rem_next -= step


### PR DESCRIPTION
## Summary
- stop forcing merged segment slices to global max viscosity/density so overlapping entries reflect their actual maxima
- add a regression test that merges contrasting batches and asserts the heterogenous slice profile is preserved

## Testing
- pytest tests/test_pipeline_performance.py


------
https://chatgpt.com/codex/tasks/task_e_68d27ef520748331a349a3bc6fa2a203