### PR TITLE
Style download buttons with primary gradient

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -117,6 +117,19 @@ st.markdown("""
         background: #b71c1c;
         color: #fff;
     }
+    .stDownloadButton button {
+        background: linear-gradient(90deg, #d32f2f 30%, #c62828 100%);
+        color: #fff !important;
+        font-weight: 600;
+        border: none;
+        border-radius: 12px;
+        box-shadow: 0 3px 18px #d32f2f44;
+        transition: background 0.19s;
+    }
+    .stDownloadButton button:hover {
+        background: #b71c1c;
+        color: #fff !important;
+    }
     .action-btn-row {
         display: flex;
         justify-content: flex-end;


### PR DESCRIPTION
## Summary
- apply the red primary gradient styling to all Streamlit download buttons via a global CSS rule

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2ef80d8988331999b26d00f3b68e9