### PR TITLE
Support Initial DRA ppm linefill inputs

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2164,7 +2164,12 @@ def solve_pipeline(
     if linefill:
         if isinstance(linefill, dict):
             vols = linefill.get('volume') or linefill.get('Volume (m³)') or linefill.get('Volume')
-            ppms = linefill.get('dra_ppm') or linefill.get('DRA ppm') or {}
+            ppms = (
+                linefill.get('dra_ppm')
+                or linefill.get('DRA ppm')
+                or linefill.get('Initial DRA (ppm)')
+                or {}
+            )
             if vols is not None:
                 items = vols.items() if isinstance(vols, dict) else enumerate(vols)
                 for idx, v in items:
@@ -2194,7 +2199,12 @@ def solve_pipeline(
                 if vol <= 0:
                     continue
                 try:
-                    ppm = float(ent.get('dra_ppm') or ent.get('DRA ppm') or 0.0)
+                    ppm = float(
+                        ent.get('dra_ppm')
+                        or ent.get('DRA ppm')
+                        or ent.get('Initial DRA (ppm)')
+                        or 0.0
+                    )
                 except Exception:
                     ppm = 0.0
                 linefill_state.append({'volume': vol, 'dra_ppm': ppm})


### PR DESCRIPTION
## Summary
- update pipeline linefill parsing to accept "Initial DRA (ppm)" columns for both dict and list inputs
- ensure parsed concentrations continue to feed existing dra_ppm handling and validation
- add regression test covering the new column for both accepted linefill formats

## Testing
- pytest tests/test_linefill_dra.py::test_initial_dra_column_is_parsed_for_linefill

------
https://chatgpt.com/codex/tasks/task_e_68d59a2d1a7083318f62c61faecc893e