### PR TITLE
Sanitise non-finite linefill DRA ppm values

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2189,6 +2189,8 @@ def solve_pipeline(
                         ppm = float(ppm_val)
                     except Exception:
                         ppm = 0.0
+                    if not math.isfinite(ppm) or ppm < 0.0:
+                        ppm = 0.0
                     linefill_state.append({'volume': vol, 'dra_ppm': ppm})
         elif isinstance(linefill, list):
             for ent in linefill:
@@ -2206,6 +2208,8 @@ def solve_pipeline(
                         or 0.0
                     )
                 except Exception:
+                    ppm = 0.0
+                if not math.isfinite(ppm) or ppm < 0.0:
                     ppm = 0.0
                 linefill_state.append({'volume': vol, 'dra_ppm': ppm})
     linefill_state = copy.deepcopy(linefill_state)

--- a/tests/test_linefill_dra.py
+++ b/tests/test_linefill_dra.py
@@ -5,6 +5,7 @@ import math
 import sys
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -340,6 +341,47 @@ def test_initial_dra_column_is_parsed_for_linefill(linefill_style: str) -> None:
     assert not result.get("error"), result.get("message")
     assert result["dra_ppm_station_a"] == pytest.approx(0.0)
     assert result["dra_inlet_ppm_station_a"] == pytest.approx(initial_ppm)
+
+
+@pytest.mark.parametrize(
+    "nan_value",
+    [math.nan, np.nan],
+    ids=["math_nan", "numpy_nan"],
+)
+@pytest.mark.parametrize("linefill_style", ["list", "dict"], ids=["list", "dict"])
+def test_initial_dra_nan_values_default_to_zero(linefill_style: str, nan_value: float) -> None:
+    """Non-finite initial ppm entries should be treated as zero when parsed."""
+
+    stations = [_make_pump_station("Station A")]
+    terminal = {"name": "Terminal", "min_residual": 5, "elev": 0.0}
+
+    diameter = stations[0]["d"]
+    volume = _volume_from_km(10.0, diameter)
+
+    if linefill_style == "list":
+        linefill = [{"volume": volume, "Initial DRA (ppm)": nan_value}]
+    else:
+        linefill = {"volume": [volume], "Initial DRA (ppm)": [nan_value]}
+
+    result = solve_pipeline(
+        stations=copy.deepcopy(stations),
+        terminal=terminal,
+        FLOW=2500.0,
+        KV_list=[3.0, 3.0],
+        rho_list=[850.0, 850.0],
+        RateDRA=0.0,
+        Price_HSD=0.0,
+        Fuel_density=0.85,
+        Ambient_temp=25.0,
+        linefill=linefill,
+        dra_reach_km=0.0,
+        hours=12.0,
+        start_time="00:00",
+        enumerate_loops=False,
+    )
+
+    assert not result.get("error"), result.get("message")
+    assert result["dra_inlet_ppm_station_a"] == pytest.approx(0.0)
 
 
 def test_zero_injection_benefits_from_inherited_slug() -> None:


### PR DESCRIPTION
## Summary
- sanitise linefill DRA ppm parsing by resetting negative or non-finite values to zero before queueing batches
- cover NaN initial ppm inputs with a regression test for both list and dict linefill styles

## Testing
- pytest tests/test_linefill_dra.py -k "initial_dra"


------
https://chatgpt.com/codex/tasks/task_e_68d59d2b6d44833187ff2660fd3ce4ae