### PR TITLE
Preserve untreated DRA front when origin pumps run without injection

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -653,6 +653,72 @@ def _trim_queue_front(
     )
 
 
+def _trim_queue_tail(
+    queue_entries: list[tuple[float, float]]
+    | tuple[tuple[float, float], ...]
+    | None,
+    trim_length: float,
+) -> tuple[tuple[float, float], ...]:
+    """Return ``queue_entries`` shortened by ``trim_length`` from the tail."""
+
+    if not queue_entries:
+        return ()
+
+    try:
+        remaining = max(float(trim_length or 0.0), 0.0)
+    except (TypeError, ValueError):
+        remaining = 0.0
+
+    normalised: list[list[float]] = []
+    for entry in queue_entries:
+        if not entry:
+            continue
+        if isinstance(entry, (list, tuple)):
+            try:
+                length_val = float(entry[0] if len(entry) > 0 else 0.0)
+            except (TypeError, ValueError):
+                length_val = 0.0
+            try:
+                ppm_val = float(entry[1] if len(entry) > 1 else 0.0)
+            except (TypeError, ValueError):
+                ppm_val = 0.0
+        else:
+            try:
+                length_val = float(entry)
+            except (TypeError, ValueError):
+                length_val = 0.0
+            ppm_val = 0.0
+        if length_val <= 0.0:
+            continue
+        normalised.append([length_val, ppm_val])
+
+    if not normalised:
+        return ()
+
+    if remaining <= 0.0:
+        return tuple((length, ppm) for length, ppm in normalised if length > 0.0)
+
+    idx = len(normalised) - 1
+    while idx >= 0 and remaining > 0.0:
+        length_val = normalised[idx][0]
+        if length_val <= 0.0:
+            normalised.pop(idx)
+            idx -= 1
+            continue
+        if remaining >= length_val - 1e-9:
+            remaining -= length_val
+            normalised.pop(idx)
+            idx -= 1
+        else:
+            normalised[idx][0] = length_val - remaining
+            remaining = 0.0
+
+    if not normalised:
+        return ()
+
+    return tuple((float(length), float(ppm)) for length, ppm in normalised if length > 0.0)
+
+
 def _take_queue_front(
     queue_entries: list[tuple[float, float]]
     | tuple[tuple[float, float], ...],
@@ -856,6 +922,7 @@ def _update_mainline_dra(
 
     base_dr_cache: dict[float, float] = {}
     pumped_slices: list[tuple[float, float]] = []
+    carried_slices: list[tuple[float, float]] = []
     for length, base_ppm in incoming_slices:
         length_val = float(length)
         if length_val <= 0:
@@ -866,9 +933,7 @@ def _update_mainline_dra(
             base_val = 0.0
         if base_val < 0:
             base_val = 0.0
-        if pump_running and is_origin and inj_requested <= 0:
-            treated_ppm = 0.0
-        elif base_val > 0 and upstream_multiplier < 1.0 and kv > 0:
+        if base_val > 0 and upstream_multiplier < 1.0 and kv > 0:
             key = round(base_val, 6)
             base_dr = base_dr_cache.get(key)
             if base_dr is None:
@@ -892,58 +957,55 @@ def _update_mainline_dra(
             treated_ppm = base_val
         else:
             treated_ppm = base_val * upstream_multiplier
+        if treated_ppm < 0:
+            treated_ppm = 0.0
+        carried_slices.append((length_val, treated_ppm))
         combined_ppm = treated_ppm + inj_effective
-        if combined_ppm < 0:
+        if pump_running and is_origin and inj_requested <= 0:
+            combined_ppm = 0.0
+        elif combined_ppm < 0:
             combined_ppm = 0.0
         pumped_slices.append((length_val, combined_ppm))
 
     inj_ppm_main = inj_requested
 
-    segment_cover_entries: list[tuple[float, float]] = []
-    downstream_entries: list[tuple[float, float]] = []
-    remaining_seg = segment_length
-    for length, ppm_val in pumped_slices:
-        length = float(length)
-        if length <= 0:
-            continue
-        take = 0.0
-        if remaining_seg > 0:
-            take = min(length, remaining_seg)
-            if take > 0:
-                segment_cover_entries.append((take, ppm_val))
-                remaining_seg -= take
-        leftover = length - take
-        if leftover > 0:
-            downstream_entries.append((leftover, ppm_val))
+    pumped_entries = [
+        (float(length), float(ppm_val))
+        for length, ppm_val in pumped_slices
+        if float(length) > 0
+    ]
 
-    queue_remainder_list: list[list[float]] = [
-        [float(length or 0.0), float(ppm_val or 0.0)]
+    remainder_entries = [
+        (float(length or 0.0), float(ppm_val or 0.0))
         for length, ppm_val in queue_remainder
         if float(length or 0.0) > 0
     ]
 
-    if remaining_seg > 0 and queue_remainder_list:
-        idx = 0
-        while remaining_seg > 0 and idx < len(queue_remainder_list):
-            length, ppm_val = queue_remainder_list[idx]
-            take = min(length, remaining_seg)
-            if take > 0:
-                segment_cover_entries.append((take, ppm_val))
-                queue_remainder_list[idx][0] = length - take
-                remaining_seg -= take
-            if queue_remainder_list[idx][0] <= 0:
-                queue_remainder_list[idx][0] = 0.0
-                idx += 1
-            elif remaining_seg <= 0:
-                break
-            else:
-                idx += 1
+    downstream_entries: list[tuple[float, float]]
+    if pump_running and is_origin and inj_requested <= 0:
+        carried_entries = [
+            (float(length), float(ppm_val))
+            for length, ppm_val in carried_slices
+            if float(length) > 0
+        ]
+        downstream_source = carried_entries + remainder_entries
+        if downstream_source:
+            trimmed = _trim_queue_tail(tuple(downstream_source), pumped_length)
+            downstream_entries = [
+                (float(length), float(ppm))
+                for length, ppm in trimmed
+                if float(length) > 0
+            ]
+        else:
+            downstream_entries = []
+    else:
+        downstream_entries = remainder_entries
 
-    trimmed_remainder: list[tuple[float, float]] = [
-        (length, ppm_val)
-        for length, ppm_val in queue_remainder_list
-        if length > 0
-    ]
+    combined_entries = pumped_entries + downstream_entries
+
+    merged_queue = _merge_queue(combined_entries)
+
+    segment_cover_entries = _take_queue_front(tuple(merged_queue), segment_length)
 
     dra_segments: list[tuple[float, float]] = []
     for length, ppm_val in segment_cover_entries:
@@ -959,16 +1021,6 @@ def _update_mainline_dra(
                 dra_segments[-1] = (prev_len + length, ppm_float)
             else:
                 dra_segments.append((length, ppm_float))
-
-    combined_entries: list[tuple[float, float]] = [
-        (float(length), float(ppm_val))
-        for length, ppm_val in (
-            segment_cover_entries + downstream_entries + trimmed_remainder
-        )
-        if float(length) > 0
-    ]
-
-    merged_queue = _merge_queue(combined_entries)
     queue_after = [
         {'length_km': length, 'dra_ppm': ppm}
         for length, ppm in merged_queue

--- a/tests/test_linefill_dra.py
+++ b/tests/test_linefill_dra.py
@@ -270,6 +270,27 @@ def _profile_untreated_length(profile: list[dict]) -> float:
     return total
 
 
+def _linefill_front_untreated(linefill_state: list[dict], diameter: float) -> float:
+    """Return the untreated distance at the head of ``linefill_state``."""
+
+    front = 0.0
+    for batch in linefill_state:
+        try:
+            volume = float(batch.get("volume", 0.0) or 0.0)
+        except Exception:
+            volume = 0.0
+        length = _km_from_volume(volume, diameter)
+        try:
+            ppm = float(batch.get("dra_ppm", 0.0) or 0.0)
+        except Exception:
+            ppm = 0.0
+        if ppm <= 0.0 and length > 0.0:
+            front += length
+        else:
+            break
+    return front
+
+
 def test_linefill_dra_persists_through_running_pumps() -> None:
     """Initial linefill DRA should reduce SDH even without new injections."""
 
@@ -429,8 +450,9 @@ def test_downstream_profile_advances_between_hours() -> None:
 
     carry_queue = queue_prev_inlet
     pumped_km = _queue_total_length(tuple(initial_queue)) - _queue_total_length(carry_queue)
-    if pumped_km > 0.0:
-        carry_queue = _merge_queue(carry_queue + ((pumped_km, 0.0),))
+    pumped_per_station = _km_from_volume(flow_m3h * hours, diameter)
+    expected_advanced = pumped_per_station * len(stations)
+    assert pumped_km == pytest.approx(expected_advanced, rel=1e-6)
 
     linefill_hour2 = [
         {
@@ -456,6 +478,72 @@ def test_downstream_profile_advances_between_hours() -> None:
 
     assert profile_hour1 != profile_hour2
     assert untreated_hour2 > untreated_hour1
+
+
+def test_origin_zero_injection_extends_front_between_runs() -> None:
+    """Successive zero-ppm runs should accumulate untreated distance upstream."""
+
+    stations = [_make_pump_station("Paradip"), _make_pump_station("Balasore")]
+    diameter = 0.7
+    for stn in stations:
+        stn["d"] = stn["d_inner"] = diameter
+        stn["kv"] = 3.0
+        stn["dra_shear_factor"] = 0.0
+        stn["shear_injection"] = False
+    stations[0]["L"] = 65.0
+    stations[1]["L"] = 70.0
+    terminal = {"name": "Terminal", "min_residual": 0.0, "elev": 0.0}
+
+    hours = 1.0
+    flow_m3h = 2590.0075234357646
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter)
+
+    initial_linefill = [
+        {"volume": _volume_from_km(30.0, diameter), "dra_ppm": 12.0},
+        {"volume": _volume_from_km(25.0, diameter), "dra_ppm": 8.0},
+    ]
+
+    common_kwargs = dict(
+        FLOW=flow_m3h,
+        KV_list=[3.0, 3.0, 3.0],
+        rho_list=[850.0, 850.0, 850.0],
+        RateDRA=0.0,
+        Price_HSD=0.0,
+        Fuel_density=0.85,
+        Ambient_temp=25.0,
+        hours=hours,
+        start_time="00:00",
+        dra_reach_km=0.0,
+        enumerate_loops=False,
+    )
+
+    result_hour1 = solve_pipeline(
+        stations=copy.deepcopy(stations),
+        terminal=terminal,
+        linefill=copy.deepcopy(initial_linefill),
+        **common_kwargs,
+    )
+
+    assert not result_hour1.get("error"), result_hour1.get("message")
+
+    front_zero_hour1 = _linefill_front_untreated(result_hour1["linefill"], diameter)
+    assert front_zero_hour1 == pytest.approx(pumped_length, abs=1e-6)
+
+    kwargs_hour2 = dict(common_kwargs)
+    kwargs_hour2["start_time"] = "01:00"
+
+    result_hour2 = solve_pipeline(
+        stations=copy.deepcopy(stations),
+        terminal=terminal,
+        linefill=copy.deepcopy(result_hour1["linefill"]),
+        **kwargs_hour2,
+    )
+
+    assert not result_hour2.get("error"), result_hour2.get("message")
+
+    front_zero_hour2 = _linefill_front_untreated(result_hour2["linefill"], diameter)
+    assert front_zero_hour2 > front_zero_hour1
+    assert front_zero_hour2 == pytest.approx(pumped_length * 2.0, abs=1e-4)
 
 
 def test_zero_injection_benefits_from_inherited_slug() -> None:
@@ -1015,9 +1103,9 @@ def test_global_shear_scales_drag_reduction_in_dr_domain() -> None:
             {"nop": 1, "dra_ppm_main": 0},
             True,
             1.0,
-            [(3.0, 10.0)],
-            [(2.0, 0.0), (23.0, 10.0)],
-            [(22.0, 10.0)],
+            [(1.0, 10.0)],
+            [(4.0, 0.0), (21.0, 10.0)],
+            [(1.0, 0.0), (21.0, 10.0)],
         ),
         (
             "running_injection",
@@ -1348,10 +1436,23 @@ def test_origin_station_without_injection_zeroes_slug() -> None:
         assert not dra_segments
         assert queue_after
         assert queue_after[0]["dra_ppm"] == 0
+        expected_front = pumped_length * (2.0 if shear_factor >= 1.0 - 1e-9 else 1.0)
         assert queue_after[0]["length_km"] == pytest.approx(
-            pumped_length,
+            expected_front,
             rel=1e-6,
         )
+
+        remaining_entries = queue_after[1:]
+        remaining_total = sum(float(entry.get("length_km", 0.0) or 0.0) for entry in remaining_entries)
+        assert remaining_total == pytest.approx(
+            initial_queue[0]["length_km"] - expected_front,
+            rel=1e-6,
+        )
+
+        tail_entry = remaining_entries[-1]
+        assert tail_entry["dra_ppm"] == initial_queue[0]["dra_ppm"]
+        expected_tail_length = max(initial_queue[0]["length_km"] - 2.0 * pumped_length, 0.0)
+        assert tail_entry["length_km"] == pytest.approx(expected_tail_length, rel=1e-6)
 
 
 def test_full_shear_zero_front_propagates_downstream() -> None:


### PR DESCRIPTION
## Summary
- keep carried DRA slices when reconstructing queues by trimming from the tail instead of re-prepending the head
- extend `_update_mainline_dra` origin handling so zero-injection runs grow the untreated front and conserve queue length
- add helper utilities and regression coverage for the Paradip/Balasore 0 ppm scenario plus updated expectations for downstream queue tests

## Testing
- pytest tests/test_linefill_dra.py -q
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d644b05b108331b6109e3a47682db0