### PR TITLE
Refactor downstream profile regression test

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -3651,8 +3651,10 @@ def solve_pipeline(
     last_maop_head = best_state['last_maop']
     last_maop_kg = best_state['last_maop_kg']
 
-    queue_source = best_state.get('dra_queue_full')
-    if queue_source is None:
+    queue_source = best_state.get('dra_queue_at_inlet')
+    if not queue_source:
+        queue_source = best_state.get('dra_queue_full')
+    if not queue_source:
         queue_source = best_state.get('dra_queue', ())
     queue_final = [
         (


### PR DESCRIPTION
## Summary
- update the downstream progression regression test to drive hour-two inputs from the first solve's returned linefill batches
- require the solver-provided carryover queue to exist before re-running and reuse prior kwargs with a later start time
- prefer the inlet queue when available but fall back to the full queue so final linefill data remains populated for other scenarios

## Testing
- pytest tests/test_linefill_dra.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d65f7666f483318e2e703ab5ef098b