### PR TITLE
Fix queue trimming for multi-diameter pipelines

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -3047,7 +3047,12 @@ def solve_pipeline(
                     upstream_length,
                     seg_length_total,
                 )
-                trim_after_segment = max(upstream_length + seg_length_total, 0.0)
+                seg_queue_consumed = _queue_total_length(segment_profile_raw)
+                queue_total_length = _queue_total_length(queue_after_full)
+                trim_after_segment = min(
+                    queue_total_length,
+                    max(upstream_length + seg_queue_consumed, 0.0),
+                )
                 queue_after_inlet = _trim_queue_front(
                     queue_after_full,
                     trim_after_segment,


### PR DESCRIPTION
## Summary
- compute the per-segment queue consumption from the generated profile before trimming the downstream queue
- clamp queue trimming to the available queue length so mixed-diameter systems retain downstream slices
- add a regression that exercises a multi-diameter pipeline across successive hours to ensure feasibility persists

## Testing
- pytest tests/test_linefill_dra.py

------
https://chatgpt.com/codex/tasks/task_e_68d66c0d061c83318f72e7fad95daf2b