### PR TITLE
Fix DRA queue ordering for extended slugs

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -969,17 +969,17 @@ def _update_mainline_dra(
             if float(length) > 0
         )
 
-    if trimmed_remainder:
-        combined_entries.extend(
-            (float(length), float(ppm_val))
-            for length, ppm_val in trimmed_remainder
-            if float(length) > 0
-        )
-
     if downstream_entries:
         combined_entries.extend(
             (float(length), float(ppm_val))
             for length, ppm_val in downstream_entries
+            if float(length) > 0
+        )
+
+    if trimmed_remainder:
+        combined_entries.extend(
+            (float(length), float(ppm_val))
+            for length, ppm_val in trimmed_remainder
             if float(length) > 0
         )
 


### PR DESCRIPTION
## Summary
- reorder `_update_mainline_dra` queue assembly so downstream leftovers stay attached to the treated slug
- add a regression test that pumps more than one segment and ensures the downstream queue starts with the new injection
- update DRA queue unit tests to match the merged slug ordering and revised shear handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6bac489d88331a8a750fc2ce010ef