### PR TITLE
Add backtracking for zero DRA failures in hourly optimizer

### DIFF
--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -180,6 +180,124 @@ def test_run_all_updates_passes_segment_slices(monkeypatch):
                 session[key] = value
 
 
+def test_time_series_solver_backtracks_to_enforce_dra(monkeypatch):
+    import pipeline_optimization_app as app
+
+    stations_base = [
+        {
+            "name": "Station A",
+            "is_pump": True,
+            "L": 20.0,
+            "D": 0.7,
+            "t": 0.007,
+            "max_pumps": 1,
+        }
+    ]
+    term_data = {"name": "Terminal", "elev": 0.0, "min_residual": 10.0}
+    hours = [0, 1]
+
+    vol_df = pd.DataFrame(
+        [
+            {
+                "Product": "Batch 1",
+                "Volume (m³)": 8000.0,
+                "Viscosity (cSt)": 2.5,
+                "Density (kg/m³)": 820.0,
+                app.INIT_DRA_COL: 0.0,
+            }
+        ]
+    )
+    vol_df = app.ensure_initial_dra_column(vol_df, default=0.0, fill_blanks=True)
+    vol_df["DRA ppm"] = vol_df[app.INIT_DRA_COL]
+    dra_linefill = app.df_to_dra_linefill(vol_df)
+    current_vol = app.apply_dra_ppm(vol_df.copy(), dra_linefill)
+
+    call_log: list[tuple[int, bool]] = []
+
+    def fake_solver(
+        stations,
+        terminal,
+        flow,
+        kv_list,
+        rho_list,
+        segment_slices,
+        RateDRA,
+        Price_HSD,
+        fuel_density,
+        ambient_temp,
+        dra_linefill_in,
+        dra_reach_km,
+        mop_kgcm2,
+        *,
+        hours,
+        start_time,
+        pump_shear_rate,
+    ):
+        hour = int(start_time.split(":")[0])
+        positive = any(float(entry.get("dra_ppm", 0.0) or 0.0) > 0 for entry in dra_linefill_in or [])
+        call_log.append((hour, positive))
+        if hour == 0:
+            if positive:
+                return {
+                    "error": False,
+                    "total_cost": 12.0,
+                    "linefill": [{"length_km": 6.0, "dra_ppm": 3.0}],
+                    "dra_front_km": 6.0,
+                }
+            return {
+                "error": False,
+                "total_cost": 10.0,
+                "linefill": [{"length_km": 0.0, "dra_ppm": 0.0}],
+                "dra_front_km": 0.0,
+            }
+        if hour == 1:
+            if positive or float(dra_reach_km) > 0.0:
+                return {
+                    "error": False,
+                    "total_cost": 11.0,
+                    "linefill": [{"length_km": 5.0, "dra_ppm": 2.5}],
+                    "dra_front_km": 5.0,
+                }
+            return {
+                "error": True,
+                "message": "No feasible pump combination found for stations.",
+            }
+        return {
+            "error": False,
+            "total_cost": 0.0,
+            "linefill": dra_linefill_in,
+            "dra_front_km": float(dra_reach_km),
+        }
+
+    monkeypatch.setattr(app, "solve_pipeline", fake_solver)
+
+    result = app._execute_time_series_solver(
+        stations_base,
+        term_data,
+        hours,
+        flow_rate=500.0,
+        plan_df=None,
+        current_vol=current_vol,
+        dra_linefill=dra_linefill,
+        dra_reach_km=0.0,
+        RateDRA=5.0,
+        Price_HSD=0.0,
+        fuel_density=820.0,
+        ambient_temp=25.0,
+        mop_kgcm2=100.0,
+        pump_shear_rate=0.0,
+        total_length=sum(stn["L"] for stn in stations_base),
+        sub_steps=1,
+    )
+
+    assert result["error"] is None
+    assert result["backtracked"] is True
+    assert len(result["reports"]) == 2
+    first_front = result["reports"][0]["result"].get("dra_front_km", 0.0)
+    assert first_front > 0.0
+    assert len(call_log) >= 3
+
+
 def test_kv_rho_from_vol_returns_segment_slices() -> None:
     stations = [
         {"name": "Station A", "L": 6.0, "D": 0.7, "t": 0.007},


### PR DESCRIPTION
## Summary
- add helper utilities to backtrack hourly optimizations when downstream runs fail due to zero DRA at the origin
- surface a Streamlit warning when backtracking is triggered and keep sequential hour reports intact
- cover the regression with a unit test that simulates a two-hour schedule requiring a non-zero origin slug

## Testing
- pytest tests/test_pipeline_performance.py::test_time_series_solver_backtracks_to_enforce_dra -q

------
https://chatgpt.com/codex/tasks/task_e_68d7db70c9e48331a3618430289a2a2c