### PR TITLE
Improve error fallback messaging

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -3027,7 +3027,9 @@ def run_all_updates():
             **search_kwargs,
         )
     if not res or res.get("error"):
-        msg = res.get("message") if isinstance(res, dict) else "Optimization failed"
+        if isinstance(res, dict):
+            st.session_state["last_error_response"] = res
+        msg = (res.get("message") or "Optimization failed") if isinstance(res, dict) else "Optimization failed"
         st.error(msg)
         return
     import copy


### PR DESCRIPTION
## Summary
- ensure the optimization error banner shows a fallback message even when the response message is empty
- store the raw error response in session state for easier debugging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84dacdf088331bdeef0e038019143