### PR TITLE
Propagate enforced origin detail to pipeline solver

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -2237,6 +2237,7 @@ def solve_pipeline(
     hours: float = 24.0,
     start_time: str = "00:00",
     pump_shear_rate: float | None = None,
+    forced_origin_detail: dict | None = None,
 ):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
@@ -2278,6 +2279,7 @@ def solve_pipeline(
                 hours,
                 start_time=start_time,
                 pump_shear_rate=pump_shear_rate,
+                forced_origin_detail=forced_origin_detail,
                 **search_kwargs,
             )
         else:
@@ -2298,6 +2300,7 @@ def solve_pipeline(
                 hours,
                 start_time=start_time,
                 pump_shear_rate=pump_shear_rate,
+                forced_origin_detail=forced_origin_detail,
                 **search_kwargs,
             )
         # Append a human-readable flow pattern name based on loop usage


### PR DESCRIPTION
## Summary
- allow the `solve_pipeline` wrapper to accept an optional `forced_origin_detail` argument
- forward the enforced-origin detail to both solver backends so they can honor the slug request

## Testing
- pytest tests/test_pipeline_performance.py -k "scheduler_solver or sequential"


------
https://chatgpt.com/codex/tasks/task_e_68de4e05b60883318d395416007b87c5