### PR TITLE
Detail enforced origin warnings for enforced injections

### DIFF
--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -557,6 +557,12 @@ def test_time_series_solver_backtracks_to_enforce_dra(monkeypatch):
     expected_cost = enforced_ppm * (flow_main * 1000.0 * 1.0 / 1e6) * 5.0
     assert first_result.get("dra_cost_station_a", 0.0) == pytest.approx(expected_cost)
     assert len(call_log) >= 3
+    warning_text = app._build_enforced_origin_warning(
+        result.get("backtrack_notes"), result.get("enforced_origin_actions")
+    )
+    assert "Plan Batch" in warning_text
+    assert "ppm" in warning_text
+    assert "m³" in warning_text
 
 
 def test_enforce_minimum_origin_dra_updates_plan_split():


### PR DESCRIPTION
## Summary
- add a helper that formats backtracking warnings using the enforced plan injections when available
- use the helper inside the UI warning so each enforced slice reports the product/index, volume and ppm applied
- extend the backtracking regression to assert the warning includes the enforced injection metadata

## Testing
- pytest tests/test_pipeline_performance.py::test_time_series_solver_backtracks_to_enforce_dra -q

------
https://chatgpt.com/codex/tasks/task_e_68de58b4be948331bcf8c79b2c8af882