### PR TITLE
Merge adjacent DRA profile slices in station table output

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -2041,20 +2041,31 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
                     continue
                 profile_entries.append((length_f, ppm_f))
 
+        merged_profile_entries = (
+            pipeline_model._merge_queue(profile_entries) if profile_entries else []
+        )
+
         treated_length = _float_or_none(res.get(f"dra_treated_length_{key}"))
         if treated_length is None:
-            treated_length = sum(length for length, ppm in profile_entries if ppm > 0)
+            treated_length = sum(
+                length for length, ppm in merged_profile_entries if ppm > 0
+            )
 
         inlet_ppm = _float_or_none(res.get(f"dra_inlet_ppm_{key}"))
         if inlet_ppm is None:
-            inlet_ppm = profile_entries[0][1] if profile_entries else 0.0
+            inlet_ppm = (
+                merged_profile_entries[0][1] if merged_profile_entries else 0.0
+            )
 
         outlet_ppm = _float_or_none(res.get(f"dra_outlet_ppm_{key}"))
         if outlet_ppm is None:
-            outlet_ppm = profile_entries[-1][1] if profile_entries else 0.0
-        if profile_entries:
+            outlet_ppm = (
+                merged_profile_entries[-1][1] if merged_profile_entries else 0.0
+            )
+        if merged_profile_entries:
             profile_str = "; ".join(
-                f"{length:.2f} km @ {ppm:.2f} ppm" for length, ppm in profile_entries
+                f"{length:.2f} km @ {ppm:.2f} ppm"
+                for length, ppm in merged_profile_entries
             )
         else:
             profile_str = ""

--- a/tests/test_apply_dra_ppm.py
+++ b/tests/test_apply_dra_ppm.py
@@ -121,10 +121,12 @@ def test_build_station_table_includes_dra_profile_columns() -> None:
         'pump_details_station_a': [],
         'dra_profile_station_a': [
             {'length_km': 2.0, 'dra_ppm': 12.0},
+            {'length_km': 1.0, 'dra_ppm': 12.0},
             {'length_km': 1.0, 'dra_ppm': 0.0},
             {'length_km': 3.0, 'dra_ppm': 10.0},
+            {'length_km': 1.0, 'dra_ppm': 10.0},
         ],
-        'dra_treated_length_station_a': 5.0,
+        'dra_treated_length_station_a': 7.0,
         'dra_inlet_ppm_station_a': 12.0,
         'dra_outlet_ppm_station_a': 10.0,
     }
@@ -150,13 +152,15 @@ def test_build_station_table_includes_dra_profile_columns() -> None:
     row = df.iloc[0]
     assert row['DRA Inlet PPM'] == pytest.approx(12.0, rel=1e-9)
     assert row['DRA Outlet PPM'] == pytest.approx(10.0, rel=1e-9)
-    assert row['DRA Treated Length (km)'] == pytest.approx(5.0, rel=1e-9)
-    assert row['DRA Untreated Length (km)'] == pytest.approx(3.0, rel=1e-9)
+    assert row['DRA Treated Length (km)'] == pytest.approx(7.0, rel=1e-9)
+    assert row['DRA Untreated Length (km)'] == pytest.approx(1.0, rel=1e-9)
     profile_str = row['DRA Profile (km@ppm)']
     assert isinstance(profile_str, str)
-    assert '2.00 km @ 12.00 ppm' in profile_str
+    assert '3.00 km @ 12.00 ppm' in profile_str
     assert '1.00 km @ 0.00 ppm' in profile_str
-    assert '3.00 km @ 10.00 ppm' in profile_str
+    assert '4.00 km @ 10.00 ppm' in profile_str
+    assert '2.00 km @ 12.00 ppm' not in profile_str
+    assert '3.00 km @ 10.00 ppm' not in profile_str
 
 
 def test_build_station_table_computes_defaults_when_solver_omits_metrics() -> None:
@@ -194,8 +198,10 @@ def test_build_station_table_computes_defaults_when_solver_omits_metrics() -> No
         'drag_reduction_station_b': 30.0,
         'drag_reduction_loop_station_b': 0.0,
         'dra_profile_station_b': [
-            {'length_km': 4.0, 'dra_ppm': 5.0},
-            {'length_km': 6.0, 'dra_ppm': 0.0},
+            {'length_km': 1.5, 'dra_ppm': 5.0},
+            {'length_km': 2.5, 'dra_ppm': 5.0},
+            {'length_km': 2.0, 'dra_ppm': 0.0},
+            {'length_km': 4.0, 'dra_ppm': 0.0},
         ],
     }
 
@@ -220,3 +226,5 @@ def test_build_station_table_computes_defaults_when_solver_omits_metrics() -> No
     profile_str = row['DRA Profile (km@ppm)']
     assert '4.00 km @ 5.00 ppm' in profile_str
     assert '6.00 km @ 0.00 ppm' in profile_str
+    assert '1.50 km @ 5.00 ppm' not in profile_str
+    assert '2.50 km @ 5.00 ppm' not in profile_str


### PR DESCRIPTION
## Summary
- merge adjacent DRA profile slices with equal ppm when building station table profiles
- ensure derived DRA metrics fall back to the merged profile and update tests accordingly

## Testing
- pytest tests/test_apply_dra_ppm.py

------
https://chatgpt.com/codex/tasks/task_e_68dee0248e6083319387359db5aa9bea