### PR TITLE
Preserve origin zero-front length when injecting DRA

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1083,14 +1083,17 @@ def _update_mainline_dra(
                 zero_front_pre = float(rest_entries[0][0])
                 rest_entries = rest_entries[1:]
 
-            zero_capacity = max(pipeline_length - inj_length, 0.0)
             # Preserve the original untreated pocket instead of inflating it with the
-            # newly pumped head length.  The downstream queue already reflects any
-            # volume tracking so we only trim if we genuinely exceed that length.
-            desired_zero = min(initial_zero_prefix, zero_capacity)
+            # newly pumped head length.  The downstream queue already reflects the
+            # tracked volume, so we only trim downstream treated fluid when required.
+            desired_zero = float(initial_zero_prefix)
             if desired_zero < zero_front_pre:
                 desired_zero = zero_front_pre
 
+            # Rebuild the queue as the injected slug, then the preserved zero front,
+            # and finally the downstream treated batches.  This mirrors how field
+            # hydraulics advance: new fluid leads the train while untreated pockets
+            # persist until the true tail encroaches on them.
             adjusted_entries: list[tuple[float, float]] = []
             if inj_entry is not None and inj_entry[0] > 0.0:
                 adjusted_entries.append(inj_entry)

--- a/tests/test_linefill_dra.py
+++ b/tests/test_linefill_dra.py
@@ -1234,7 +1234,8 @@ def test_origin_zero_front_remains_bounded_with_repeated_updates() -> None:
     assert queue_after_stage1
     zero_front_1 = queue_after_stage1[0]
     assert zero_front_1["dra_ppm"] == 0
-    assert zero_front_1["length_km"] == pytest.approx(pumped_length, rel=1e-6)
+    zero_reference = zero_front_1["length_km"]
+    assert zero_reference == pytest.approx(pumped_length, rel=1e-6)
 
     precomputed_stage2 = _prepare_dra_queue_consumption(
         queue_after_stage1,
@@ -1258,7 +1259,7 @@ def test_origin_zero_front_remains_bounded_with_repeated_updates() -> None:
     assert queue_after_stage2
     zero_front_2 = queue_after_stage2[0]
     assert zero_front_2["dra_ppm"] == 0
-    assert zero_front_2["length_km"] == pytest.approx(pumped_length, rel=1e-6)
+    assert zero_front_2["length_km"] == pytest.approx(zero_reference, rel=1e-6)
 
 
 def test_origin_zero_front_persists_when_injecting_after_idle_hours() -> None:
@@ -1314,7 +1315,8 @@ def test_origin_zero_front_persists_when_injecting_after_idle_hours() -> None:
     assert queue_stage2
     accumulated_zero = queue_stage2[0]
     assert accumulated_zero["dra_ppm"] == 0
-    assert accumulated_zero["length_km"] == pytest.approx(pumped_length, rel=1e-6)
+    zero_reference = accumulated_zero["length_km"]
+    assert zero_reference == pytest.approx(pumped_length, rel=1e-6)
 
     opt_inject = {"nop": 1, "dra_ppm_main": 25.0}
 
@@ -1340,7 +1342,7 @@ def test_origin_zero_front_persists_when_injecting_after_idle_hours() -> None:
     assert inj_ppm == pytest.approx(opt_inject["dra_ppm_main"], rel=1e-9)
     assert queue_stage3
     total_length = sum(entry["length_km"] for entry in queue_stage3)
-    expected_zero_length = pumped_length
+    expected_zero_length = zero_reference
     assert expected_zero_length <= total_length + 1e-6
 
     injected_slug = queue_stage3[0]


### PR DESCRIPTION
## Summary
- stop the origin-specific queue adjustment from inflating the zero-ppm front when adding a new slug
- document the mass-conserving ordering applied when rebuilding the queue
- update origin regression tests to assert the zero front keeps its previously tracked length across injections

## Testing
- pytest tests/test_dra_slug_transition.py tests/test_linefill_dra.py

------
https://chatgpt.com/codex/tasks/task_e_68df4bf094ac83318038ceb25f28642a