### PR TITLE
Preserve origin DRA ordering and merge profile display

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1089,6 +1089,11 @@ def _update_mainline_dra(
             desired_zero = float(initial_zero_prefix)
             if desired_zero < zero_front_pre:
                 desired_zero = zero_front_pre
+            zero_capacity = max(pipeline_length - inj_length, 0.0)
+            if zero_capacity > 0.0:
+                desired_zero = min(desired_zero, zero_capacity)
+            else:
+                desired_zero = 0.0
 
             # Rebuild the queue as the injected slug, then the preserved zero front,
             # and finally the downstream treated batches.  This mirrors how field


### PR DESCRIPTION
## Summary
- clamp the preserved zero-ppm pocket at the origin to the available pipeline capacity so new injections no longer stretch untreated fluid
- add regression coverage for field-style origin injections and for merged DRA profile formatting in the station table

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dea327e46083318f111ccab1dd3273