### PR TITLE
Handle station drag reduction caps in baseline requirement

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -2307,10 +2307,18 @@ def solve_pipeline(
     except Exception:
         baseline_requirement = None
 
+    baseline_enforceable = True
+    baseline_warnings: list = []
     if isinstance(baseline_requirement, dict):
+        baseline_warnings = baseline_requirement.get("warnings") or []
+        for warning in baseline_warnings:
+            message = warning.get("message") if isinstance(warning, dict) else None
+            if message:
+                st.warning(message)
+        baseline_enforceable = bool(baseline_requirement.get("enforceable", True))
         ppm_floor = float(baseline_requirement.get("dra_ppm", 0.0) or 0.0)
         length_floor = float(baseline_requirement.get("length_km", 0.0) or 0.0)
-        if ppm_floor > 0 and length_floor > 0:
+        if baseline_enforceable and ppm_floor > 0 and length_floor > 0:
             st.session_state["origin_lacing_baseline"] = copy.deepcopy(baseline_requirement)
         else:
             st.session_state.pop("origin_lacing_baseline", None)
@@ -2341,7 +2349,8 @@ def solve_pipeline(
                 detail["dra_perc"] = max(current_perc, perc_floor)
         return detail
 
-    forced_detail_effective = _combine_origin_detail(baseline_requirement, forced_origin_detail)
+    baseline_for_enforcement = baseline_requirement if baseline_enforceable else None
+    forced_detail_effective = _combine_origin_detail(baseline_for_enforcement, forced_origin_detail)
     if isinstance(forced_detail_effective, dict) and not forced_detail_effective:
         forced_detail_effective = None
 
@@ -3594,10 +3603,18 @@ def run_all_updates():
         )
     except Exception:
         baseline_requirement = None
+    baseline_enforceable = True
+    baseline_warnings: list = []
     if isinstance(baseline_requirement, dict):
+        baseline_warnings = baseline_requirement.get("warnings") or []
+        for warning in baseline_warnings:
+            message = warning.get("message") if isinstance(warning, dict) else None
+            if message:
+                st.warning(message)
+        baseline_enforceable = bool(baseline_requirement.get("enforceable", True))
         ppm_floor = float(baseline_requirement.get("dra_ppm", 0.0) or 0.0)
         length_floor = float(baseline_requirement.get("length_km", 0.0) or 0.0)
-        if ppm_floor > 0 and length_floor > 0:
+        if baseline_enforceable and ppm_floor > 0 and length_floor > 0:
             st.session_state["origin_lacing_baseline"] = copy.deepcopy(baseline_requirement)
         else:
             st.session_state.pop("origin_lacing_baseline", None)
@@ -3625,7 +3642,8 @@ def run_all_updates():
                 merged["dra_perc"] = max(current_perc, perc_floor)
         return merged
 
-    forced_detail_effective = _merge_baseline_detail(baseline_requirement, forced_detail)
+    baseline_for_enforcement = baseline_requirement if baseline_enforceable else None
+    forced_detail_effective = _merge_baseline_detail(baseline_for_enforcement, forced_detail)
     if isinstance(forced_detail_effective, dict) and not forced_detail_effective:
         forced_detail_effective = None
 


### PR DESCRIPTION
## Summary
- cap minimum-lacing requirements by each station's max_dr and surface warnings with uncapped percentages
- teach the Streamlit solver to show max_dr warnings and skip enforcing infeasible baselines
- add regression coverage ensuring max_dr exceedances report warnings without forcing impossible floors

## Testing
- `pytest tests/test_pipeline_performance.py::test_compute_minimum_lacing_requirement_finds_floor -q`
- `pytest tests/test_pipeline_performance.py::test_compute_minimum_lacing_requirement_flags_station_cap -q`
- `pytest tests/test_pipeline_performance.py::test_run_all_updates_passes_segment_slices -q`


------
https://chatgpt.com/codex/tasks/task_e_68dfecd6af50833185ad5bc561c9ecd4