### PR TITLE
Refine baseline lacing enforcement

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1805,10 +1805,16 @@ def compute_minimum_lacing_requirement(
         )
         residual_in = downstream_residual
 
-    result['dra_perc'] = float(max_dra_perc)
-    result['dra_ppm'] = float(max_dra_ppm) if max_dra_perc > 0 else 0.0
-    result['dra_perc_uncapped'] = float(max_dra_perc_uncapped)
     result['segments'] = segment_requirements
+    if segment_requirements:
+        result['dra_perc'] = None
+        result['dra_ppm'] = None
+        result['dra_perc_uncapped'] = None
+        result['length_km'] = None
+    else:
+        result['dra_perc'] = float(max_dra_perc)
+        result['dra_ppm'] = float(max_dra_ppm) if max_dra_perc > 0 else 0.0
+        result['dra_perc_uncapped'] = float(max_dra_perc_uncapped)
     return result
 
 


### PR DESCRIPTION
## Summary
- stop collapsing minimum lacing results into a single ppm/length pair and keep segment-level data only
- drive solve_pipeline from the stored segment floors instead of forcing a flattened queue floor
- refresh UI metrics/exports and tests to work with segment-specific baseline information

## Testing
- pytest tests/test_pipeline_performance.py -k compute_minimum
- pytest tests/test_pipeline_performance.py -k enforce_minimum_origin_dra_respects_baseline_requirement

------
https://chatgpt.com/codex/tasks/task_e_68e00e6e94dc833199211765f1c7c644