### PR TITLE
Ensure DRA lacing baseline propagates to solver and tests

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -3923,7 +3923,10 @@ def solve_pipeline(
                             if floor_limited:
                                 opt_entry['dra_floor_limited'] = True
                             opts.append(opt_entry)
-            if not any(o['nop'] == 0 for o in opts):
+            allow_zero_option = not floor_limited and floor_perc_min_int <= 0 and floor_ppm_min <= 0.0
+            if i == 1:
+                allow_zero_option = False
+            if allow_zero_option and not any(o['nop'] == 0 for o in opts):
                 opts.insert(0, {
                     'nop': 0,
                     'rpm': 0,

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -3324,4 +3324,5 @@ def test_dra_profile_reflects_hourly_push_examples() -> None:
     _assert_profile(profile_b_zero, [(2.0, 0.0), (18.0, 10.0)])
 
     _, profile_b_no_injection = _profiles_for_case(12.0, True, 0.0, True)
-    _assert_profile(profile_b_no_injection,
+    _assert_profile(profile_b_no_injection, [(2.0, 0.0), (18.0, 10.0)])
+


### PR DESCRIPTION
## Summary
- merge baseline lacing floors with user overrides, propagate per-segment minimum length/PPM to the solver, and keep the initial queue pre-laced when requirements exist.
- update DRA lacing regression tests to assert that inherited slugs remain present without injecting new chemical while still tracking SDH history.
- adjust the hourly profile expectations so zero-injection cases preserve the previously laced downstream concentration.

## Testing
- pytest tests/test_apply_dra_ppm.py tests/test_dra_slug_transition.py tests/test_linefill_dra.py tests/test_linefill_snapshot.py tests/test_pipeline_app_defaults.py tests/test_pipeline_performance.py -q


------
https://chatgpt.com/codex/tasks/task_e_68df9cae393c83318c64aa31dcdefe26