### PR TITLE
Ceil drag reducer ppm requirements

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2045,6 +2045,9 @@ def compute_minimum_lacing_requirement(
             except Exception:
                 dra_ppm_needed = 0.0
 
+            if dra_ppm_needed > 0.0:
+                dra_ppm_needed = math.ceil(dra_ppm_needed)
+
             if dr_needed > max_dra_perc:
                 max_dra_perc = dr_needed
                 max_dra_ppm = dra_ppm_needed


### PR DESCRIPTION
## Summary
- round interpolated drag-reducer ppm values up to the next increment
- propagate ceiled ppm requirements through minimum lacing computation
- expand the lacing requirement test to assert rounding of fractional ppm values

## Testing
- pytest tests/test_pipeline_performance.py::test_compute_minimum_lacing_requirement_finds_floor
- pytest tests/test_linefill_dra.py

------
https://chatgpt.com/codex/tasks/task_e_68e1754eb49083319cf879fa2d34b239