### PR TITLE
Expose suction head in lacing baseline

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1759,6 +1759,7 @@ def compute_minimum_lacing_requirement(
     min_suction = _coerce_float_local(min_suction_head, 0.0)
     if min_suction < 0.0:
         min_suction = 0.0
+    result['suction_head'] = float(min_suction)
 
     def _station_density(stn: Mapping[str, object]) -> float:
         rho_val = _coerce_float_local(stn.get('rho'), 0.0)


### PR DESCRIPTION
## Summary
- persist the minimum suction pressure control with DRA lacing settings and surface the chosen value alongside baseline metrics
- retain suction head data when collecting per-segment lacing floors and show it in the results table to aid operator review
- expose the suction head assumption from the lacing helper so scenarios round-trip and downstream consumers can reference it

## Testing
- pytest tests/test_pipeline_performance.py::test_compute_minimum_lacing_requirement_finds_floor
- pytest tests/test_pipeline_performance.py::test_compute_minimum_lacing_requirement_accounts_for_residual_head

------
https://chatgpt.com/codex/tasks/task_e_68e17e33a0188331bd90d39c260a20d0