### PR TITLE
Display zero-floor DRA lacing segments

### DIFF
--- a/tests/test_pipeline_app_defaults.py
+++ b/tests/test_pipeline_app_defaults.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pandas as pd
+
 import pipeline_optimization_app as app
 
 
@@ -41,3 +43,51 @@ def test_collect_search_depth_kwargs_handles_missing_pipeline_constants(monkeypa
         "state_top_k": 50,
         "state_cost_margin": 5000.0,
     }
+
+
+def test_collect_segment_floors_includes_zero_floor_segments() -> None:
+    """Zero-lacing segments should be preserved for display."""
+
+    baseline = {
+        "segments": [
+            {"station_idx": 0, "length_km": 6.0, "dra_ppm": 0.0, "dra_perc": 0.0},
+            {"station_idx": 1, "length_km": 4.0, "dra_ppm": 5.0},
+            {"station_idx": 2, "length_km": 3.5},
+        ]
+    }
+
+    result = app._collect_segment_floors(baseline)
+
+    assert len(result) == 3
+    assert result[0]["dra_ppm"] == 0.0
+    assert result[0]["dra_perc"] == 0.0
+    assert result[1]["dra_ppm"] == 5.0
+    assert result[1]["dra_perc"] == 0.0
+    assert result[2]["dra_ppm"] == 0.0
+    assert result[2]["dra_perc"] == 0.0
+
+
+def test_segment_floor_dataframe_handles_zero_floor_rows() -> None:
+    """Rendering helper should build a table even when floors are zero."""
+
+    stations = [
+        {"name": "Alpha"},
+        {"name": "Bravo"},
+    ]
+    baseline_segments = [
+        {"station_idx": 0, "length_km": 10.0, "dra_ppm": 0.0, "dra_perc": 0.0},
+        {"station_idx": 1, "length_km": 8.0, "dra_ppm": 4.5, "dra_perc": 9.0, "suction_head": 1.2},
+    ]
+
+    seg_df = app._build_segment_floor_dataframe(
+        baseline_segments,
+        stations,
+        terminal_name="Terminal",
+        default_suction=0.5,
+    )
+
+    assert isinstance(seg_df, pd.DataFrame)
+    assert list(seg_df["Segment"]) == ["Alpha → Bravo", "Bravo → Terminal"]
+    assert list(seg_df["Floor PPM"]) == [0.0, 4.5]
+    assert list(seg_df["Floor %DR"]) == [0.0, 9.0]
+    assert list(seg_df["Suction head (m)"]) == [0.5, 1.2]


### PR DESCRIPTION
## Summary
- ensure `_collect_segment_floors` preserves zero-floor baseline segments and records zero %DR values
- centralize baseline segment table construction and format zero floors for display
- add regression coverage for zero-floor segment scenarios

## Testing
- PYTHONPATH=. pytest tests/test_pipeline_app_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68e28b76e10c833191974ab699cf2ccf