### PR TITLE
Ceil DRA rounding for lacing requirements

### DIFF
--- a/dra_utils.py
+++ b/dra_utils.py
@@ -160,7 +160,12 @@ def _compute_ppm_for_dr(
     dra_curve_data: Dict[float, pd.DataFrame | None],
     rounding_step: float | None = None,
 ) -> float:
-    """Internal helper implementing :func:`get_ppm_for_dr` without caching."""
+    """Return the ceiled PPM requirement for ``dr`` at viscosity ``visc``.
+
+    The helper interpolates between the nearest drag-reducer curves and then
+    applies a ceiling to the next multiple of ``rounding_step`` (defaulting to
+    whole-PPM increments).
+    """
 
     visc = float(visc)
     lower, upper = _nearest_bounds(visc, dra_curve_data)

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2068,9 +2068,6 @@ def compute_minimum_lacing_requirement(
             except Exception:
                 dra_ppm_needed = 0.0
 
-            if dra_ppm_needed > 0.0:
-                dra_ppm_needed = math.ceil(dra_ppm_needed)
-
             if dr_needed > max_dra_perc:
                 max_dra_perc = dr_needed
                 max_dra_ppm = dra_ppm_needed

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -1568,6 +1568,51 @@ def test_compute_minimum_lacing_requirement_finds_floor():
     assert result["suction_heads"] == pytest.approx([min_suction])
 
 
+def test_compute_minimum_lacing_requirement_propagates_ceiled_ppm(monkeypatch):
+    import pipeline_model as model
+
+    stations = [
+        {
+            "name": "Station A",
+            "is_pump": True,
+            "min_pumps": 1,
+            "max_pumps": 1,
+            "pump_type": "type1",
+            "MinRPM": 3000,
+            "DOL": 3000,
+            "A": 0.0,
+            "B": 0.0,
+            "C": 4.0,
+            "P": 0.0,
+            "Q": 0.0,
+            "R": 0.0,
+            "S": 0.0,
+            "T": 75.0,
+            "L": 10.0,
+            "d": 0.7,
+            "t": 0.007,
+            "rough": 0.00004,
+            "delivery": 0.0,
+            "supply": 0.0,
+        }
+    ]
+    terminal = {"min_residual": 0.0, "elev": 0.0}
+
+    monkeypatch.setattr(model, "get_ppm_for_dr", lambda _visc, _dr: 3.5)
+
+    result = model.compute_minimum_lacing_requirement(
+        stations,
+        terminal,
+        max_flow_m3h=900.0,
+        max_visc_cst=2.5,
+        min_suction_head=1.0,
+    )
+
+    segments = result.get("segments")
+    assert isinstance(segments, list) and len(segments) == 1
+    assert segments[0]["dra_ppm"] == pytest.approx(3.5)
+
+
 def test_compute_minimum_lacing_requirement_accounts_for_residual_head():
     import pipeline_model as model
 


### PR DESCRIPTION
## Summary
- update `_compute_ppm_for_dr` documentation to describe the ceiling behaviour to configurable increments
- let the minimum lacing calculation reuse the ceiled ppm returned by `get_ppm_for_dr`
- add regression coverage to ensure lacing segments keep fractional ppm requirements that were already rounded up

## Testing
- pytest tests/test_dra_utils_rounding.py tests/test_pipeline_performance.py::test_compute_minimum_lacing_requirement_propagates_ceiled_ppm

------
https://chatgpt.com/codex/tasks/task_e_68e29e24ea2c83319844f3e145e5afe3