### PR TITLE
Ensure baseline tables include zero-lacing segment rows

### DIFF
--- a/tests/test_pipeline_app_defaults.py
+++ b/tests/test_pipeline_app_defaults.py
@@ -67,6 +67,25 @@ def test_collect_segment_floors_includes_zero_floor_segments() -> None:
     assert result[2]["dra_perc"] == 0.0
 
 
+def test_collect_segment_floors_backfills_missing_segments() -> None:
+    """Station pairs without explicit requirements should surface as zero floors."""
+
+    baseline = {
+        "segments": [
+            {"station_idx": 1, "length_km": 4.0, "dra_ppm": 5.0, "suction_head": 0.7},
+        ],
+        "segment_lengths": [6.0, 4.0, 3.5],
+        "suction_heads": [0.5, 0.7, 0.9],
+    }
+
+    result = app._collect_segment_floors(baseline)
+
+    assert [entry["station_idx"] for entry in result] == [0, 1, 2]
+    assert [entry["length_km"] for entry in result] == [6.0, 4.0, 3.5]
+    assert [entry["dra_ppm"] for entry in result] == [0.0, 5.0, 0.0]
+    assert [entry["suction_head"] for entry in result] == [0.5, 0.7, 0.9]
+
+
 def test_segment_floor_dataframe_handles_zero_floor_rows() -> None:
     """Rendering helper should build a table even when floors are zero."""
 


### PR DESCRIPTION
## Summary
- extend `_collect_segment_floors` to backfill station pairs with zero-ppm placeholders using optional length and suction metadata
- ensure the baseline segment table falls back to freshly collected floors when stored data is missing
- add regression coverage for zero-floor segment backfilling

## Testing
- PYTHONPATH=. pytest tests/test_pipeline_app_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68e29ff0c764833181b806889336b073