### PR TITLE
Ensure zero DRA hours report explicit profile fallback

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -2508,6 +2508,7 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
         treated_length = _float_or_none(res.get(f"dra_treated_length_{key}"))
         if treated_length is None:
             treated_length = sum(length for length, ppm in profile_entries if ppm > 0)
+        treated_length = float(treated_length or 0.0)
 
         inlet_ppm = _float_or_none(res.get(f"dra_inlet_ppm_{key}"))
         if inlet_ppm is None:
@@ -2521,7 +2522,7 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
                 f"{length:.2f} km @ {ppm:.2f} ppm" for length, ppm in profile_entries
             )
         else:
-            profile_str = ""
+            profile_str = "0.00 km @ 0.00 ppm"
 
         row['DRA Inlet PPM'] = inlet_ppm
         row['DRA Outlet PPM'] = outlet_ppm

--- a/tests/test_apply_dra_ppm.py
+++ b/tests/test_apply_dra_ppm.py
@@ -220,3 +220,61 @@ def test_build_station_table_computes_defaults_when_solver_omits_metrics() -> No
     profile_str = row['DRA Profile (km@ppm)']
     assert '4.00 km @ 5.00 ppm' in profile_str
     assert '6.00 km @ 0.00 ppm' in profile_str
+
+
+def test_build_station_table_formats_zero_dra_profile() -> None:
+    """Hours without injection should still report a zero-length profile."""
+
+    res = {
+        'stations_used': [
+            {
+                'name': 'station_c',
+                'orig_name': 'Station C',
+                'is_pump': True,
+            }
+        ],
+        'pipeline_flow_station_c': 900.0,
+        'loopline_flow_station_c': 0.0,
+        'pump_flow_station_c': 900.0,
+        'power_cost_station_c': 0.0,
+        'dra_cost_station_c': 0.0,
+        'dra_ppm_station_c': 0.0,
+        'dra_ppm_loop_station_c': 0.0,
+        'num_pumps_station_c': 1,
+        'efficiency_station_c': 70.0,
+        'pump_bkw_station_c': 85.0,
+        'motor_kw_station_c': 90.0,
+        'reynolds_station_c': 1.0,
+        'head_loss_station_c': 3.5,
+        'head_loss_kgcm2_station_c': 0.35,
+        'velocity_station_c': 1.2,
+        'residual_head_station_c': 24.0,
+        'rh_kgcm2_station_c': 2.4,
+        'sdh_station_c': 27.0,
+        'sdh_kgcm2_station_c': 2.7,
+        'maop_station_c': 68.0,
+        'maop_kgcm2_station_c': 6.8,
+        'drag_reduction_station_c': 0.0,
+        'drag_reduction_loop_station_c': 0.0,
+        'dra_profile_station_c': [],
+    }
+
+    base_stations = [
+        {
+            'name': 'Station C',
+            'is_pump': True,
+            'pump_names': ['Pump C'],
+            'max_pumps': 1,
+            'min_pumps': 1,
+            'L': 6.0,
+        }
+    ]
+
+    df = build_station_table(res, base_stations)
+    row = df.iloc[0]
+
+    assert row['DRA Treated Length (km)'] == pytest.approx(0.0, rel=1e-9)
+    assert row['DRA Untreated Length (km)'] == pytest.approx(6.0, rel=1e-9)
+    assert row['DRA Inlet PPM'] == pytest.approx(0.0, abs=1e-9)
+    assert row['DRA Outlet PPM'] == pytest.approx(0.0, abs=1e-9)
+    assert row['DRA Profile (km@ppm)'] == "0.00 km @ 0.00 ppm"


### PR DESCRIPTION
## Summary
- ensure the station summary uses a "0.00 km @ 0.00 ppm" placeholder when no DRA profile segments are present
- normalise treated length calculations so exports keep treated/untreated totals consistent
- add a regression test that exercises the zero-profile formatting for hours without injection

## Testing
- pytest tests/test_apply_dra_ppm.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a248cab48331a365311e1ca276b1