### PR TITLE
Enforce warning segment floors during scheduling

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -3150,6 +3150,27 @@ def solve_pipeline(
                 combined['limited_by_station'] = True
             segment_floor_lookup[idx_int] = combined  # type: ignore[assignment]
 
+    N = len(stations)
+
+    def _coerce_suction_value(raw: float | int | None) -> float:
+        if raw is None:
+            return 0.0
+        val = _coerce_float(raw, 0.0)
+        if math.isnan(val) or val < 0.0:
+            val = 0.0
+        return float(val)
+
+    if isinstance(station_suction_heads, Sequence) and not isinstance(station_suction_heads, (str, bytes)):
+        suction_profile = [
+            _coerce_suction_value(station_suction_heads[idx])
+            if idx < len(station_suction_heads)
+            else 0.0
+            for idx in range(N)
+        ]
+    else:
+        base_suction_val = _coerce_suction_value(station_suction_heads) if station_suction_heads is not None else 0.0
+        suction_profile = [base_suction_val] * N
+
     # When requested, perform an outer enumeration over loop usage patterns.
     # We only enter this branch when no explicit per-station loop usage is
     # specified.  Each candidate pattern is mapped onto the stations with
@@ -3312,27 +3333,6 @@ def solve_pipeline(
                     ppm = 0.0
                 linefill_state.append({'volume': vol, 'dra_ppm': ppm})
     linefill_state = copy.deepcopy(linefill_state)
-
-    N = len(stations)
-
-    def _coerce_suction_value(raw: float | int | None) -> float:
-        if raw is None:
-            return 0.0
-        val = _coerce_float(raw, 0.0)
-        if math.isnan(val) or val < 0.0:
-            val = 0.0
-        return float(val)
-
-    if isinstance(station_suction_heads, Sequence) and not isinstance(station_suction_heads, (str, bytes)):
-        suction_profile = [
-            _coerce_suction_value(station_suction_heads[idx])
-            if idx < len(station_suction_heads)
-            else 0.0
-            for idx in range(N)
-        ]
-    else:
-        base_suction_val = _coerce_suction_value(station_suction_heads) if station_suction_heads is not None else 0.0
-        suction_profile = [base_suction_val] * N
 
     # ------------------------------------------------------------------
     # Two-pass optimisation: first run a coarse search with enlarged

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -2757,13 +2757,14 @@ def solve_pipeline(
         segment_floors = _collect_segment_floors(baseline_requirement)
         if segment_floors:
             baseline_segments = copy.deepcopy(segment_floors)
-        if baseline_enforceable and baseline_summary.get("has_positive_segments"):
+        store_baseline = bool(baseline_summary.get("has_positive_segments")) or bool(baseline_segments)
+        if store_baseline:
             st.session_state["origin_lacing_baseline"] = copy.deepcopy(baseline_requirement)
         else:
             st.session_state.pop("origin_lacing_baseline", None)
     else:
         st.session_state.pop("origin_lacing_baseline", None)
-    if baseline_enforceable and baseline_segments:
+    if baseline_segments:
         st.session_state["origin_lacing_segment_baseline"] = copy.deepcopy(baseline_segments)
     else:
         st.session_state.pop("origin_lacing_segment_baseline", None)
@@ -2805,26 +2806,25 @@ def solve_pipeline(
         return user or None
 
     baseline_for_enforcement: dict | None = None
-    if baseline_enforceable:
-        base_detail: dict[str, object] = {}
-        ppm_floor = float(baseline_summary.get("dra_ppm", 0.0) or 0.0)
-        perc_floor = float(baseline_summary.get("dra_perc", 0.0) or 0.0)
-        if ppm_floor > 0.0:
-            base_detail["dra_ppm"] = ppm_floor
-        if perc_floor > 0.0:
-            base_detail["dra_perc"] = perc_floor
-        if baseline_segments:
-            base_detail["segments"] = copy.deepcopy(baseline_segments)
-            seg_total = sum(float(seg.get("length_km", 0.0) or 0.0) for seg in baseline_segments)
-            if seg_total > 0.0:
-                base_detail["length_km"] = seg_total
-        if "length_km" not in base_detail:
-            length_floor = float(baseline_summary.get("length_km", 0.0) or 0.0)
-            if length_floor > 0.0:
-                base_detail["length_km"] = length_floor
-        if base_detail:
-            baseline_for_enforcement = base_detail
-    baseline_segment_floors = baseline_segments if (baseline_enforceable and baseline_segments) else None
+    base_detail: dict[str, object] = {}
+    ppm_floor = float(baseline_summary.get("dra_ppm", 0.0) or 0.0)
+    perc_floor = float(baseline_summary.get("dra_perc", 0.0) or 0.0)
+    if ppm_floor > 0.0:
+        base_detail["dra_ppm"] = ppm_floor
+    if perc_floor > 0.0:
+        base_detail["dra_perc"] = perc_floor
+    if baseline_segments:
+        base_detail["segments"] = copy.deepcopy(baseline_segments)
+        seg_total = sum(float(seg.get("length_km", 0.0) or 0.0) for seg in baseline_segments)
+        if seg_total > 0.0:
+            base_detail["length_km"] = seg_total
+    if "length_km" not in base_detail:
+        length_floor = float(baseline_summary.get("length_km", 0.0) or 0.0)
+        if length_floor > 0.0:
+            base_detail["length_km"] = length_floor
+    if base_detail:
+        baseline_for_enforcement = base_detail
+    baseline_segment_floors = baseline_segments if baseline_segments else None
     forced_detail_effective = _combine_origin_detail(baseline_for_enforcement, forced_origin_detail)
     if isinstance(forced_detail_effective, dict) and not forced_detail_effective:
         forced_detail_effective = None
@@ -4254,13 +4254,14 @@ def run_all_updates():
         segment_floors = _collect_segment_floors(baseline_requirement)
         if segment_floors:
             baseline_segments = copy.deepcopy(segment_floors)
-        if baseline_enforceable and baseline_summary.get("has_positive_segments"):
+        store_baseline = bool(baseline_summary.get("has_positive_segments")) or bool(baseline_segments)
+        if store_baseline:
             st.session_state["origin_lacing_baseline"] = copy.deepcopy(baseline_requirement)
         else:
             st.session_state.pop("origin_lacing_baseline", None)
     else:
         st.session_state.pop("origin_lacing_baseline", None)
-    if baseline_enforceable and baseline_segments:
+    if baseline_segments:
         st.session_state["origin_lacing_segment_baseline"] = copy.deepcopy(baseline_segments)
     else:
         st.session_state.pop("origin_lacing_segment_baseline", None)
@@ -4419,21 +4420,25 @@ def run_all_updates():
         return merged
 
     baseline_for_enforcement: dict | None = None
-    if baseline_enforceable:
-        base_detail: dict[str, object] = {}
-        ppm_floor = float(baseline_summary.get("dra_ppm", 0.0) or 0.0)
-        perc_floor = float(baseline_summary.get("dra_perc", 0.0) or 0.0)
-        if ppm_floor > 0.0:
-            base_detail["dra_ppm"] = ppm_floor
-        if perc_floor > 0.0:
-            base_detail["dra_perc"] = perc_floor
-        if baseline_segments:
-            base_detail["segments"] = copy.deepcopy(baseline_segments)
-            total_seg_length = sum(float(seg.get("length_km", 0.0) or 0.0) for seg in baseline_segments)
-            if total_seg_length > 0.0:
-                base_detail["length_km"] = total_seg_length
-        if base_detail:
-            baseline_for_enforcement = base_detail
+    base_detail: dict[str, object] = {}
+    ppm_floor = float(baseline_summary.get("dra_ppm", 0.0) or 0.0)
+    perc_floor = float(baseline_summary.get("dra_perc", 0.0) or 0.0)
+    if ppm_floor > 0.0:
+        base_detail["dra_ppm"] = ppm_floor
+    if perc_floor > 0.0:
+        base_detail["dra_perc"] = perc_floor
+    if baseline_segments:
+        base_detail["segments"] = copy.deepcopy(baseline_segments)
+        total_seg_length = sum(float(seg.get("length_km", 0.0) or 0.0) for seg in baseline_segments)
+        if total_seg_length > 0.0:
+            base_detail["length_km"] = total_seg_length
+    if "length_km" not in base_detail:
+        length_floor = float(baseline_summary.get("length_km", 0.0) or 0.0)
+        if length_floor > 0.0:
+            base_detail["length_km"] = length_floor
+    if base_detail:
+        baseline_for_enforcement = base_detail
+    baseline_segment_floors = baseline_segments if baseline_segments else None
     forced_detail_effective = _merge_baseline_detail(baseline_for_enforcement, forced_detail)
     if isinstance(forced_detail_effective, dict) and not forced_detail_effective:
         forced_detail_effective = None
@@ -4459,6 +4464,7 @@ def run_all_updates():
             pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
             station_suction_heads=suction_profile,
             forced_origin_detail=copy.deepcopy(forced_detail_effective) if forced_detail_effective else None,
+            segment_floors=baseline_segment_floors,
             **search_kwargs,
         )
     if not res or res.get("error"):


### PR DESCRIPTION
## Summary
- keep segment floor baselines when the lacing requirement reports warnings and persist them for UI state
- always provide those floors to the optimisation backends and merge them into enforced origin details for hourly/daily runs
- initialise suction profiles before loop enumeration and add a regression test that captures warned floors in the generated schedule

## Testing
- pytest tests/test_pipeline_performance.py::test_scheduler_honours_warning_floor


------
https://chatgpt.com/codex/tasks/task_e_68e2a424e3e88331a001f9c36f220b63