### PR TITLE
Ceil drag-reducer ppm requirements

### DIFF
--- a/dra_utils.py
+++ b/dra_utils.py
@@ -148,7 +148,7 @@ def get_ppm_bounds(
     return result
 
 
-def _round_cache_key(*values: float, precision: int = 2) -> tuple[float, ...]:
+def _round_cache_key(*values: float, precision: int = 6) -> tuple[float, ...]:
     """Return a tuple suitable for memoisation keyed by rounded ``values``."""
 
     return tuple(round(float(val), precision) for val in values)
@@ -174,7 +174,11 @@ def _compute_ppm_for_dr(
 
         if val <= 0.0:
             return 0.0
-        return math.ceil(val / step_value) * step_value
+        quotient = val / step_value
+        nearest = round(quotient)
+        if math.isclose(quotient, nearest, rel_tol=1e-9, abs_tol=1e-9):
+            return nearest * step_value
+        return math.ceil(quotient) * step_value
 
     if lower == upper:
         return round_ppm(_ppm_from_df(dra_curve_data[lower], dr))

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2047,9 +2047,6 @@ def compute_minimum_lacing_requirement(
             except Exception:
                 dra_ppm_needed = 0.0
 
-            if dra_ppm_needed > 0.0:
-                dra_ppm_needed = math.ceil(dra_ppm_needed)
-
             if dr_needed > max_dra_perc:
                 max_dra_perc = dr_needed
                 max_dra_ppm = dra_ppm_needed

--- a/tests/test_dra_utils_rounding.py
+++ b/tests/test_dra_utils_rounding.py
@@ -41,3 +41,11 @@ def test_get_ppm_for_dr_honours_custom_rounding_step() -> None:
     data = _sample_curve()
     result = get_ppm_for_dr(3.0, 5.0, dra_curve_data=data, rounding_step=0.5)
     assert result == pytest.approx(3.5)
+
+
+def test_get_ppm_for_dr_rounds_fractional_interpolations_upwards() -> None:
+    """Interpolated values that fall between integers round up."""
+
+    data = _sample_curve()
+    interpolated = get_ppm_for_dr(3.0, 7.0, dra_curve_data=data)
+    assert interpolated == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- ensure drag reducer ppm interpolation always rounds up to the configured increment
- propagate the ceiled ppm through the minimum lacing requirement helper
- extend drag reducer rounding tests to cover fractional interpolations

## Testing
- pytest tests/test_dra_utils_rounding.py tests/test_pipeline_performance.py::test_compute_minimum_lacing_requirement_finds_floor

------
https://chatgpt.com/codex/tasks/task_e_68e2c6a8a9a4833189d3e62ff3215a95