### PR TITLE
Handle zero-ppm DRA profiles

### DIFF
--- a/tests/test_apply_dra_ppm.py
+++ b/tests/test_apply_dra_ppm.py
@@ -220,3 +220,71 @@ def test_build_station_table_computes_defaults_when_solver_omits_metrics() -> No
     profile_str = row['DRA Profile (km@ppm)']
     assert '4.00 km @ 5.00 ppm' in profile_str
     assert '6.00 km @ 0.00 ppm' in profile_str
+
+
+def test_build_station_table_includes_zero_ppm_profile_for_floorless_station() -> None:
+    """Stations without a floor should still report zero-ppm segments."""
+
+    res = {
+        'stations_used': [
+            {
+                'name': 'station_c',
+                'orig_name': 'Station C',
+                'is_pump': True,
+            }
+        ],
+        'pipeline_flow_station_c': 900.0,
+        'loopline_flow_station_c': 0.0,
+        'pump_flow_station_c': 900.0,
+        'power_cost_station_c': 0.0,
+        'dra_cost_station_c': 0.0,
+        'dra_ppm_station_c': 0.0,
+        'dra_ppm_loop_station_c': 0.0,
+        'num_pumps_station_c': 1,
+        'efficiency_station_c': 70.0,
+        'pump_bkw_station_c': 85.0,
+        'motor_kw_station_c': 92.0,
+        'reynolds_station_c': 1.0,
+        'head_loss_station_c': 3.5,
+        'head_loss_kgcm2_station_c': 0.35,
+        'velocity_station_c': 1.7,
+        'residual_head_station_c': 22.0,
+        'rh_kgcm2_station_c': 2.2,
+        'sdh_station_c': 24.0,
+        'sdh_kgcm2_station_c': 2.4,
+        'maop_station_c': 65.0,
+        'maop_kgcm2_station_c': 6.5,
+        'drag_reduction_station_c': 0.0,
+        'drag_reduction_loop_station_c': 0.0,
+        'dra_profile_station_c': [
+            {'length_km': 2.5, 'dra_ppm': 0.0},
+            {'length_km': 1.5, 'dra_ppm': 0.0},
+        ],
+        'dra_treated_length_station_c': 0.0,
+        'dra_inlet_ppm_station_c': 0.0,
+        'dra_outlet_ppm_station_c': 0.0,
+    }
+
+    base_stations = [
+        {
+            'name': 'Station C',
+            'is_pump': True,
+            'pump_names': ['Pump Zero'],
+            'max_pumps': 1,
+            'min_pumps': 1,
+            'L': 4.0,
+            'dra_floor_ppm_min': 0.0,
+        }
+    ]
+
+    df = build_station_table(res, base_stations)
+    row = df.iloc[0]
+
+    assert row['DRA Treated Length (km)'] == pytest.approx(0.0, rel=1e-9)
+    assert row['DRA Untreated Length (km)'] == pytest.approx(4.0, rel=1e-9)
+    assert row['DRA Inlet PPM'] == pytest.approx(0.0, rel=1e-9)
+    assert row['DRA Outlet PPM'] == pytest.approx(0.0, rel=1e-9)
+    profile_str = row['DRA Profile (km@ppm)']
+    assert profile_str.strip() != ''
+    assert '2.50 km @ 0.00 ppm' in profile_str
+    assert '1.50 km @ 0.00 ppm' in profile_str


### PR DESCRIPTION
## Summary
- preserve inherited DRA profile slices when stations inject at zero ppm so that downstream reporting retains segment detail
- adjust treated-length/inlet/outlet calculations and related tests to tolerate zero-ppm profile entries
- add coverage ensuring build_station_table renders zero-ppm profiles when no floor ppm is enforced

## Testing
- `pytest tests/test_apply_dra_ppm.py::test_build_station_table_includes_zero_ppm_profile_for_floorless_station tests/test_pipeline_performance.py::test_time_series_solver_backtracks_to_enforce_dra -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68e2d234ba5883318e03820722cbb3b8