### PR TITLE
Allow optimiser to explore DRA when station cap unset

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -822,7 +822,7 @@ if "stations" not in st.session_state:
         'min_residual': 50.0, 'is_pump': False,
         'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
         'max_pumps': 1, 'MinRPM': 1200.0, 'DOL': 1500.0,
-        'max_dr': pipeline_model.DEFAULT_MAX_DR,
+        'max_dr': 0.0,
         'delivery': 0.0,
         'supply': 0.0
     }]
@@ -837,7 +837,7 @@ with st.sidebar:
             'min_residual': 50.0, 'is_pump': False,
             'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
             'max_pumps': 1, 'MinRPM': 1000.0, 'DOL': 1500.0,
-            'max_dr': pipeline_model.DEFAULT_MAX_DR,
+            'max_dr': 0.0,
             'delivery': 0.0,
             'supply': 0.0
         }
@@ -857,7 +857,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
             stn['L'] = st.number_input("Length to next Station (km)", value=stn['L'], step=1.0, key=f"L{idx}")
             stn['max_dr'] = st.number_input(
                 "Max achievable Drag Reduction (%)",
-                value=stn.get('max_dr', pipeline_model.DEFAULT_MAX_DR),
+                value=stn.get('max_dr', 0.0),
                 key=f"mdr{idx}"
             )
             if idx == 1:
@@ -893,7 +893,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                 loop['rough'] = st.number_input("Pipe Roughness (m)", value=loop.get('rough', 0.00004), format="%.7f", step=0.0000001, key=f"looprough{idx}")
                 loop['max_dr'] = st.number_input(
                     "Max Drag Reduction (%)",
-                    value=loop.get('max_dr', pipeline_model.DEFAULT_MAX_DR),
+                    value=loop.get('max_dr', 0.0),
                     key=f"loopmdr{idx}"
                 )
                 loop['elev'] = st.number_input("Elevation (m)", value=loop.get('elev', stn.get('elev',0.0)), step=0.1, key=f"loopelev{idx}")

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -822,7 +822,7 @@ if "stations" not in st.session_state:
         'min_residual': 50.0, 'is_pump': False,
         'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
         'max_pumps': 1, 'MinRPM': 1200.0, 'DOL': 1500.0,
-        'max_dr': 0.0,
+        'max_dr': pipeline_model.DEFAULT_MAX_DR,
         'delivery': 0.0,
         'supply': 0.0
     }]
@@ -837,7 +837,7 @@ with st.sidebar:
             'min_residual': 50.0, 'is_pump': False,
             'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
             'max_pumps': 1, 'MinRPM': 1000.0, 'DOL': 1500.0,
-            'max_dr': 0.0,
+            'max_dr': pipeline_model.DEFAULT_MAX_DR,
             'delivery': 0.0,
             'supply': 0.0
         }
@@ -855,7 +855,11 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
             stn['elev'] = st.number_input("Elevation (m)", value=stn['elev'], step=0.1, key=f"elev{idx}")
             stn['is_pump'] = st.checkbox("Pumping Station?", value=stn['is_pump'], key=f"pump{idx}")
             stn['L'] = st.number_input("Length to next Station (km)", value=stn['L'], step=1.0, key=f"L{idx}")
-            stn['max_dr'] = st.number_input("Max achievable Drag Reduction (%)", value=stn.get('max_dr', 0.0), key=f"mdr{idx}")
+            stn['max_dr'] = st.number_input(
+                "Max achievable Drag Reduction (%)",
+                value=stn.get('max_dr', pipeline_model.DEFAULT_MAX_DR),
+                key=f"mdr{idx}"
+            )
             if idx == 1:
                 stn['min_residual'] = st.number_input("Available Suction Head (m)", value=stn.get('min_residual',50.0), step=0.1, key=f"res{idx}")
         with col2:
@@ -887,7 +891,11 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                 loop['SMYS'] = st.number_input("SMYS (psi)", value=loop.get('SMYS', stn['SMYS']), step=1000.0, key=f"loopSMYS{idx}")
             with lcol3:
                 loop['rough'] = st.number_input("Pipe Roughness (m)", value=loop.get('rough', 0.00004), format="%.7f", step=0.0000001, key=f"looprough{idx}")
-                loop['max_dr'] = st.number_input("Max Drag Reduction (%)", value=loop.get('max_dr', 0.0), key=f"loopmdr{idx}")
+                loop['max_dr'] = st.number_input(
+                    "Max Drag Reduction (%)",
+                    value=loop.get('max_dr', pipeline_model.DEFAULT_MAX_DR),
+                    key=f"loopmdr{idx}"
+                )
                 loop['elev'] = st.number_input("Elevation (m)", value=loop.get('elev', stn.get('elev',0.0)), step=0.1, key=f"loopelev{idx}")
 
             loop_peak_key = f"loop_peak_data_{idx}"


### PR DESCRIPTION
## Summary
- add a shared DEFAULT_MAX_DR constant plus helper utilities so optimisation falls back to a 70% drag reduction cap whenever a station omits its limit
- update the Streamlit UI defaults to prepopulate station and loop entries with the shared drag reduction cap so DRA remains available unless explicitly disabled

## Testing
- pytest tests/test_linefill_dra.py *(fails: existing expectations around DRA queue propagation now differ after enabling fallback caps)*

------
https://chatgpt.com/codex/tasks/task_e_68e35bb339548331b94093423f2f3959