### PR TITLE
Adjust baseline lacing requirement suction handling

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2029,6 +2029,7 @@ def compute_minimum_lacing_requirement(
     max_dra_perc = 0.0
     max_dra_ppm = 0.0
     max_dra_perc_uncapped = 0.0
+    carried_head_available = 0.0
     for idx, stn in enumerate(stations_copy):
         flow_segment = flows[idx + 1] if idx + 1 < len(flows) else flows[-1]
         flow_segment = max(_coerce_float_local(flow_segment, max_flow), 0.0)
@@ -2097,6 +2098,8 @@ def compute_minimum_lacing_requirement(
         dr_unbounded = 0.0
         limited_by_station = False
         available_head = residual_head + max_head
+        if carried_head_available > residual_head:
+            available_head = max(available_head, carried_head_available)
         suction_requirement = min_suction if stn.get('is_pump') else 0.0
         effective_available_head = max(available_head - suction_requirement, 0.0)
         gap = sdh_required - effective_available_head
@@ -2161,6 +2164,8 @@ def compute_minimum_lacing_requirement(
             'limited_by_station': bool(limited_by_station),
         }
         segment_requirements.append(segment_entry)
+
+        carried_head_available = effective_available_head
 
         if example_segment is None or segment_entry['dra_perc_uncapped'] > example_segment.get('dra_perc_uncapped', 0.0):
             example_segment = {

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2094,7 +2094,8 @@ def compute_minimum_lacing_requirement(
         dr_unbounded = 0.0
         limited_by_station = False
         available_head = residual_head + max_head
-        effective_available_head = max(available_head - min_suction, 0.0)
+        suction_requirement = min_suction if stn.get('is_pump') else 0.0
+        effective_available_head = max(available_head - suction_requirement, 0.0)
         gap = sdh_required - effective_available_head
         if gap > 1e-6 and sdh_required > 0.0:
             dr_unbounded = (gap / sdh_required) * 100.0
@@ -2154,7 +2155,7 @@ def compute_minimum_lacing_requirement(
                 'residual_head': float(residual_head),
                 'max_head_available': float(effective_available_head),
                 'available_head_before_suction': float(available_head),
-                'suction_head': float(min_suction),
+                'suction_head': float(suction_requirement),
                 'limited_by_station': bool(limited_by_station),
             }
         )

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -1582,6 +1582,16 @@ def test_compute_minimum_lacing_requirement_finds_floor():
     assert seg_entry["available_head_before_suction"] == pytest.approx(available_head)
     assert seg_entry["max_head_available"] == pytest.approx(effective_available)
 
+    explanation = result.get("explanation")
+    assert isinstance(explanation, str) and "Station A" in explanation
+    example = result.get("example_segment")
+    assert isinstance(example, dict)
+    assert example["station_idx"] == 0
+    assert example["station_name"] == "Station A"
+    assert example["sdh_gap"] == pytest.approx(expected_gap)
+    assert example["flow_m3h"] == pytest.approx(flow)
+    assert example["viscosity_cst"] == pytest.approx(2.5)
+
 
 def test_compute_minimum_lacing_requirement_accounts_for_residual_head():
     import pipeline_model as model
@@ -1653,6 +1663,12 @@ def test_compute_minimum_lacing_requirement_accounts_for_residual_head():
     assert seg_entry["max_head_available"] == pytest.approx(effective_available)
     assert seg_entry["dra_perc"] == pytest.approx(expected_dr, rel=1e-3, abs=1e-3)
 
+    example = result.get("example_segment")
+    assert isinstance(example, dict) and example["station_idx"] == 0
+    assert example["station_name"] == "Station A"
+    assert example["sdh_gap"] == pytest.approx(expected_gap)
+    assert example["residual_head"] == pytest.approx(residual_head)
+
 
 def test_compute_minimum_lacing_requirement_flags_station_cap():
     import pipeline_model as model
@@ -1706,6 +1722,7 @@ def test_compute_minimum_lacing_requirement_flags_station_cap():
     assert seg_entry.get("dra_perc_uncapped", 0.0) > seg_entry["dra_perc"]
     assert seg_entry.get("limited_by_station") is True
     assert seg_entry.get("dra_ppm") == pytest.approx(model.get_ppm_for_dr(2.5, 30.0))
+    assert result.get("example_segment", {}).get("station_name") == "Station A"
 
 
 def test_compute_minimum_lacing_requirement_handles_invalid_input():
@@ -1728,6 +1745,8 @@ def test_compute_minimum_lacing_requirement_handles_invalid_input():
     assert result.get("segments") == []
     assert result.get("warnings") == []
     assert result.get("enforceable") is True
+    assert result.get("explanation") == ""
+    assert result.get("example_segment") is None
 
 
 def test_segment_floors_overlay_queue_minimum():


### PR DESCRIPTION
## Summary
- only subtract the minimum suction head at pump stations when evaluating the baseline lacing requirement
- report the per-segment suction head used in the requirement details so non-pump segments keep their residual head budget

## Testing
- pytest tests/test_pipeline_performance.py -k minimum_lacing

------
https://chatgpt.com/codex/tasks/task_e_68e495b8c10483318fb035625562c792