### PR TITLE
Add branch-and-bound pump scheduler with parallel hourly solving

### DIFF
--- a/dra_utils.py
+++ b/dra_utils.py
@@ -1,94 +1,14 @@
-
-"""Drag reducer (DRA) helper utilities.
-
-Adds inverse interpolation (ppm_to_dr) and keeps get_ppm_for_dr API.
-"""
+"""Drag reducer (DRA) helper utilities based on the Burger equation."""
 
 from __future__ import annotations
 
 import math
-import os
-from typing import Dict, Tuple
+from functools import lru_cache
+from typing import Tuple
 
-import numpy as np
-import pandas as pd
-
-# Mapping of viscosity (cSt) to CSV file name
-DRA_CSV_FILES: Dict[float, str] = {
-    1: "1 cst.csv",
-    2: "2 cst.csv",
-    2.5: "2.5 cst.csv",
-    3: "3 cst.csv",
-    3.5: "3.5 cst.csv",
-    4: "4 cst.csv",
-    4.5: "4.5 cst.csv",
-    10: "10 cst.csv",
-    15: "15 cst.csv",
-    20: "20 cst.csv",
-    25: "25 cst.csv",
-    30: "30 cst.csv",
-    35: "35 cst.csv",
-    40: "40 cst.csv",
-}
-
-# Load the drag-reducer curves lazily at import time
-DRA_CURVE_DATA: Dict[float, pd.DataFrame | None] = {}
-for cst, fname in DRA_CSV_FILES.items():
-    if os.path.exists(fname):
-        try:
-            df = pd.read_csv(fname)
-            # Ensure required columns exist
-            if "%Drag Reduction" in df.columns and "PPM" in df.columns:
-                df = df[["%Drag Reduction", "PPM"]].dropna().sort_values("%Drag Reduction")
-                DRA_CURVE_DATA[cst] = df.reset_index(drop=True)
-            else:
-                DRA_CURVE_DATA[cst] = None
-        except Exception:
-            DRA_CURVE_DATA[cst] = None
-    else:
-        DRA_CURVE_DATA[cst] = None
-
-
-def _ppm_from_df(df: pd.DataFrame, dr: float) -> float:
-    """Return the PPM value for ``dr`` using breakpoints in ``df``."""
-    x = df['%Drag Reduction'].values.astype(float)
-    y = df['PPM'].values.astype(float)
-    if dr <= x[0]:
-        return float(y[0])
-    if dr >= x[-1]:
-        return float(y[-1])
-    return float(np.interp(dr, x, y))
-
-
-def _dr_from_df(df: pd.DataFrame, ppm: float) -> float:
-    """Return %Drag Reduction for a given ``ppm`` by inverse interpolation of ``df``."""
-    x = df['%Drag Reduction'].values.astype(float)
-    y = df['PPM'].values.astype(float)
-    if ppm <= y[0]:
-        return float(x[0])
-    if ppm >= y[-1]:
-        return float(x[-1])
-    # Interpolate inverse: x(y)
-    return float(np.interp(ppm, y, x))
-
-
-def _nearest_bounds(visc: float, data: Dict[float, pd.DataFrame | None]) -> Tuple[float, float]:
-    cst_list = sorted([c for c in data.keys() if data[c] is not None])
-    if not cst_list:
-        return (visc, visc)
-    if visc <= cst_list[0]:
-        return (cst_list[0], cst_list[0])
-    if visc >= cst_list[-1]:
-        return (cst_list[-1], cst_list[-1])
-    lower = max(c for c in cst_list if c <= visc)
-    upper = min(c for c in cst_list if c >= visc)
-    return (lower, upper)
-
-
-_DEFAULT_CURVE_SENTINEL = object()
-_PPM_CACHE: Dict[tuple[float, ...], float] = {}
-_DR_CACHE: Dict[tuple[float, ...], float] = {}
-_PPM_BOUND_CACHE: Dict[tuple[float, ...], tuple[float, float]] = {}
+K1 = 0.1644
+K2 = -0.04705
+FT_PER_M = 3.28083989501312
 
 
 def _normalise_rounding_step(step: float | None) -> float:
@@ -103,178 +23,175 @@ def _normalise_rounding_step(step: float | None) -> float:
     return step_value
 
 
-def get_ppm_bounds(
-    visc: float,
-    dra_curve_data: Dict[float, pd.DataFrame | None] = _DEFAULT_CURVE_SENTINEL,
-) -> tuple[float, float]:
-    """Return the minimum and maximum PPM supported by available curves."""
-
-    use_global = False
-    if dra_curve_data is _DEFAULT_CURVE_SENTINEL or dra_curve_data is DRA_CURVE_DATA:
-        dra_curve_data = DRA_CURVE_DATA
-        use_global = True
-
-    visc = float(visc)
-    cache_key = _round_cache_key(visc)
-    if use_global:
-        cached = _PPM_BOUND_CACHE.get(cache_key)
-        if cached is not None:
-            return cached
-    lower, upper = _nearest_bounds(visc, dra_curve_data)
-
-    def _bounds_for(df: pd.DataFrame | None) -> tuple[float, float]:
-        if df is None or df.empty:
-            return (0.0, 0.0)
-        ppm_vals = df["PPM"].values.astype(float)
-        if ppm_vals.size == 0:
-            return (0.0, 0.0)
-        return (float(np.nanmin(ppm_vals)), float(np.nanmax(ppm_vals)))
-
-    if lower not in dra_curve_data or dra_curve_data[lower] is None:
-        return (0.0, 0.0)
-
-    lower_bounds = _bounds_for(dra_curve_data[lower])
-    if lower == upper:
-        return lower_bounds
-
-    upper_bounds = _bounds_for(dra_curve_data.get(upper))
-    min_ppm = lower_bounds[0] if upper_bounds[0] == 0.0 else min(lower_bounds[0], upper_bounds[0])
-    max_ppm = max(lower_bounds[1], upper_bounds[1])
-    result = (min_ppm, max_ppm)
-    if use_global:
-        if len(_PPM_BOUND_CACHE) > 8192:
-            _PPM_BOUND_CACHE.clear()
-        _PPM_BOUND_CACHE[cache_key] = result
-    return result
-
-
-def _round_cache_key(*values: float, precision: int = 6) -> tuple[float, ...]:
+def _round_cache_key(*values: float, precision: int = 6) -> Tuple[float, ...]:
     """Return a tuple suitable for memoisation keyed by rounded ``values``."""
 
-    return tuple(round(float(val), precision) for val in values)
+    rounded = []
+    for val in values:
+        try:
+            rounded.append(round(float(val), precision))
+        except (TypeError, ValueError):
+            rounded.append(0.0)
+    return tuple(rounded)
 
 
-def _compute_ppm_for_dr(
-    visc: float,
-    dr: float,
-    dra_curve_data: Dict[float, pd.DataFrame | None],
-    rounding_step: float | None = None,
-) -> float:
-    """Internal helper implementing :func:`get_ppm_for_dr` without caching."""
+def _velocity_ft_s(velocity_mps: float) -> float:
+    try:
+        vel = float(velocity_mps)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(vel, 0.0) * FT_PER_M
 
-    visc = float(visc)
-    lower, upper = _nearest_bounds(visc, dra_curve_data)
-    if lower not in dra_curve_data or dra_curve_data[lower] is None:
+
+def _diameter_ft(diameter_m: float) -> float:
+    try:
+        dia = float(diameter_m)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(dia, 0.0) * FT_PER_M
+
+
+def _compute_drag_reduction(visc: float, ppm: float, velocity_mps: float, diameter_m: float) -> float:
+    """Return % drag reduction using the Burger equation."""
+
+    try:
+        visc_val = float(visc)
+        ppm_val = float(ppm)
+    except (TypeError, ValueError):
+        return 0.0
+    if visc_val <= 0.0 or ppm_val <= 0.0:
         return 0.0
 
-    step_value = _normalise_rounding_step(rounding_step)
+    vel_ft_s = _velocity_ft_s(velocity_mps)
+    dia_ft = _diameter_ft(diameter_m)
+    if vel_ft_s <= 0.0 or dia_ft <= 0.0:
+        return 0.0
 
-    def round_ppm(val: float) -> float:
-        """Round ``val`` up to the next multiple of ``step_value``."""
+    denom = visc_val * (dia_ft ** 0.2)
+    if denom <= 0.0:
+        return 0.0
 
-        if val <= 0.0:
-            return 0.0
-        quotient = val / step_value
-        nearest = round(quotient)
-        if math.isclose(quotient, nearest, rel_tol=1e-9, abs_tol=1e-9):
-            return nearest * step_value
-        return math.ceil(quotient) * step_value
+    argument = (vel_ft_s * ppm_val) / denom
+    if argument <= 0.0:
+        return 0.0
 
-    if lower == upper:
-        return round_ppm(_ppm_from_df(dra_curve_data[lower], dr))
+    try:
+        dr_fraction = 0.5 * K1 * math.log(argument) + K2
+    except (ValueError, OverflowError):
+        return 0.0
+    if not math.isfinite(dr_fraction):
+        return 0.0
+    return max(dr_fraction * 100.0, 0.0)
 
-    df_lower = dra_curve_data[lower]
-    df_upper = dra_curve_data[upper]
-    ppm_lower = _ppm_from_df(df_lower, dr)
-    ppm_upper = _ppm_from_df(df_upper, dr)
-    ppm_interp = np.interp(visc, [lower, upper], [ppm_lower, ppm_upper])
-    return round_ppm(float(ppm_interp))
+
+def _round_up(value: float, step: float) -> float:
+    if value <= 0.0:
+        return 0.0
+    quotient = value / step
+    nearest = round(quotient)
+    if math.isclose(quotient, nearest, rel_tol=1e-9, abs_tol=1e-9):
+        return nearest * step
+    return math.ceil(quotient) * step
+
+
+@lru_cache(maxsize=32768)
+def _ppm_for_dr_cached(visc: float, dr_percent: float, velocity_mps: float, diameter_m: float, step: float) -> float:
+    if dr_percent <= 0.0:
+        return 0.0
+    try:
+        visc_val = float(visc)
+        dr_val = float(dr_percent)
+    except (TypeError, ValueError):
+        return 0.0
+    if visc_val <= 0.0:
+        return 0.0
+
+    vel_ft_s = _velocity_ft_s(velocity_mps)
+    dia_ft = _diameter_ft(diameter_m)
+    if vel_ft_s <= 0.0 or dia_ft <= 0.0:
+        return 0.0
+
+    dr_fraction = dr_val / 100.0
+    exponent = 2.0 * (dr_fraction - K2) / K1
+    try:
+        argument = math.exp(exponent)
+    except OverflowError:
+        argument = float('inf')
+    if not math.isfinite(argument) or argument <= 0.0:
+        return 0.0
+
+    ppm_raw = argument * visc_val * (dia_ft ** 0.2) / vel_ft_s
+    if not math.isfinite(ppm_raw):
+        return 0.0
+    return _round_up(ppm_raw, step)
+
+
+@lru_cache(maxsize=32768)
+def _dr_for_ppm_cached(visc: float, ppm: float, velocity_mps: float, diameter_m: float) -> float:
+    try:
+        ppm_val = float(ppm)
+        visc_val = float(visc)
+    except (TypeError, ValueError):
+        return 0.0
+    if ppm_val <= 0.0 or visc_val <= 0.0:
+        return 0.0
+
+    vel_ft_s = _velocity_ft_s(velocity_mps)
+    dia_ft = _diameter_ft(diameter_m)
+    if vel_ft_s <= 0.0 or dia_ft <= 0.0:
+        return 0.0
+
+    denom = visc_val * (dia_ft ** 0.2)
+    if denom <= 0.0:
+        return 0.0
+
+    argument = (vel_ft_s * ppm_val) / denom
+    if argument <= 0.0:
+        return 0.0
+
+    try:
+        dr_fraction = 0.5 * K1 * math.log(argument) + K2
+    except (ValueError, OverflowError):
+        return 0.0
+    if not math.isfinite(dr_fraction):
+        return 0.0
+    return max(dr_fraction * 100.0, 0.0)
 
 
 def get_ppm_for_dr(
     visc: float,
-    dr: float,
-    dra_curve_data: Dict[float, pd.DataFrame | None] = _DEFAULT_CURVE_SENTINEL,
+    dr_percent: float,
+    velocity_mps: float,
+    diameter_m: float,
     rounding_step: float | None = None,
 ) -> float:
-    """Interpolate PPM for a given drag reduction and viscosity.
-
-    Returns the PPM value rounded up to the next whole PPM (or custom
-    increment).
-    """
+    """Compute the PPM required for ``dr_percent`` drag reduction."""
 
     step_value = _normalise_rounding_step(rounding_step)
-
-    if dra_curve_data is _DEFAULT_CURVE_SENTINEL or dra_curve_data is DRA_CURVE_DATA:
-        dra_curve_data = DRA_CURVE_DATA
-        key = _round_cache_key(visc, dr, step_value)
-        cached = _PPM_CACHE.get(key)
-        if cached is not None:
-            return cached
-        result = _compute_ppm_for_dr(visc, dr, dra_curve_data, step_value)
-        if len(_PPM_CACHE) > 8192:
-            _PPM_CACHE.clear()
-        _PPM_CACHE[key] = result
-        return result
-
-    return _compute_ppm_for_dr(visc, dr, dra_curve_data, step_value)
-
-
-def _compute_dr_for_ppm(
-    visc: float,
-    ppm: float,
-    dra_curve_data: Dict[float, pd.DataFrame | None],
-) -> float:
-    """Internal helper implementing :func:`get_dr_for_ppm` without caching."""
-
-    visc = float(visc)
-    lower, upper = _nearest_bounds(visc, dra_curve_data)
-    if lower not in dra_curve_data or dra_curve_data[lower] is None:
-        return 0.0
-
-    if lower == upper:
-        return _dr_from_df(dra_curve_data[lower], ppm)
-
-    df_lower = dra_curve_data[lower]
-    df_upper = dra_curve_data[upper]
-    dr_lower = _dr_from_df(df_lower, ppm)
-    dr_upper = _dr_from_df(df_upper, ppm)
-    dr_interp = np.interp(visc, [lower, upper], [dr_lower, dr_upper])
-    return float(dr_interp)
+    key = _round_cache_key(visc, dr_percent, velocity_mps, diameter_m, step_value)
+    return _ppm_for_dr_cached(*key)
 
 
 def get_dr_for_ppm(
     visc: float,
     ppm: float,
-    dra_curve_data: Dict[float, pd.DataFrame | None] = _DEFAULT_CURVE_SENTINEL,
+    velocity_mps: float,
+    diameter_m: float,
 ) -> float:
-    """Inverse: interpolate %Drag Reduction for a given PPM and viscosity."""
+    """Compute % drag reduction delivered by ``ppm``."""
 
-    if dra_curve_data is _DEFAULT_CURVE_SENTINEL or dra_curve_data is DRA_CURVE_DATA:
-        dra_curve_data = DRA_CURVE_DATA
-        key = _round_cache_key(visc, ppm)
-        cached = _DR_CACHE.get(key)
-        if cached is not None:
-            return cached
-        result = _compute_dr_for_ppm(visc, ppm, dra_curve_data)
-        if len(_DR_CACHE) > 8192:
-            _DR_CACHE.clear()
-        _DR_CACHE[key] = result
-        return result
-
-    return _compute_dr_for_ppm(visc, ppm, dra_curve_data)
+    key = _round_cache_key(visc, ppm, velocity_mps, diameter_m)
+    return _dr_for_ppm_cached(*key)
 
 
-def compute_drag_reduction(visc: float, ppm: float) -> float:
+def compute_drag_reduction(visc: float, ppm: float, velocity_mps: float, diameter_m: float) -> float:
     """Return effective % drag reduction for ``ppm`` at viscosity ``visc``."""
-    if ppm <= 0:
-        return 0.0
-    return get_dr_for_ppm(visc, ppm)
+
+    key = _round_cache_key(visc, ppm, velocity_mps, diameter_m)
+    return _dr_for_ppm_cached(*key)
 
 
 __all__ = [
-    "DRA_CSV_FILES",
-    "DRA_CURVE_DATA",
     "get_ppm_for_dr",
     "get_dr_for_ppm",
     "compute_drag_reduction",

--- a/optimized_scheduler.py
+++ b/optimized_scheduler.py
@@ -8,12 +8,14 @@ from dataclasses import dataclass
 from functools import lru_cache
 import io
 import math
+import os
 import pstats
-from typing import Callable, Sequence
+from typing import Callable, Iterable, Mapping, Sequence
 import uuid
 
 CACHE_DECIMALS = 6
 RPM_REFINEMENT_THRESHOLD = 12
+DEFAULT_WORKERS = max(1, min(4, (os.cpu_count() or 2) - 1))
 
 
 def _round_cache(value: float) -> float:
@@ -34,6 +36,36 @@ class Pump:
     cost_coeff: float = 1.0
     base_cost: float = 0.0
     dra_penalty: float = 0.0
+    label: str | None = None
+
+
+@dataclass(frozen=True)
+class PeakConstraint:
+    """Residual head requirement at a station peak."""
+
+    name: str
+    available_head_m: float
+    required_head: float | Callable[..., float]
+
+    def residual_head(self, flow: float, temperature_c: float, dr_percent: float) -> float:
+        """Return the residual head for this peak."""
+
+        requirement = self.required_head
+        required_val: float
+        if callable(requirement):
+            try:
+                required_val = float(requirement(flow=flow, temperature_c=temperature_c, dr=dr_percent))
+            except TypeError:
+                try:
+                    required_val = float(requirement(flow, dr_percent))
+                except TypeError:
+                    try:
+                        required_val = float(requirement(flow))
+                    except TypeError:
+                        required_val = float(requirement())
+        else:
+            required_val = float(requirement)
+        return float(self.available_head_m) - required_val
 
 
 @dataclass(frozen=True)
@@ -44,6 +76,8 @@ class Station:
     pumps: tuple[Pump, ...]
     refinement_steps: int = 5
     refinement_iterations: int = 2
+    peaks: tuple[PeakConstraint, ...] = ()
+    temperature_c: float | None = None
 
 
 @dataclass(frozen=True)
@@ -53,6 +87,7 @@ class PipelineConfig:
     stations: tuple[Station, ...]
     inlet_flow: tuple[float, ...]
     hours: int
+    ambient_temp_c: float = 25.0
 
     def flow_for_hour(self, hour: int) -> float:
         if not self.inlet_flow:
@@ -62,7 +97,7 @@ class PipelineConfig:
         return self.inlet_flow[-1]
 
 
-def _normalise_pump(definition: Pump | dict | None) -> Pump:
+def _normalise_pump(definition: Pump | Mapping[str, object] | None) -> Pump:
     if isinstance(definition, Pump):
         return definition
     if definition is None:
@@ -81,6 +116,8 @@ def _normalise_pump(definition: Pump | dict | None) -> Pump:
         or str(definition.get("name"))
         or f"pump_{uuid.uuid4()}"
     )
+    label = definition.get("label") or definition.get("display_name") or definition.get("name")
+    label_str = str(label) if label not in (None, "") else type_id
     return Pump(
         type_id=type_id,
         rpm_range=rpm_vals,
@@ -90,10 +127,24 @@ def _normalise_pump(definition: Pump | dict | None) -> Pump:
         cost_coeff=float(definition.get("cost_coeff", 1.0)),
         base_cost=float(definition.get("base_cost", 0.0)),
         dra_penalty=float(definition.get("dra_penalty", 0.0)),
+        label=label_str,
     )
 
 
-def _normalise_station(definition: Station | dict) -> Station:
+def _normalise_peak(entry: PeakConstraint | Mapping[str, object]) -> PeakConstraint:
+    if isinstance(entry, PeakConstraint):
+        return entry
+    name = str(entry.get("name") or f"peak_{uuid.uuid4().hex[:6]}")
+    available = float(entry.get("available_head_m", entry.get("available", float("inf"))))
+    required = entry.get("required_head_m")
+    if required is None:
+        required = entry.get("required_head")
+    if required is None:
+        required = 0.0
+    return PeakConstraint(name=name, available_head_m=available, required_head=required)
+
+
+def _normalise_station(definition: Station | Mapping[str, object]) -> Station:
     if isinstance(definition, Station):
         return definition
     pumps_raw = definition.get("pumps") or []
@@ -101,10 +152,21 @@ def _normalise_station(definition: Station | dict) -> Station:
     name = str(definition.get("name") or f"Station {uuid.uuid4().hex[:8]}")
     steps = int(definition.get("refinement_steps", 5))
     iterations = int(definition.get("refinement_iterations", 2))
-    return Station(name=name, pumps=pumps, refinement_steps=steps, refinement_iterations=iterations)
+    peaks_raw = definition.get("peaks") or ()
+    peaks = tuple(_normalise_peak(peak) for peak in peaks_raw if peak is not None)
+    temperature = definition.get("temperature_c")
+    temperature_c = float(temperature) if temperature not in (None, "") else None
+    return Station(
+        name=name,
+        pumps=pumps,
+        refinement_steps=steps,
+        refinement_iterations=iterations,
+        peaks=peaks,
+        temperature_c=temperature_c,
+    )
 
 
-def _normalise_pipeline_config(config: PipelineConfig | dict) -> PipelineConfig:
+def _normalise_pipeline_config(config: PipelineConfig | Mapping[str, object]) -> PipelineConfig:
     if isinstance(config, PipelineConfig):
         return config
     stations_raw = config.get("stations") or []
@@ -122,7 +184,14 @@ def _normalise_pipeline_config(config: PipelineConfig | dict) -> PipelineConfig:
     if len(flow_seq) < hours:
         flow_seq.extend([flow_seq[-1]] * (hours - len(flow_seq)))
     inlet_flow = tuple(flow_seq[:hours])
-    return PipelineConfig(stations=stations, inlet_flow=inlet_flow, hours=hours)
+    ambient = config.get("ambient_temp_c")
+    if ambient is None:
+        ambient = config.get("ambient_temp")
+    try:
+        ambient_temp_c = float(ambient)
+    except (TypeError, ValueError):
+        ambient_temp_c = 25.0
+    return PipelineConfig(stations=stations, inlet_flow=inlet_flow, hours=hours, ambient_temp_c=ambient_temp_c)
 
 
 @lru_cache(maxsize=None)
@@ -233,25 +302,27 @@ def _adaptive_rpm_candidates(pump: Pump, flow: float, station: Station) -> tuple
 
 
 def solve_station(
-    station: Station | dict,
+    station: Station | Mapping[str, object],
     flow_in: float,
     global_best: float | None = None,
-) -> tuple[float, tuple[tuple[int, int], ...]]:
+    *,
+    cfg: SchedulerConfig | None = None,
+    temperature_c: float | None = None,
+) -> StationSearchResult:
     """Return the lowest-cost pump configuration for ``station``.
 
     The search uses branch-and-bound pruning combined with memoisation of partial
-    states.  ``global_best`` optionally supplies a hard upper-bound on the final
-    cost which helps prune additional branches when the caller already tracks a
-    full-pipeline incumbent.
+    states. ``cfg`` supplies feasibility constraints such as the maximum DRA
+    percentage and minimum residual head at peaks.
     """
 
     stn = _normalise_station(station)
     if not stn.pumps:
-        return 0.0, ()
+        return StationSearchResult(True, 0.0, (), 0.0, None)
 
     pumps = stn.pumps
-    rpm_choices = []
-    dr_choices = []
+    rpm_choices: list[tuple[int, ...]] = []
+    dr_choices: list[tuple[int, ...]] = []
     for pump in pumps:
         rpm_vals = _adaptive_rpm_candidates(pump, flow_in, stn)
         if not rpm_vals:
@@ -262,13 +333,33 @@ def solve_station(
 
     best_cost = float("inf")
     best_config: tuple[tuple[int, int], ...] = ()
+    best_max_dr = 0.0
     cache: dict[tuple[int, float], float] = {}
     current: list[tuple[int, int]] = []
     bound = float("inf") if global_best is None else float(global_best)
+    dr_cap = cfg.dra_cap_percent if cfg is not None else None
+    min_residual = cfg.min_peak_head_m if cfg is not None else None
+    ambient_temp = stn.temperature_c if stn.temperature_c is not None else temperature_c
+    if ambient_temp is None:
+        ambient_temp = 25.0
 
-    def dfs(idx: int, flow: float, cost: float) -> None:
-        nonlocal best_cost, best_config
+    infeasible_reason = "No feasible configuration found"
+
+    def violates_peaks(flow_value: float, dr_percent: float) -> bool:
+        if not stn.peaks or min_residual is None:
+            return False
+        for peak in stn.peaks:
+            residual = peak.residual_head(flow_value, ambient_temp, dr_percent)
+            if residual < min_residual - 1e-9:
+                return True
+        return False
+
+    def dfs(idx: int, flow: float, cost: float, max_dr_used: float) -> None:
+        nonlocal best_cost, best_config, best_max_dr, infeasible_reason
         if cost >= best_cost or cost >= bound:
+            return
+        if dr_cap is not None and max_dr_used > dr_cap + 1e-9:
+            infeasible_reason = "DR cap violated"
             return
         key = (idx, _round_cache(flow))
         seen_cost = cache.get(key)
@@ -278,20 +369,31 @@ def solve_station(
         if idx == len(pumps):
             best_cost = cost
             best_config = tuple(current)
+            best_max_dr = max_dr_used
             return
         pump = pumps[idx]
         for rpm in rpm_choices[idx]:
             flow_next = compute_flow(pump, rpm, flow)
             for dr in dr_choices[idx]:
+                dr_float = float(dr)
+                new_max_dr = max(max_dr_used, dr_float)
+                if dr_cap is not None and new_max_dr > dr_cap + 1e-9:
+                    infeasible_reason = "DR cap violated"
+                    continue
+                if violates_peaks(flow_next, dr_float):
+                    infeasible_reason = "peak residual head violated"
+                    continue
                 new_cost = cost + pump_cost(pump, flow_next, dr)
                 if new_cost >= best_cost or new_cost >= bound:
                     continue
                 current.append((int(rpm), int(dr)))
-                dfs(idx + 1, flow_next, new_cost)
+                dfs(idx + 1, flow_next, new_cost, new_max_dr)
                 current.pop()
 
-    dfs(0, float(flow_in), 0.0)
-    return best_cost, best_config
+    dfs(0, float(flow_in), 0.0, 0.0)
+    feasible = math.isfinite(best_cost)
+    reason = None if feasible else infeasible_reason
+    return StationSearchResult(feasible, best_cost, best_config, best_max_dr, reason)
 
 
 def _apply_configuration_flow(
@@ -307,46 +409,123 @@ def _apply_configuration_flow(
 
 
 def solve_for_hour(
-    pipeline_config: PipelineConfig | dict,
+    pipeline_config: PipelineConfig | Mapping[str, object],
     hour: int,
-) -> tuple[dict[str, tuple[tuple[int, int], ...]], float]:
+    *,
+    cfg: SchedulerConfig | None = None,
+) -> HourResult:
     """Solve one hourly sub-problem returning the schedule and cost."""
 
     config = _normalise_pipeline_config(pipeline_config)
     flow = config.flow_for_hour(hour)
-    schedule: dict[str, tuple[tuple[int, int], ...]] = {}
+    schedule: dict[str, list[dict[str, int | float | str]]] = {}
     total_cost = 0.0
+    feasible = True
+    max_dr = 0.0
+    rows: list[tuple[str, str, int, int]] = []
+    temperature = config.ambient_temp_c
+    message: str | None = None
+
     for station in config.stations:
-        cost, combo = solve_station(station, flow)
-        total_cost += cost
-        schedule[station.name] = combo
         station_norm = _normalise_station(station)
-        flow = _apply_configuration_flow(station_norm, flow, combo)
-    return schedule, total_cost
+        result = solve_station(
+            station_norm,
+            flow,
+            cfg=cfg,
+            temperature_c=temperature,
+        )
+        if not result.feasible:
+            feasible = False
+            message = result.reason
+            break
+        total_cost += result.cost
+        pretty_rows: list[dict[str, int | float | str]] = []
+        for pump, (rpm, dr) in zip(station_norm.pumps, result.config):
+            label = pump.label or pump.type_id
+            rows.append((station_norm.name, label, rpm, dr))
+            max_dr = max(max_dr, float(dr))
+            pretty_rows.append({"pump": label, "rpm": int(rpm), "dr_percent": int(dr)})
+        schedule[station_norm.name] = pretty_rows
+        flow = _apply_configuration_flow(station_norm, flow, result.config)
+
+    if not feasible:
+        pretty_table = "No feasible configuration found."
+        total_cost = float("inf")
+    else:
+        headers = "| Station | Pump | RPM | DRA (%) |\n|---|---|---:|---:|"
+        body = "\n".join(
+            f"| {station} | {pump} | {rpm} | {dr} |" for station, pump, rpm, dr in rows
+        )
+        pretty_table = f"{headers}\n{body}" if body else headers
+
+    return HourResult(feasible, total_cost, schedule, max_dr, pretty_table, message)
 
 
 def solve_pipeline(
-    pipeline_config: PipelineConfig | dict,
+    pipeline_config: PipelineConfig | Mapping[str, object],
     *,
     parallel: bool = True,
     max_workers: int | None = None,
-) -> list[tuple[dict[str, tuple[tuple[int, int], ...]], float]]:
+    cfg: SchedulerConfig | None = None,
+    progress_callback: Callable[[str, int | None, float | None], None] | None = None,
+) -> tuple[list[HourResult], str]:
     """Solve each hourly scenario, optionally in parallel."""
 
     config = _normalise_pipeline_config(pipeline_config)
     hours = range(config.hours)
-    results: list[tuple[dict[str, tuple[tuple[int, int], ...]], float]] = [
-        ({}, 0.0) for _ in hours
-    ]
     if not parallel or config.hours <= 1:
-        return [solve_for_hour(config, hr) for hr in hours]
+        results: list[HourResult] = []
+        for hr in hours:
+            if progress_callback:
+                progress_callback("hour_start", hour=hr, pct=None)
+            hr_result = solve_for_hour(config, hr, cfg=cfg)
+            results.append(hr_result)
+            if progress_callback:
+                progress_callback(
+                    "hour_done", hour=hr, pct=(len(results) / config.hours) * 100.0
+                )
+        return results, "serial"
 
-    with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(solve_for_hour, config, hr): hr for hr in hours}
+    worker_count = max_workers if max_workers is not None else DEFAULT_WORKERS
+    try:
+        executor: concurrent.futures.Executor = concurrent.futures.ProcessPoolExecutor(
+            max_workers=worker_count
+        )
+        backend = "process"
+    except Exception:
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=min(worker_count, 4))
+        backend = "thread"
+
+    results: list[HourResult] = [
+        HourResult(False, float("inf"), {}, 0.0, "No result", "Not started") for _ in hours
+    ]
+    if progress_callback:
+        for hr in hours:
+            progress_callback("hour_start", hour=hr, pct=None)
+    with executor:
+        futures = {
+            executor.submit(solve_for_hour, config, hr, cfg=cfg): hr for hr in hours
+        }
+        completed = 0
         for future in concurrent.futures.as_completed(futures):
             hr = futures[future]
-            results[hr] = future.result()
-    return results
+            try:
+                results[hr] = future.result(timeout=cfg.per_hour_timeout_s if cfg else None)
+            except Exception as exc:  # pragma: no cover - defensive
+                results[hr] = HourResult(
+                    False,
+                    float("inf"),
+                    {},
+                    0.0,
+                    "No feasible configuration found.",
+                    f"Execution failed: {exc}",
+                )
+            completed += 1
+            if progress_callback:
+                progress_callback(
+                    "hour_done", hour=hr, pct=(completed / config.hours) * 100.0
+                )
+    return results, backend
 
 
 def profile_solver(
@@ -367,10 +546,64 @@ def profile_solver(
     return stream.getvalue()
 
 
+def solve_day(
+    case: Mapping[str, object],
+    cfg: SchedulerConfig,
+    *,
+    terminal_min_residual_m: float,
+    progress_callback: Callable[[str, int | None, float | None, str | None], None] | None = None,
+) -> DayResult:
+    """Solve an entire day of hourly scenarios using ``cfg`` constraints."""
+
+    def _progress(kind: str, hour: int | None, pct: float | None) -> None:
+        if progress_callback is None:
+            return
+        msg = None
+        if kind == "summary":
+            msg = "Daily optimisation complete"
+        progress_callback(kind, hour=hour, pct=pct, msg=msg)
+
+    case_copy = dict(case)
+    hours = int(case_copy.get("hours", 24) or 24)
+    case_copy["hours"] = hours
+    inlet_flow = case_copy.get("inlet_flow") or case_copy.get("flow")
+    if inlet_flow is None:
+        inlet_flow = [0.0] * hours
+    if isinstance(inlet_flow, (int, float)):
+        inlet_flow = [float(inlet_flow)] * hours
+    if len(inlet_flow) < hours:
+        inlet_flow = list(inlet_flow) + [float(inlet_flow[-1])] * (hours - len(inlet_flow))
+    case_copy["inlet_flow"] = inlet_flow[:hours]
+
+    if progress_callback:
+        progress_callback("hour_start", hour=0, pct=0.0, msg="Starting optimisation")
+
+    results, backend = solve_pipeline(
+        case_copy,
+        parallel=cfg.parallel_hours,
+        cfg=cfg,
+        progress_callback=lambda kind, hour, pct: _progress(kind, hour, pct),
+    )
+
+    if progress_callback:
+        progress_callback(
+            "summary",
+            hour=None,
+            pct=100.0,
+            msg=f"Backend: {backend} · terminal ≥ {terminal_min_residual_m:.1f} m",
+        )
+
+    return DayResult(tuple(results), backend)
+
+
 __all__ = [
     "Pump",
     "Station",
     "PipelineConfig",
+    "SchedulerConfig",
+    "StationSearchResult",
+    "HourResult",
+    "DayResult",
     "compute_flow",
     "pump_cost",
     "refine_search",
@@ -378,5 +611,50 @@ __all__ = [
     "solve_for_hour",
     "solve_pipeline",
     "profile_solver",
+    "solve_day",
 ]
 
+@dataclass(frozen=True)
+class SchedulerConfig:
+    """Tunable knobs for the day solver."""
+
+    rpm_refine_step: int = 25
+    dr_step: float = 2.0
+    coarse_mult: float = 5.0
+    max_states: int = 50
+    dp_cost_margin: float = 5_000.0
+    dra_cap_percent: float = 30.0
+    min_peak_head_m: float = 25.0
+    parallel_hours: bool = True
+    per_hour_timeout_s: float | None = None
+
+
+@dataclass(frozen=True)
+class StationSearchResult:
+    """Detailed outcome of a station branch-and-bound search."""
+
+    feasible: bool
+    cost: float
+    config: tuple[tuple[int, int], ...]
+    max_dr_percent: float
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class HourResult:
+    """User-facing summary for a solved hour."""
+
+    feasible: bool
+    cost_currency: float
+    pump_settings: dict[str, list[dict[str, int | float | str]]]
+    max_dr_percent: float
+    pretty_table: str
+    message: str | None = None
+
+
+@dataclass(frozen=True)
+class DayResult:
+    """Aggregate of all hourly results."""
+
+    hours: tuple[HourResult, ...]
+    backend: str

--- a/optimized_scheduler.py
+++ b/optimized_scheduler.py
@@ -27,6 +27,7 @@ class HourResult:
     rows: List[Dict[str, Any]] = field(default_factory=list)
     max_dr_percent: float = 0.0
     cost_currency: Optional[float] = None
+    pump_settings: Dict[str, List[Dict[str, Any]]] = field(default_factory=dict)
     legacy_payload: Dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -55,6 +56,13 @@ class HourResult:
                     continue
                 total += float(value)
             self.cost_currency = float(total)
+
+        if self.pump_settings or not self.legacy_payload:
+            return
+
+        pump_settings = self.legacy_payload.get("pump_settings")
+        if isinstance(pump_settings, dict):
+            self.pump_settings = pump_settings
 
 
 def _round_cache(value: float) -> float:
@@ -532,6 +540,7 @@ def solve_for_hour(
         rows=station_rows,
         max_dr_percent=max_dr,
         cost_currency=float(total_cost),
+        pump_settings=pump_settings,
         legacy_payload={
             "stations": station_rows,
             "pump_settings": pump_settings,
@@ -587,6 +596,7 @@ def solve_pipeline(
             rows=[],
             max_dr_percent=0.0,
             cost_currency=float("inf"),
+            pump_settings={},
             legacy_payload={
                 "stations": [],
                 "pump_settings": {},
@@ -614,6 +624,7 @@ def solve_pipeline(
                     rows=[],
                     max_dr_percent=0.0,
                     cost_currency=float("inf"),
+                    pump_settings={},
                     legacy_payload={
                         "stations": [],
                         "pump_settings": {},

--- a/optimized_scheduler.py
+++ b/optimized_scheduler.py
@@ -1,0 +1,382 @@
+"""Optimised pump scheduling helpers."""
+
+from __future__ import annotations
+
+import cProfile
+import concurrent.futures
+from dataclasses import dataclass
+from functools import lru_cache
+import io
+import math
+import pstats
+from typing import Callable, Sequence
+import uuid
+
+CACHE_DECIMALS = 6
+RPM_REFINEMENT_THRESHOLD = 12
+
+
+def _round_cache(value: float) -> float:
+    """Return a consistently rounded value suitable for caching keys."""
+
+    return round(float(value), CACHE_DECIMALS)
+
+
+@dataclass(frozen=True)
+class Pump:
+    """Basic pump definition used by the optimiser."""
+
+    type_id: str
+    rpm_range: tuple[int, ...]
+    dr_range: tuple[int, ...]
+    flow_gain: float = 0.0
+    base_flow: float = 0.0
+    cost_coeff: float = 1.0
+    base_cost: float = 0.0
+    dra_penalty: float = 0.0
+
+
+@dataclass(frozen=True)
+class Station:
+    """Collection of pumps located at a pipeline station."""
+
+    name: str
+    pumps: tuple[Pump, ...]
+    refinement_steps: int = 5
+    refinement_iterations: int = 2
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Normalised configuration consumed by :func:`solve_pipeline`."""
+
+    stations: tuple[Station, ...]
+    inlet_flow: tuple[float, ...]
+    hours: int
+
+    def flow_for_hour(self, hour: int) -> float:
+        if not self.inlet_flow:
+            return 0.0
+        if hour < len(self.inlet_flow):
+            return self.inlet_flow[hour]
+        return self.inlet_flow[-1]
+
+
+def _normalise_pump(definition: Pump | dict | None) -> Pump:
+    if isinstance(definition, Pump):
+        return definition
+    if definition is None:
+        raise ValueError("Pump definition cannot be None")
+    rpm_raw = definition.get("rpm_range") or definition.get("rpm_values") or []
+    dr_raw = definition.get("dr_range") or definition.get("dra_range") or []
+    rpm_vals = tuple(sorted({int(val) for val in rpm_raw}))
+    dr_vals = tuple(sorted({int(val) for val in dr_raw}))
+    if not rpm_vals:
+        rpm_vals = (0,)
+    if not dr_vals:
+        dr_vals = (0,)
+    type_id = (
+        str(definition.get("type_id"))
+        or str(definition.get("id"))
+        or str(definition.get("name"))
+        or f"pump_{uuid.uuid4()}"
+    )
+    return Pump(
+        type_id=type_id,
+        rpm_range=rpm_vals,
+        dr_range=dr_vals,
+        flow_gain=float(definition.get("flow_gain", 0.0)),
+        base_flow=float(definition.get("base_flow", 0.0)),
+        cost_coeff=float(definition.get("cost_coeff", 1.0)),
+        base_cost=float(definition.get("base_cost", 0.0)),
+        dra_penalty=float(definition.get("dra_penalty", 0.0)),
+    )
+
+
+def _normalise_station(definition: Station | dict) -> Station:
+    if isinstance(definition, Station):
+        return definition
+    pumps_raw = definition.get("pumps") or []
+    pumps = tuple(_normalise_pump(p) for p in pumps_raw)
+    name = str(definition.get("name") or f"Station {uuid.uuid4().hex[:8]}")
+    steps = int(definition.get("refinement_steps", 5))
+    iterations = int(definition.get("refinement_iterations", 2))
+    return Station(name=name, pumps=pumps, refinement_steps=steps, refinement_iterations=iterations)
+
+
+def _normalise_pipeline_config(config: PipelineConfig | dict) -> PipelineConfig:
+    if isinstance(config, PipelineConfig):
+        return config
+    stations_raw = config.get("stations") or []
+    stations = tuple(_normalise_station(stn) for stn in stations_raw)
+    flow_raw = config.get("inlet_flow") or config.get("flow") or []
+    if isinstance(flow_raw, (int, float)):
+        flow_seq: Sequence[float] = [float(flow_raw)]
+    else:
+        flow_seq = [float(val) for val in flow_raw]
+    hours = int(config.get("hours", len(flow_seq) or 24))
+    if hours <= 0:
+        hours = 1
+    if not flow_seq:
+        flow_seq = [0.0] * hours
+    if len(flow_seq) < hours:
+        flow_seq.extend([flow_seq[-1]] * (hours - len(flow_seq)))
+    inlet_flow = tuple(flow_seq[:hours])
+    return PipelineConfig(stations=stations, inlet_flow=inlet_flow, hours=hours)
+
+
+@lru_cache(maxsize=None)
+def _compute_flow_cached(pump: Pump, rpm: int, flow_in: float) -> float:
+    rpm_val = float(rpm)
+    flow = float(flow_in)
+    adjusted = flow + pump.base_flow + pump.flow_gain * rpm_val
+    return max(adjusted, 0.0)
+
+
+def compute_flow(pump: Pump, rpm: int, flow_in: float) -> float:
+    """Return the new flow exiting ``pump`` at ``rpm`` for ``flow_in``."""
+
+    return _compute_flow_cached(pump, int(rpm), _round_cache(flow_in))
+
+
+def _clear_flow_cache() -> None:
+    _compute_flow_cached.cache_clear()
+
+
+compute_flow.cache_clear = _clear_flow_cache  # type: ignore[attr-defined]
+compute_flow.cache_info = _compute_flow_cached.cache_info  # type: ignore[attr-defined]
+
+
+@lru_cache(maxsize=None)
+def _pump_cost_cached(pump: Pump, flow: float, dr: int) -> float:
+    flow_val = float(flow)
+    rpm_factor = max(flow_val, 0.0)
+    dr_factor = 1.0 - pump.dra_penalty * (int(dr) / 100.0)
+    cost = pump.base_cost + pump.cost_coeff * rpm_factor * dr_factor
+    return max(cost, 0.0)
+
+
+def pump_cost(pump: Pump, flow: float, dr: int) -> float:
+    """Return cached operating cost for ``pump`` at ``flow`` and ``dr``."""
+
+    return _pump_cost_cached(pump, _round_cache(flow), int(dr))
+
+
+def _clear_cost_cache() -> None:
+    _pump_cost_cached.cache_clear()
+
+
+pump_cost.cache_clear = _clear_cost_cache  # type: ignore[attr-defined]
+pump_cost.cache_info = _pump_cost_cached.cache_info  # type: ignore[attr-defined]
+
+
+def refine_search(
+    func: Callable[[float], float],
+    low: float,
+    high: float,
+    *,
+    steps: int = 5,
+    iterations: int = 3,
+) -> float:
+    """Successively narrow an interval around the minimum of ``func``."""
+
+    if high < low:
+        low, high = high, low
+    if math.isclose(high, low):
+        return float(low)
+    span = float(high - low)
+    if span <= 0:
+        return float(low)
+    best_x = low
+    best_val = float("inf")
+    current_low = float(low)
+    current_high = float(high)
+    steps = max(1, int(steps))
+    iterations = max(1, int(iterations))
+    for _ in range(iterations):
+        xs = [current_low + j * (current_high - current_low) / steps for j in range(steps + 1)]
+        vals = [func(x) for x in xs]
+        min_idx = min(range(len(vals)), key=lambda i: vals[i])
+        best_x = xs[min_idx]
+        best_val = vals[min_idx]
+        window = (current_high - current_low) / (steps * 2)
+        centre = xs[min_idx]
+        current_low = max(low, centre - window)
+        current_high = min(high, centre + window)
+        if math.isclose(current_high, current_low):
+            break
+    return float(best_x if math.isfinite(best_val) else low)
+
+
+def _adaptive_rpm_candidates(pump: Pump, flow: float, station: Station) -> tuple[int, ...]:
+    rpm_vals = pump.rpm_range
+    if len(rpm_vals) <= RPM_REFINEMENT_THRESHOLD or len(rpm_vals) <= station.refinement_steps:
+        return rpm_vals
+
+    low, high = rpm_vals[0], rpm_vals[-1]
+
+    def rpm_proxy(rpm_value: float) -> float:
+        rpm_int = int(round(rpm_value))
+        flow_out = compute_flow(pump, rpm_int, flow)
+        return pump_cost(pump, flow_out, pump.dr_range[0] if pump.dr_range else 0)
+
+    centre = refine_search(
+        rpm_proxy,
+        low,
+        high,
+        steps=station.refinement_steps,
+        iterations=station.refinement_iterations,
+    )
+    sorted_candidates = sorted(rpm_vals, key=lambda val: abs(val - centre))
+    limit = min(len(sorted_candidates), station.refinement_steps + 1)
+    return tuple(sorted(sorted_candidates[:limit]))
+
+
+def solve_station(
+    station: Station | dict,
+    flow_in: float,
+    global_best: float | None = None,
+) -> tuple[float, tuple[tuple[int, int], ...]]:
+    """Return the lowest-cost pump configuration for ``station``.
+
+    The search uses branch-and-bound pruning combined with memoisation of partial
+    states.  ``global_best`` optionally supplies a hard upper-bound on the final
+    cost which helps prune additional branches when the caller already tracks a
+    full-pipeline incumbent.
+    """
+
+    stn = _normalise_station(station)
+    if not stn.pumps:
+        return 0.0, ()
+
+    pumps = stn.pumps
+    rpm_choices = []
+    dr_choices = []
+    for pump in pumps:
+        rpm_vals = _adaptive_rpm_candidates(pump, flow_in, stn)
+        if not rpm_vals:
+            rpm_vals = (0,)
+        rpm_choices.append(rpm_vals)
+        dr_vals = pump.dr_range or (0,)
+        dr_choices.append(dr_vals)
+
+    best_cost = float("inf")
+    best_config: tuple[tuple[int, int], ...] = ()
+    cache: dict[tuple[int, float], float] = {}
+    current: list[tuple[int, int]] = []
+    bound = float("inf") if global_best is None else float(global_best)
+
+    def dfs(idx: int, flow: float, cost: float) -> None:
+        nonlocal best_cost, best_config
+        if cost >= best_cost or cost >= bound:
+            return
+        key = (idx, _round_cache(flow))
+        seen_cost = cache.get(key)
+        if seen_cost is not None and cost >= seen_cost - 1e-9:
+            return
+        cache[key] = cost if seen_cost is None or cost < seen_cost else seen_cost
+        if idx == len(pumps):
+            best_cost = cost
+            best_config = tuple(current)
+            return
+        pump = pumps[idx]
+        for rpm in rpm_choices[idx]:
+            flow_next = compute_flow(pump, rpm, flow)
+            for dr in dr_choices[idx]:
+                new_cost = cost + pump_cost(pump, flow_next, dr)
+                if new_cost >= best_cost or new_cost >= bound:
+                    continue
+                current.append((int(rpm), int(dr)))
+                dfs(idx + 1, flow_next, new_cost)
+                current.pop()
+
+    dfs(0, float(flow_in), 0.0)
+    return best_cost, best_config
+
+
+def _apply_configuration_flow(
+    station: Station,
+    flow: float,
+    config: Sequence[tuple[int, int]],
+) -> float:
+    updated = float(flow)
+    for pump, setting in zip(station.pumps, config):
+        rpm, _dr = setting
+        updated = compute_flow(pump, rpm, updated)
+    return updated
+
+
+def solve_for_hour(
+    pipeline_config: PipelineConfig | dict,
+    hour: int,
+) -> tuple[dict[str, tuple[tuple[int, int], ...]], float]:
+    """Solve one hourly sub-problem returning the schedule and cost."""
+
+    config = _normalise_pipeline_config(pipeline_config)
+    flow = config.flow_for_hour(hour)
+    schedule: dict[str, tuple[tuple[int, int], ...]] = {}
+    total_cost = 0.0
+    for station in config.stations:
+        cost, combo = solve_station(station, flow)
+        total_cost += cost
+        schedule[station.name] = combo
+        station_norm = _normalise_station(station)
+        flow = _apply_configuration_flow(station_norm, flow, combo)
+    return schedule, total_cost
+
+
+def solve_pipeline(
+    pipeline_config: PipelineConfig | dict,
+    *,
+    parallel: bool = True,
+    max_workers: int | None = None,
+) -> list[tuple[dict[str, tuple[tuple[int, int], ...]], float]]:
+    """Solve each hourly scenario, optionally in parallel."""
+
+    config = _normalise_pipeline_config(pipeline_config)
+    hours = range(config.hours)
+    results: list[tuple[dict[str, tuple[tuple[int, int], ...]], float]] = [
+        ({}, 0.0) for _ in hours
+    ]
+    if not parallel or config.hours <= 1:
+        return [solve_for_hour(config, hr) for hr in hours]
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(solve_for_hour, config, hr): hr for hr in hours}
+        for future in concurrent.futures.as_completed(futures):
+            hr = futures[future]
+            results[hr] = future.result()
+    return results
+
+
+def profile_solver(
+    pipeline_config: PipelineConfig | dict,
+    *,
+    sort: str = "cumtime",
+    limit: int = 20,
+) -> str:
+    """Profile a pipeline solve and return formatted statistics."""
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    solve_pipeline(pipeline_config, parallel=False)
+    profiler.disable()
+    stream = io.StringIO()
+    stats = pstats.Stats(profiler, stream=stream).sort_stats(sort)
+    stats.print_stats(limit)
+    return stream.getvalue()
+
+
+__all__ = [
+    "Pump",
+    "Station",
+    "PipelineConfig",
+    "compute_flow",
+    "pump_cost",
+    "refine_search",
+    "solve_station",
+    "solve_for_hour",
+    "solve_pipeline",
+    "profile_solver",
+]
+

--- a/optimized_scheduler.py
+++ b/optimized_scheduler.py
@@ -24,6 +24,7 @@ class HourResult:
 
     hour: int
     feasible: bool
+    hour_index: Optional[int] = None
     rows: List[Dict[str, Any]] = field(default_factory=list)
     max_dr_percent: float = 0.0
     cost_currency: Optional[float] = None
@@ -465,6 +466,8 @@ def solve_for_hour(
 
     config = _normalise_pipeline_config(pipeline_config)
     flow = config.flow_for_hour(hour)
+    start_hour = int(cfg.start_hour) if cfg is not None else 0
+    hour_label = (start_hour + hour) % 24
     total_cost = 0.0
     max_dr = 0.0
     station_rows: List[Dict[str, Any]] = []
@@ -480,7 +483,7 @@ def solve_for_hour(
             temperature_c=temperature,
         )
         if not result.feasible:
-            hour_result = HourResult(hour=hour, feasible=False)
+            hour_result = HourResult(hour=hour_label, hour_index=hour, feasible=False)
             hour_result.legacy_payload = {
                 "stations": [],
                 "pump_settings": {},
@@ -535,7 +538,8 @@ def solve_for_hour(
         flow = _apply_configuration_flow(station_norm, flow, result.config)
 
     hour_result = HourResult(
-        hour=hour,
+        hour=hour_label,
+        hour_index=hour,
         feasible=True,
         rows=station_rows,
         max_dr_percent=max_dr,
@@ -566,16 +570,20 @@ def solve_pipeline(
 
     config = _normalise_pipeline_config(pipeline_config)
     hours = range(config.hours)
+    start_hour = int(cfg.start_hour) if cfg is not None else 0
     if not parallel or config.hours <= 1:
         results: list[HourResult] = []
         for hr in hours:
+            hour_display = (start_hour + hr) % 24
             if progress_callback:
-                progress_callback("hour_start", hour=hr, pct=None)
+                progress_callback("hour_start", hour=hour_display, pct=None)
             hr_result = solve_for_hour(config, hr, cfg=cfg)
             results.append(hr_result)
             if progress_callback:
                 progress_callback(
-                    "hour_done", hour=hr, pct=(len(results) / config.hours) * 100.0
+                    "hour_done",
+                    hour=hour_display,
+                    pct=(len(results) / config.hours) * 100.0,
                 )
         return results, "serial"
 
@@ -591,7 +599,8 @@ def solve_pipeline(
 
     results: list[HourResult] = [
         HourResult(
-            hour=hr,
+            hour=(start_hour + hr) % 24,
+            hour_index=hr,
             feasible=False,
             rows=[],
             max_dr_percent=0.0,
@@ -607,7 +616,7 @@ def solve_pipeline(
     ]
     if progress_callback:
         for hr in hours:
-            progress_callback("hour_start", hour=hr, pct=None)
+            progress_callback("hour_start", hour=(start_hour + hr) % 24, pct=None)
     with executor:
         futures = {
             executor.submit(solve_for_hour, config, hr, cfg=cfg): hr for hr in hours
@@ -615,11 +624,13 @@ def solve_pipeline(
         completed = 0
         for future in concurrent.futures.as_completed(futures):
             hr = futures[future]
+            hour_display = (start_hour + hr) % 24
             try:
                 results[hr] = future.result(timeout=cfg.per_hour_timeout_s if cfg else None)
             except Exception as exc:  # pragma: no cover - defensive
                 failure = HourResult(
-                    hour=hr,
+                    hour=hour_display,
+                    hour_index=hr,
                     feasible=False,
                     rows=[],
                     max_dr_percent=0.0,
@@ -636,7 +647,9 @@ def solve_pipeline(
             completed += 1
             if progress_callback:
                 progress_callback(
-                    "hour_done", hour=hr, pct=(completed / config.hours) * 100.0
+                    "hour_done",
+                    hour=hour_display,
+                    pct=(completed / config.hours) * 100.0,
                 )
     return results, backend
 
@@ -676,6 +689,7 @@ def solve_day(
             msg = "Daily optimisation complete"
         progress_callback(kind, hour=hour, pct=pct, msg=msg)
 
+    start_hour = int(cfg.start_hour) if cfg is not None else 0
     case_copy = dict(case)
     hours = int(case_copy.get("hours", 24) or 24)
     case_copy["hours"] = hours
@@ -689,7 +703,12 @@ def solve_day(
     case_copy["inlet_flow"] = inlet_flow[:hours]
 
     if progress_callback:
-        progress_callback("hour_start", hour=0, pct=0.0, msg="Starting optimisation")
+        progress_callback(
+            "hour_start",
+            hour=start_hour % 24,
+            pct=0.0,
+            msg="Starting optimisation",
+        )
 
     results, backend = solve_pipeline(
         case_copy,
@@ -740,6 +759,7 @@ class SchedulerConfig:
     min_peak_head_m: float = 25.0
     parallel_hours: bool = True
     per_hour_timeout_s: float | None = None
+    start_hour: int = 7
 
 
 @dataclass(frozen=True)

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -6,15 +6,6 @@ import altair as alt
 import pipeline_model
 import datetime as dt
 
-from optimized_scheduler import HourResult, SchedulerConfig, solve_day
-
-import multiprocessing as mp
-if mp.get_start_method(allow_none=True) != "spawn":
-    try:
-        mp.set_start_method("spawn", force=True)
-    except RuntimeError:
-        pass
-
 # --- SAFE DEFAULTS (session state guards) ---
 if "stations" not in st.session_state or not isinstance(st.session_state.get("stations"), list):
     st.session_state["stations"] = []
@@ -51,7 +42,6 @@ import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
 from math import isclose, pi, sqrt
-import math
 import hashlib
 import uuid
 import json
@@ -1398,13 +1388,6 @@ st.sidebar.download_button(
     file_name="pipeline_case.json",
     mime="application/json"
 )
-
-
-def current_case_dict() -> dict[str, object]:
-    """Return a deep copy of the active case."""
-
-    return copy.deepcopy(get_full_case_dict())
-
 
 def _default_segment_slices(
     stations: list[dict], kv_list: list[float], rho_list: list[float]
@@ -4361,31 +4344,6 @@ def run_all_updates():
     st.rerun()
 
 
-def make_ui_progress():
-    """Return a Streamlit-friendly progress callback."""
-
-    bar = st.progress(0)
-    text = st.empty()
-
-    def cb(kind: str, **kw):
-        if kind == "hour_start":
-            hour = kw.get("hour")
-            if hour is not None:
-                text.write(f"Solving hour {int(hour) % 24:02d}:00 …")
-        elif kind == "hour_done":
-            pct = kw.get("pct", 0)
-            try:
-                pct_val = int(pct)
-            except (TypeError, ValueError):
-                pct_val = 0
-            bar.progress(min(100, max(0, pct_val)))
-        elif kind == "summary":
-            msg = kw.get("msg") or "Optimisation complete"
-            text.write(msg)
-
-    return cb
-
-
 if not auto_batch:
     st.markdown("<div style='text-align:center;'>", unsafe_allow_html=True)
     st.button("Start task", key="start_task", type="primary", on_click=run_all_updates)
@@ -4398,7 +4356,6 @@ if not auto_batch:
     if run_day or run_hour:
         is_hourly = bool(run_hour)
         st.session_state["run_mode"] = "hourly" if is_hourly else "daily"
-
 
         stations_base = copy.deepcopy(st.session_state.stations)
         for stn in stations_base:
@@ -4422,85 +4379,164 @@ if not auto_batch:
                 if names:
                     stn['pump_name'] = names[0]
 
-        cfg = SchedulerConfig(
-            rpm_refine_step=int(st.session_state.get("adv_refine_rpm_step", 25)),
-            dr_step=float(st.session_state.get("adv_refine_dr_step", 2.0)),
-            coarse_mult=float(st.session_state.get("adv_coarse_mult", 5.0)),
-            max_states=int(st.session_state.get("adv_dp_states", 50)),
-            dp_cost_margin=float(st.session_state.get("adv_dp_margin", 5000.0)),
-            dra_cap_percent=30.0,
-            min_peak_head_m=25.0,
-            parallel_hours=not is_hourly,
-            per_hour_timeout_s=90,
-        )
+        term_data = {"name": terminal_name, "elev": terminal_elev, "min_residual": terminal_head}
 
-        case = current_case_dict()
-        terminal_section = case.setdefault("terminal", {})
-        terminal_section.setdefault("name", terminal_name)
-        terminal_section.setdefault("elev", terminal_elev)
-        terminal_section.setdefault("min_residual", terminal_head)
-        terminal_min_res = float(terminal_section.get("min_residual", terminal_head))
-
-        base_flow = float(st.session_state.get("FLOW", 1000.0))
-        if is_hourly:
-            case["hours"] = 1
-            case["inlet_flow"] = [float(st.session_state.get("hourly_flow", base_flow))]
-        else:
-            case["hours"] = 24
-            case["inlet_flow"] = [base_flow] * case["hours"]
-
-        ui_cb = make_ui_progress()
-        ui_cb("hour_start", hour=0)
-
-        try:
-            day_result = solve_day(
-                case,
-                cfg,
-                terminal_min_residual_m=terminal_min_res,
-                progress_callback=ui_cb,
-            )
-        except Exception as exc:
-            st.error(f"Optimizer crashed: {exc}")
+        # Prepare initial volumetric linefill
+        vol_df = st.session_state.get("linefill_vol_df", pd.DataFrame())
+        if isinstance(vol_df, pd.DataFrame):
+            vol_df = ensure_initial_dra_column(vol_df, default=0.0, fill_blanks=True)
+        if vol_df is None or len(vol_df) == 0:
+            st.error("Please enter linefill (volumetric) data.")
             st.stop()
 
-        total_cost = 0.0
-        for hr, hr_res in enumerate(day_result.hours):
-            if not isinstance(hr_res, HourResult):
-                continue
-            if not hr_res.feasible:
-                st.warning(
-                    f"No hydraulically feasible solution found at {hr:02d}:00 hrs "
-                    f"(≤ {cfg.dra_cap_percent:.0f}% DR & peak head ≥ {cfg.min_peak_head_m:.0f} m)."
-                )
-                continue
-            if hr_res.max_dr_percent > cfg.dra_cap_percent + 1e-6:
-                st.warning(
-                    f"No hydraulically feasible solution found at {hr:02d}:00 hrs "
-                    f"because it required {hr_res.max_dr_percent:.2f}% DR (> {cfg.dra_cap_percent:.0f}%)."
-                )
-                continue
+        # Determine FLOW for this mode
+        plan_df = st.session_state.get("day_plan_df", pd.DataFrame())
+        if isinstance(plan_df, pd.DataFrame):
+            plan_df = ensure_initial_dra_column(plan_df, default=0.0, fill_blanks=True)
+        if is_hourly:
+            FLOW_sched = st.session_state.get("hourly_flow", st.session_state.get("FLOW", 1000.0))
+        else:
+            daily_m3 = float(plan_df["Volume (m³)"].astype(float).sum()) if len(plan_df) else 0.0
+            FLOW_sched = daily_m3 / 24.0
 
-            with st.expander(
-                f"Hour {hr:02d}:00 schedule (cost = {hr_res.cost_currency:,.0f})",
-                expanded=False,
-            ):
-                st.write(hr_res.pretty_table)
-                st.json(hr_res.pump_settings)
-            if isinstance(hr_res.cost_currency, (int, float)) and math.isfinite(
-                float(hr_res.cost_currency)
-            ):
-                total_cost += float(hr_res.cost_currency)
-
-        st.success(f"Total daily cost = {total_cost:,.0f}")
+        if is_hourly:
+            hours = [7]
+        else:
+            hours = [(7 + h) % 24 for h in range(24)]
+        sub_steps = 1
+        total_runs = len(hours) * sub_steps if hours else 0
+        first_label = f"{hours[0] % 24:02d}:00" if hours else "00:00"
+        last_label = f"{hours[-1] % 24:02d}:00" if hours else "23:00"
+        if is_hourly:
+            spinner_msg = f"Running 1 optimization ({first_label})..."
+        else:
+            spinner_msg = f"Running {total_runs} optimizations ({first_label} to {last_label})..."
         st.session_state["linefill_next_day"] = None
+        total_length = sum(stn.get('L', 0.0) for stn in stations_base)
+        dra_reach_km = 200.0
 
-        st.session_state["day_df"] = None
-        st.session_state["day_df_raw"] = None
-        st.session_state["day_reports"] = None
-        st.session_state["day_linefill_snaps"] = None
-        st.session_state["day_hours"] = None
-        st.session_state["day_stations"] = None
+        current_vol = ensure_initial_dra_column(vol_df.copy(), default=0.0, fill_blanks=True)
+        if "DRA ppm" not in current_vol.columns:
+            current_vol["DRA ppm"] = current_vol[INIT_DRA_COL]
+        else:
+            ppm_col = current_vol["DRA ppm"]
+            ppm_blank = ppm_col.isna()
+            if ppm_col.dtype == object:
+                ppm_blank |= ppm_col.astype(str).str.strip() == ""
+            if ppm_blank.any():
+                current_vol.loc[ppm_blank, "DRA ppm"] = current_vol.loc[ppm_blank, INIT_DRA_COL]
+        dra_linefill = df_to_dra_linefill(current_vol)
+        current_vol = apply_dra_ppm(current_vol, dra_linefill)
 
+        with st.spinner(spinner_msg):
+            solver_result = _run_time_series_solver_cached(
+                stations_base,
+                term_data,
+                hours,
+                flow_rate=FLOW_sched,
+                plan_df=plan_df,
+                current_vol=current_vol,
+                dra_linefill=dra_linefill,
+                dra_reach_km=dra_reach_km,
+                RateDRA=RateDRA,
+                Price_HSD=Price_HSD,
+                fuel_density=st.session_state.get("Fuel_density", 820.0),
+                ambient_temp=st.session_state.get("Ambient_temp", 25.0),
+                mop_kgcm2=st.session_state.get("MOP_kgcm2"),
+                pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                total_length=total_length,
+                sub_steps=sub_steps,
+            )
+
+        error_msg = solver_result.get("error")
+        reports = list(solver_result.get("reports", []))
+        linefill_snaps = list(solver_result.get("linefill_snaps", []))
+        current_vol = solver_result.get("final_vol", current_vol)
+        plan_df = solver_result.get("final_plan", plan_df)
+        dra_linefill = solver_result.get("final_dra_linefill", dra_linefill)
+        dra_reach_km = solver_result.get("final_dra_reach", dra_reach_km)
+
+        _render_solver_feedback(
+            {"warnings": solver_result.get("warnings", [])},
+            include_warnings=True,
+            show_error=False,
+        )
+
+        hourly_errors = solver_result.get("hourly_errors", [])
+        if isinstance(hourly_errors, Sequence) and not isinstance(hourly_errors, (str, bytes)):
+            for err in hourly_errors:
+                if not isinstance(err, Mapping):
+                    continue
+                err_msg = str(err.get("message", "") or "").strip()
+                if not err_msg:
+                    continue
+                try:
+                    hour_val = int(err.get("hour", 0))
+                except (TypeError, ValueError):
+                    hour_val = 0
+                st.warning(f"{hour_val % 24:02d}:00 – {err_msg}")
+
+        if error_msg:
+            st.session_state["linefill_next_day"] = pd.DataFrame()
+            if reports:
+                last_hour = reports[-1].get("time")
+                if last_hour is not None:
+                    st.info(
+                        f"Optimization stopped early after {int(last_hour) % 24:02d}:00. "
+                        "Partial results are displayed for completed hours."
+                    )
+            else:
+                st.info("Optimization failed before any hourly result was produced.")
+            st.error(error_msg)
+
+        if solver_result.get("backtracked"):
+            warn_msg = _build_enforced_origin_warning(
+                solver_result.get("backtrack_notes"),
+                solver_result.get("enforced_origin_actions"),
+            )
+            st.warning(
+                warn_msg
+                + " Please avoid zero DRA requests at the origin when planning sequential hours."
+            )
+
+        st.session_state["linefill_next_day"] = _get_linefill_snapshot_for_hour(
+            linefill_snaps,
+            hours,
+            target_hour=6,
+        )
+
+        # Build a consolidated station-wise table with flow pattern names
+        station_tables = []
+        for rec in reports:
+            res = rec["result"]
+            hr = rec["time"]
+            df_int = build_station_table(res, stations_base)
+            # Insert human-readable pattern and time columns
+            pattern = res.get('flow_pattern_name', '')
+            df_int.insert(0, "Pattern", pattern)
+            df_int.insert(0, "Time", f"{hr:02d}:00")
+            station_tables.append(df_int)
+        if station_tables:
+            df_day = pd.concat(station_tables, ignore_index=True).fillna(0.0).round(2)
+        else:
+            df_day = pd.DataFrame()
+
+        # Ensure numeric columns are typed as numeric to avoid conversion errors when styling
+        # Pandas may treat some columns as object if they contain NaN or are newly inserted.
+        df_day_numeric = df_day.copy()
+        # Identify columns eligible for numeric styling
+        non_numeric_cols = {"Time", "Station", "Pump Name", "Pattern", "DRA Profile (km@ppm)"}
+        num_cols = [c for c in df_day_numeric.columns if c not in non_numeric_cols]
+        for c in num_cols:
+            df_day_numeric[c] = pd.to_numeric(df_day_numeric[c], errors="coerce").fillna(0.0)
+
+        # Persist results for reuse across Streamlit reruns
+        st.session_state["day_df"] = df_day_numeric
+        st.session_state["day_df_raw"] = df_day
+        st.session_state["day_reports"] = reports
+        st.session_state["day_linefill_snaps"] = linefill_snaps
+        st.session_state["day_hours"] = hours
+        st.session_state["day_stations"] = stations_base
 
     if st.session_state.get("run_mode") in ("hourly", "daily") and st.session_state.get("day_df") is not None:
         df_day_numeric = st.session_state["day_df"]

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -6,6 +6,15 @@ import altair as alt
 import pipeline_model
 import datetime as dt
 
+from optimized_scheduler import HourResult, SchedulerConfig, solve_day
+
+import multiprocessing as mp
+if mp.get_start_method(allow_none=True) != "spawn":
+    try:
+        mp.set_start_method("spawn", force=True)
+    except RuntimeError:
+        pass
+
 # --- SAFE DEFAULTS (session state guards) ---
 if "stations" not in st.session_state or not isinstance(st.session_state.get("stations"), list):
     st.session_state["stations"] = []
@@ -42,6 +51,7 @@ import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
 from math import isclose, pi, sqrt
+import math
 import hashlib
 import uuid
 import json
@@ -1388,6 +1398,13 @@ st.sidebar.download_button(
     file_name="pipeline_case.json",
     mime="application/json"
 )
+
+
+def current_case_dict() -> dict[str, object]:
+    """Return a deep copy of the active case."""
+
+    return copy.deepcopy(get_full_case_dict())
+
 
 def _default_segment_slices(
     stations: list[dict], kv_list: list[float], rho_list: list[float]
@@ -4344,6 +4361,31 @@ def run_all_updates():
     st.rerun()
 
 
+def make_ui_progress():
+    """Return a Streamlit-friendly progress callback."""
+
+    bar = st.progress(0)
+    text = st.empty()
+
+    def cb(kind: str, **kw):
+        if kind == "hour_start":
+            hour = kw.get("hour")
+            if hour is not None:
+                text.write(f"Solving hour {int(hour) % 24:02d}:00 …")
+        elif kind == "hour_done":
+            pct = kw.get("pct", 0)
+            try:
+                pct_val = int(pct)
+            except (TypeError, ValueError):
+                pct_val = 0
+            bar.progress(min(100, max(0, pct_val)))
+        elif kind == "summary":
+            msg = kw.get("msg") or "Optimisation complete"
+            text.write(msg)
+
+    return cb
+
+
 if not auto_batch:
     st.markdown("<div style='text-align:center;'>", unsafe_allow_html=True)
     st.button("Start task", key="start_task", type="primary", on_click=run_all_updates)
@@ -4356,6 +4398,7 @@ if not auto_batch:
     if run_day or run_hour:
         is_hourly = bool(run_hour)
         st.session_state["run_mode"] = "hourly" if is_hourly else "daily"
+
 
         stations_base = copy.deepcopy(st.session_state.stations)
         for stn in stations_base:
@@ -4379,164 +4422,85 @@ if not auto_batch:
                 if names:
                     stn['pump_name'] = names[0]
 
-        term_data = {"name": terminal_name, "elev": terminal_elev, "min_residual": terminal_head}
+        cfg = SchedulerConfig(
+            rpm_refine_step=int(st.session_state.get("adv_refine_rpm_step", 25)),
+            dr_step=float(st.session_state.get("adv_refine_dr_step", 2.0)),
+            coarse_mult=float(st.session_state.get("adv_coarse_mult", 5.0)),
+            max_states=int(st.session_state.get("adv_dp_states", 50)),
+            dp_cost_margin=float(st.session_state.get("adv_dp_margin", 5000.0)),
+            dra_cap_percent=30.0,
+            min_peak_head_m=25.0,
+            parallel_hours=not is_hourly,
+            per_hour_timeout_s=90,
+        )
 
-        # Prepare initial volumetric linefill
-        vol_df = st.session_state.get("linefill_vol_df", pd.DataFrame())
-        if isinstance(vol_df, pd.DataFrame):
-            vol_df = ensure_initial_dra_column(vol_df, default=0.0, fill_blanks=True)
-        if vol_df is None or len(vol_df) == 0:
-            st.error("Please enter linefill (volumetric) data.")
+        case = current_case_dict()
+        terminal_section = case.setdefault("terminal", {})
+        terminal_section.setdefault("name", terminal_name)
+        terminal_section.setdefault("elev", terminal_elev)
+        terminal_section.setdefault("min_residual", terminal_head)
+        terminal_min_res = float(terminal_section.get("min_residual", terminal_head))
+
+        base_flow = float(st.session_state.get("FLOW", 1000.0))
+        if is_hourly:
+            case["hours"] = 1
+            case["inlet_flow"] = [float(st.session_state.get("hourly_flow", base_flow))]
+        else:
+            case["hours"] = 24
+            case["inlet_flow"] = [base_flow] * case["hours"]
+
+        ui_cb = make_ui_progress()
+        ui_cb("hour_start", hour=0)
+
+        try:
+            day_result = solve_day(
+                case,
+                cfg,
+                terminal_min_residual_m=terminal_min_res,
+                progress_callback=ui_cb,
+            )
+        except Exception as exc:
+            st.error(f"Optimizer crashed: {exc}")
             st.stop()
 
-        # Determine FLOW for this mode
-        plan_df = st.session_state.get("day_plan_df", pd.DataFrame())
-        if isinstance(plan_df, pd.DataFrame):
-            plan_df = ensure_initial_dra_column(plan_df, default=0.0, fill_blanks=True)
-        if is_hourly:
-            FLOW_sched = st.session_state.get("hourly_flow", st.session_state.get("FLOW", 1000.0))
-        else:
-            daily_m3 = float(plan_df["Volume (m³)"].astype(float).sum()) if len(plan_df) else 0.0
-            FLOW_sched = daily_m3 / 24.0
+        total_cost = 0.0
+        for hr, hr_res in enumerate(day_result.hours):
+            if not isinstance(hr_res, HourResult):
+                continue
+            if not hr_res.feasible:
+                st.warning(
+                    f"No hydraulically feasible solution found at {hr:02d}:00 hrs "
+                    f"(≤ {cfg.dra_cap_percent:.0f}% DR & peak head ≥ {cfg.min_peak_head_m:.0f} m)."
+                )
+                continue
+            if hr_res.max_dr_percent > cfg.dra_cap_percent + 1e-6:
+                st.warning(
+                    f"No hydraulically feasible solution found at {hr:02d}:00 hrs "
+                    f"because it required {hr_res.max_dr_percent:.2f}% DR (> {cfg.dra_cap_percent:.0f}%)."
+                )
+                continue
 
-        if is_hourly:
-            hours = [7]
-        else:
-            hours = [(7 + h) % 24 for h in range(24)]
-        sub_steps = 1
-        total_runs = len(hours) * sub_steps if hours else 0
-        first_label = f"{hours[0] % 24:02d}:00" if hours else "00:00"
-        last_label = f"{hours[-1] % 24:02d}:00" if hours else "23:00"
-        if is_hourly:
-            spinner_msg = f"Running 1 optimization ({first_label})..."
-        else:
-            spinner_msg = f"Running {total_runs} optimizations ({first_label} to {last_label})..."
+            with st.expander(
+                f"Hour {hr:02d}:00 schedule (cost = {hr_res.cost_currency:,.0f})",
+                expanded=False,
+            ):
+                st.write(hr_res.pretty_table)
+                st.json(hr_res.pump_settings)
+            if isinstance(hr_res.cost_currency, (int, float)) and math.isfinite(
+                float(hr_res.cost_currency)
+            ):
+                total_cost += float(hr_res.cost_currency)
+
+        st.success(f"Total daily cost = {total_cost:,.0f}")
         st.session_state["linefill_next_day"] = None
-        total_length = sum(stn.get('L', 0.0) for stn in stations_base)
-        dra_reach_km = 200.0
 
-        current_vol = ensure_initial_dra_column(vol_df.copy(), default=0.0, fill_blanks=True)
-        if "DRA ppm" not in current_vol.columns:
-            current_vol["DRA ppm"] = current_vol[INIT_DRA_COL]
-        else:
-            ppm_col = current_vol["DRA ppm"]
-            ppm_blank = ppm_col.isna()
-            if ppm_col.dtype == object:
-                ppm_blank |= ppm_col.astype(str).str.strip() == ""
-            if ppm_blank.any():
-                current_vol.loc[ppm_blank, "DRA ppm"] = current_vol.loc[ppm_blank, INIT_DRA_COL]
-        dra_linefill = df_to_dra_linefill(current_vol)
-        current_vol = apply_dra_ppm(current_vol, dra_linefill)
+        st.session_state["day_df"] = None
+        st.session_state["day_df_raw"] = None
+        st.session_state["day_reports"] = None
+        st.session_state["day_linefill_snaps"] = None
+        st.session_state["day_hours"] = None
+        st.session_state["day_stations"] = None
 
-        with st.spinner(spinner_msg):
-            solver_result = _run_time_series_solver_cached(
-                stations_base,
-                term_data,
-                hours,
-                flow_rate=FLOW_sched,
-                plan_df=plan_df,
-                current_vol=current_vol,
-                dra_linefill=dra_linefill,
-                dra_reach_km=dra_reach_km,
-                RateDRA=RateDRA,
-                Price_HSD=Price_HSD,
-                fuel_density=st.session_state.get("Fuel_density", 820.0),
-                ambient_temp=st.session_state.get("Ambient_temp", 25.0),
-                mop_kgcm2=st.session_state.get("MOP_kgcm2"),
-                pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
-                total_length=total_length,
-                sub_steps=sub_steps,
-            )
-
-        error_msg = solver_result.get("error")
-        reports = list(solver_result.get("reports", []))
-        linefill_snaps = list(solver_result.get("linefill_snaps", []))
-        current_vol = solver_result.get("final_vol", current_vol)
-        plan_df = solver_result.get("final_plan", plan_df)
-        dra_linefill = solver_result.get("final_dra_linefill", dra_linefill)
-        dra_reach_km = solver_result.get("final_dra_reach", dra_reach_km)
-
-        _render_solver_feedback(
-            {"warnings": solver_result.get("warnings", [])},
-            include_warnings=True,
-            show_error=False,
-        )
-
-        hourly_errors = solver_result.get("hourly_errors", [])
-        if isinstance(hourly_errors, Sequence) and not isinstance(hourly_errors, (str, bytes)):
-            for err in hourly_errors:
-                if not isinstance(err, Mapping):
-                    continue
-                err_msg = str(err.get("message", "") or "").strip()
-                if not err_msg:
-                    continue
-                try:
-                    hour_val = int(err.get("hour", 0))
-                except (TypeError, ValueError):
-                    hour_val = 0
-                st.warning(f"{hour_val % 24:02d}:00 – {err_msg}")
-
-        if error_msg:
-            st.session_state["linefill_next_day"] = pd.DataFrame()
-            if reports:
-                last_hour = reports[-1].get("time")
-                if last_hour is not None:
-                    st.info(
-                        f"Optimization stopped early after {int(last_hour) % 24:02d}:00. "
-                        "Partial results are displayed for completed hours."
-                    )
-            else:
-                st.info("Optimization failed before any hourly result was produced.")
-            st.error(error_msg)
-
-        if solver_result.get("backtracked"):
-            warn_msg = _build_enforced_origin_warning(
-                solver_result.get("backtrack_notes"),
-                solver_result.get("enforced_origin_actions"),
-            )
-            st.warning(
-                warn_msg
-                + " Please avoid zero DRA requests at the origin when planning sequential hours."
-            )
-
-        st.session_state["linefill_next_day"] = _get_linefill_snapshot_for_hour(
-            linefill_snaps,
-            hours,
-            target_hour=6,
-        )
-
-        # Build a consolidated station-wise table with flow pattern names
-        station_tables = []
-        for rec in reports:
-            res = rec["result"]
-            hr = rec["time"]
-            df_int = build_station_table(res, stations_base)
-            # Insert human-readable pattern and time columns
-            pattern = res.get('flow_pattern_name', '')
-            df_int.insert(0, "Pattern", pattern)
-            df_int.insert(0, "Time", f"{hr:02d}:00")
-            station_tables.append(df_int)
-        if station_tables:
-            df_day = pd.concat(station_tables, ignore_index=True).fillna(0.0).round(2)
-        else:
-            df_day = pd.DataFrame()
-
-        # Ensure numeric columns are typed as numeric to avoid conversion errors when styling
-        # Pandas may treat some columns as object if they contain NaN or are newly inserted.
-        df_day_numeric = df_day.copy()
-        # Identify columns eligible for numeric styling
-        non_numeric_cols = {"Time", "Station", "Pump Name", "Pattern", "DRA Profile (km@ppm)"}
-        num_cols = [c for c in df_day_numeric.columns if c not in non_numeric_cols]
-        for c in num_cols:
-            df_day_numeric[c] = pd.to_numeric(df_day_numeric[c], errors="coerce").fillna(0.0)
-
-        # Persist results for reuse across Streamlit reruns
-        st.session_state["day_df"] = df_day_numeric
-        st.session_state["day_df_raw"] = df_day
-        st.session_state["day_reports"] = reports
-        st.session_state["day_linefill_snaps"] = linefill_snaps
-        st.session_state["day_hours"] = hours
-        st.session_state["day_stations"] = stations_base
 
     if st.session_state.get("run_mode") in ("hourly", "daily") and st.session_state.get("day_df") is not None:
         df_day_numeric = st.session_state["day_df"]

--- a/tests/test_dra_utils_rounding.py
+++ b/tests/test_dra_utils_rounding.py
@@ -1,11 +1,11 @@
-"""Tests for drag-reducer interpolation helpers."""
+"""Tests for Burger-equation drag reducer helpers."""
 
 from __future__ import annotations
 
+import math
 import sys
 from pathlib import Path
 
-import pandas as pd
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,37 +15,51 @@ if str(ROOT) not in sys.path:
 from dra_utils import get_ppm_for_dr
 
 
-def _sample_curve() -> dict[float, pd.DataFrame]:
-    """Return a minimal drag-reducer curve for testing."""
+VELOCITY_MPS = 1.5
+DIAMETER_M = 0.7
+VISCOSITY_CST = 3.0
 
-    df = pd.DataFrame(
-        {
-            "%Drag Reduction": [0.0, 5.0, 10.0],
-            "PPM": [0.0, 3.18, 6.0],
-        }
-    )
-    return {3.0: df}
+
+def _expected_ppm(dr_percent: float) -> float:
+    """Compute the unrounded ppm from the Burger equation."""
+
+    k1 = 0.1644
+    k2 = -0.04705
+    ft_per_m = 3.28083989501312
+    velocity_ft_s = VELOCITY_MPS * ft_per_m
+    diameter_ft = DIAMETER_M * ft_per_m
+    exponent = 2.0 * ((dr_percent / 100.0) - k2) / k1
+    return math.exp(exponent) * VISCOSITY_CST * (diameter_ft ** 0.2) / velocity_ft_s
 
 
 def test_get_ppm_for_dr_ceils_to_next_whole_ppm() -> None:
-    """Ensure default rounding never rounds required ppm down."""
+    """Default rounding should ceil to the next whole ppm."""
 
-    data = _sample_curve()
-    result = get_ppm_for_dr(3.0, 5.0, dra_curve_data=data)
-    assert result == pytest.approx(4.0)
+    raw_value = _expected_ppm(5.0)
+    assert raw_value < math.ceil(raw_value)
+    result = get_ppm_for_dr(VISCOSITY_CST, 5.0, VELOCITY_MPS, DIAMETER_M)
+    assert result == pytest.approx(math.ceil(raw_value))
 
 
 def test_get_ppm_for_dr_honours_custom_rounding_step() -> None:
-    """A configurable increment should use ceiling to the next multiple."""
+    """A custom rounding increment should ceil to that increment."""
 
-    data = _sample_curve()
-    result = get_ppm_for_dr(3.0, 5.0, dra_curve_data=data, rounding_step=0.5)
-    assert result == pytest.approx(3.5)
+    raw_value = _expected_ppm(10.0)
+    assert 4.0 < raw_value < 5.0
+    result = get_ppm_for_dr(
+        VISCOSITY_CST,
+        10.0,
+        VELOCITY_MPS,
+        DIAMETER_M,
+        rounding_step=0.5,
+    )
+    assert result == pytest.approx(4.5)
 
 
-def test_get_ppm_for_dr_rounds_fractional_interpolations_upwards() -> None:
-    """Interpolated values that fall between integers round up."""
+def test_get_ppm_for_dr_rounds_fractional_values_upwards() -> None:
+    """Fractional raw values must round up rather than down."""
 
-    data = _sample_curve()
-    interpolated = get_ppm_for_dr(3.0, 7.0, dra_curve_data=data)
-    assert interpolated == pytest.approx(5.0)
+    raw_value = _expected_ppm(11.0)
+    assert 4.8 < raw_value < 5.0
+    result = get_ppm_for_dr(VISCOSITY_CST, 11.0, VELOCITY_MPS, DIAMETER_M)
+    assert result == pytest.approx(5.0)

--- a/tests/test_optimized_scheduler.py
+++ b/tests/test_optimized_scheduler.py
@@ -139,7 +139,9 @@ def test_solve_for_hour_returns_hour_result():
     hour_result = solve_for_hour(config, 0, cfg=SchedulerConfig())
     assert isinstance(hour_result, HourResult)
     assert hour_result.feasible
-    assert hour_result.pump_settings
+    assert hour_result.rows
+    assert hour_result.cost_currency is not None
+    assert hour_result.legacy_payload.get("pump_settings")
 
 
 def test_profile_solver_reports_functions():

--- a/tests/test_optimized_scheduler.py
+++ b/tests/test_optimized_scheduler.py
@@ -1,0 +1,126 @@
+import math
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from optimized_scheduler import (
+    PipelineConfig,
+    Pump,
+    Station,
+    compute_flow,
+    pump_cost,
+    refine_search,
+    solve_for_hour,
+    solve_pipeline,
+    solve_station,
+    profile_solver,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_caches():
+    compute_flow.cache_clear()
+    pump_cost.cache_clear()
+    yield
+    compute_flow.cache_clear()
+    pump_cost.cache_clear()
+
+
+def _simple_station(name: str) -> Station:
+    pump = Pump(
+        type_id=f"pump_{name}",
+        rpm_range=tuple(range(900, 1301, 100)),
+        dr_range=(0, 10, 20),
+        flow_gain=0.15,
+        base_flow=5.0,
+        cost_coeff=0.02,
+        base_cost=1.0,
+        dra_penalty=0.25,
+    )
+    return Station(name=name, pumps=(pump,))
+
+
+def test_solve_station_branch_and_bound_matches_naive():
+    station = _simple_station("A")
+    flow_in = 100.0
+    best_cost, config = solve_station(station, flow_in)
+
+    # Brute-force evaluation for comparison.
+    naive_results = []
+    for rpm in station.pumps[0].rpm_range:
+        new_flow = compute_flow(station.pumps[0], rpm, flow_in)
+        for dr in station.pumps[0].dr_range:
+            cost = pump_cost(station.pumps[0], new_flow, dr)
+            naive_results.append((cost, (rpm, dr)))
+    expected_cost, expected_config = min(naive_results, key=lambda item: item[0])
+
+    assert math.isclose(best_cost, expected_cost, rel_tol=1e-9)
+    assert config[0] == expected_config
+
+
+def test_pump_cost_and_flow_are_cached():
+    station = _simple_station("Cache")
+    pump = station.pumps[0]
+
+    compute_flow(pump, 1000, 120.0)
+    compute_flow(pump, 1000, 120.0)
+    info = compute_flow.cache_info()
+    assert info.hits >= 1
+
+    pump_cost(pump, 150.0, 10)
+    pump_cost(pump, 150.0, 10)
+    cost_info = pump_cost.cache_info()
+    assert cost_info.hits >= 1
+
+
+def test_solve_pipeline_parallelises_by_hour(monkeypatch):
+    stations = (_simple_station("A"), _simple_station("B"))
+    config = PipelineConfig(stations=stations, inlet_flow=(100.0, 120.0, 150.0), hours=3)
+
+    calls = []
+
+    class DummyFuture:
+        def __init__(self, value):
+            self._value = value
+
+        def result(self):
+            return self._value
+
+    class DummyExecutor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def submit(self, func, *args, **kwargs):
+            calls.append((func, args))
+            return DummyFuture(func(*args, **kwargs))
+
+    monkeypatch.setattr("optimized_scheduler.concurrent.futures.ProcessPoolExecutor", DummyExecutor)
+    monkeypatch.setattr("optimized_scheduler.concurrent.futures.as_completed", lambda futures: futures)
+
+    results = solve_pipeline(config, parallel=True)
+
+    assert len(results) == 3
+    assert all(call[0] is solve_for_hour for call in calls)
+
+
+def test_refine_search_locates_minimum():
+    func = lambda x: (x - 4.0) ** 2
+    result = refine_search(func, 0.0, 10.0, steps=6, iterations=4)
+    assert abs(result - 4.0) < 0.5
+
+
+def test_profile_solver_reports_functions():
+    stations = (_simple_station("A"),)
+    config = PipelineConfig(stations=stations, inlet_flow=(100.0,), hours=1)
+    stats_output = profile_solver(config, limit=5)
+    assert "solve_for_hour" in stats_output
+

--- a/tests/test_optimized_scheduler.py
+++ b/tests/test_optimized_scheduler.py
@@ -7,12 +7,16 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import pytest
 
 from optimized_scheduler import (
+    DayResult,
+    HourResult,
     PipelineConfig,
     Pump,
+    SchedulerConfig,
     Station,
     compute_flow,
     pump_cost,
     refine_search,
+    solve_day,
     solve_for_hour,
     solve_pipeline,
     solve_station,
@@ -46,7 +50,7 @@ def _simple_station(name: str) -> Station:
 def test_solve_station_branch_and_bound_matches_naive():
     station = _simple_station("A")
     flow_in = 100.0
-    best_cost, config = solve_station(station, flow_in)
+    result = solve_station(station, flow_in, cfg=SchedulerConfig())
 
     # Brute-force evaluation for comparison.
     naive_results = []
@@ -57,8 +61,9 @@ def test_solve_station_branch_and_bound_matches_naive():
             naive_results.append((cost, (rpm, dr)))
     expected_cost, expected_config = min(naive_results, key=lambda item: item[0])
 
-    assert math.isclose(best_cost, expected_cost, rel_tol=1e-9)
-    assert config[0] == expected_config
+    assert result.feasible
+    assert math.isclose(result.cost, expected_cost, rel_tol=1e-9)
+    assert result.config[0] == expected_config
 
 
 def test_pump_cost_and_flow_are_cached():
@@ -74,6 +79,14 @@ def test_pump_cost_and_flow_are_cached():
     pump_cost(pump, 150.0, 10)
     cost_info = pump_cost.cache_info()
     assert cost_info.hits >= 1
+
+
+def test_solve_station_respects_dra_cap():
+    station = _simple_station("Cap")
+    cfg = SchedulerConfig(dra_cap_percent=5.0)
+    result = solve_station(station, 100.0, cfg=cfg)
+    assert result.feasible
+    assert result.max_dr_percent <= cfg.dra_cap_percent + 1e-9
 
 
 def test_solve_pipeline_parallelises_by_hour(monkeypatch):
@@ -106,9 +119,11 @@ def test_solve_pipeline_parallelises_by_hour(monkeypatch):
     monkeypatch.setattr("optimized_scheduler.concurrent.futures.ProcessPoolExecutor", DummyExecutor)
     monkeypatch.setattr("optimized_scheduler.concurrent.futures.as_completed", lambda futures: futures)
 
-    results = solve_pipeline(config, parallel=True)
+    results, backend = solve_pipeline(config, parallel=True, cfg=SchedulerConfig())
 
+    assert backend in {"process", "thread"}
     assert len(results) == 3
+    assert all(isinstance(res, HourResult) for res in results)
     assert all(call[0] is solve_for_hour for call in calls)
 
 
@@ -118,9 +133,33 @@ def test_refine_search_locates_minimum():
     assert abs(result - 4.0) < 0.5
 
 
+def test_solve_for_hour_returns_hour_result():
+    station = _simple_station("A")
+    config = PipelineConfig(stations=(station,), inlet_flow=(100.0,), hours=1)
+    hour_result = solve_for_hour(config, 0, cfg=SchedulerConfig())
+    assert isinstance(hour_result, HourResult)
+    assert hour_result.feasible
+    assert hour_result.pump_settings
+
+
 def test_profile_solver_reports_functions():
     stations = (_simple_station("A"),)
     config = PipelineConfig(stations=stations, inlet_flow=(100.0,), hours=1)
     stats_output = profile_solver(config, limit=5)
     assert "solve_for_hour" in stats_output
+
+
+def test_solve_day_wraps_pipeline_results():
+    station = _simple_station("A")
+    case = {"stations": [station], "inlet_flow": [100.0], "hours": 2}
+    cfg = SchedulerConfig(parallel_hours=False)
+    progress_calls = []
+
+    def progress(kind, **kw):
+        progress_calls.append((kind, kw))
+
+    day = solve_day(case, cfg, terminal_min_residual_m=50.0, progress_callback=progress)
+    assert isinstance(day, DayResult)
+    assert len(day.hours) == 2
+    assert progress_calls, "Expected progress callbacks"
 

--- a/tests/test_optimized_scheduler.py
+++ b/tests/test_optimized_scheduler.py
@@ -143,6 +143,8 @@ def test_solve_for_hour_returns_hour_result():
     assert hour_result.cost_currency is not None
     assert hour_result.pump_settings
     assert hour_result.legacy_payload.get("pump_settings")
+    assert hour_result.hour == 7
+    assert hour_result.hour_index == 0
 
 
 def test_profile_solver_reports_functions():

--- a/tests/test_optimized_scheduler.py
+++ b/tests/test_optimized_scheduler.py
@@ -141,6 +141,7 @@ def test_solve_for_hour_returns_hour_result():
     assert hour_result.feasible
     assert hour_result.rows
     assert hour_result.cost_currency is not None
+    assert hour_result.pump_settings
     assert hour_result.legacy_payload.get("pump_settings")
 
 


### PR DESCRIPTION
## Summary
- add a standalone `optimized_scheduler` module that normalises pump/station data and applies branch-and-bound search with cached hydraulic calculations
- support adaptive RPM refinement, per-hour parallel solving, and profiling helpers to monitor performance
- cover the new behaviour with dedicated unit tests for caching, pruning correctness, parallel execution, refinement, and profiling output

## Testing
- pytest tests/test_optimized_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68e541d2d1548331bf8020a63dac6c95