### PR TITLE
Fix Burger equation application in DRA helpers

### DIFF
--- a/dra_utils.py
+++ b/dra_utils.py
@@ -76,7 +76,7 @@ def _compute_drag_reduction(visc: float, ppm: float, velocity_mps: float, diamet
         return 0.0
 
     try:
-        dr_fraction = 0.5 * K1 * math.log(argument) + K2
+        dr_fraction = K1 * math.log(argument) + K2
     except (ValueError, OverflowError):
         return 0.0
     if not math.isfinite(dr_fraction):
@@ -112,7 +112,7 @@ def _ppm_for_dr_cached(visc: float, dr_percent: float, velocity_mps: float, diam
         return 0.0
 
     dr_fraction = dr_val / 100.0
-    exponent = 2.0 * (dr_fraction - K2) / K1
+    exponent = (dr_fraction - K2) / K1
     try:
         argument = math.exp(exponent)
     except OverflowError:
@@ -150,7 +150,7 @@ def _dr_for_ppm_cached(visc: float, ppm: float, velocity_mps: float, diameter_m:
         return 0.0
 
     try:
-        dr_fraction = 0.5 * K1 * math.log(argument) + K2
+        dr_fraction = K1 * math.log(argument) + K2
     except (ValueError, OverflowError):
         return 0.0
     if not math.isfinite(dr_fraction):

--- a/tests/test_dra_utils_rounding.py
+++ b/tests/test_dra_utils_rounding.py
@@ -28,27 +28,27 @@ def _expected_ppm(dr_percent: float) -> float:
     ft_per_m = 3.28083989501312
     velocity_ft_s = VELOCITY_MPS * ft_per_m
     diameter_ft = DIAMETER_M * ft_per_m
-    exponent = 2.0 * ((dr_percent / 100.0) - k2) / k1
+    exponent = ((dr_percent / 100.0) - k2) / k1
     return math.exp(exponent) * VISCOSITY_CST * (diameter_ft ** 0.2) / velocity_ft_s
 
 
 def test_get_ppm_for_dr_ceils_to_next_whole_ppm() -> None:
     """Default rounding should ceil to the next whole ppm."""
 
-    raw_value = _expected_ppm(5.0)
-    assert raw_value < math.ceil(raw_value)
-    result = get_ppm_for_dr(VISCOSITY_CST, 5.0, VELOCITY_MPS, DIAMETER_M)
+    raw_value = _expected_ppm(15.0)
+    assert 2.0 < raw_value < 3.0
+    result = get_ppm_for_dr(VISCOSITY_CST, 15.0, VELOCITY_MPS, DIAMETER_M)
     assert result == pytest.approx(math.ceil(raw_value))
 
 
 def test_get_ppm_for_dr_honours_custom_rounding_step() -> None:
     """A custom rounding increment should ceil to that increment."""
 
-    raw_value = _expected_ppm(10.0)
-    assert 4.0 < raw_value < 5.0
+    raw_value = _expected_ppm(25.0)
+    assert 4.0 < raw_value < 4.5
     result = get_ppm_for_dr(
         VISCOSITY_CST,
-        10.0,
+        25.0,
         VELOCITY_MPS,
         DIAMETER_M,
         rounding_step=0.5,
@@ -59,7 +59,7 @@ def test_get_ppm_for_dr_honours_custom_rounding_step() -> None:
 def test_get_ppm_for_dr_rounds_fractional_values_upwards() -> None:
     """Fractional raw values must round up rather than down."""
 
-    raw_value = _expected_ppm(11.0)
-    assert 4.8 < raw_value < 5.0
-    result = get_ppm_for_dr(VISCOSITY_CST, 11.0, VELOCITY_MPS, DIAMETER_M)
-    assert result == pytest.approx(5.0)
+    raw_value = _expected_ppm(20.0)
+    assert 3.0 < raw_value < 4.0
+    result = get_ppm_for_dr(VISCOSITY_CST, 20.0, VELOCITY_MPS, DIAMETER_M)
+    assert result == pytest.approx(4.0)


### PR DESCRIPTION
## Summary
- remove the erroneous 0.5 multiplier that was being applied to the Burger equation in the drag reducer utilities
- update the ppm exponent derivation so the inverse Burger calculation now mirrors the provided formula
- refresh the rounding tests to validate the corrected ppm magnitudes while keeping the same rounding guarantees

## Testing
- pytest tests/test_dra_utils_rounding.py
- pytest tests/test_linefill_dra.py tests/test_dra_slug_transition.py

------
https://chatgpt.com/codex/tasks/task_e_68e761ae8078833193b772334c6e82bc