### PR TITLE
Ensure DRA floor ppm always derives from Burger equation

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2153,7 +2153,7 @@ def compute_minimum_lacing_requirement(
     discharge head (SDH) at design flow, and compares that against the head the
     station can produce when all pump combinations operate at their DOL speed.
     Whenever the available head is insufficient the required drag reduction is
-    computed from ``%DR = 100 * (\Delta SDH / head_loss_friction)`` so that only
+    computed from ``%DR = 100 * (Δ SDH / head_loss_friction)`` so that only
     the frictional component is reduced.  The upstream suction reserve defaults
     to ``min_suction_head`` (rather than any per-station overrides) and the
     available discharge head is capped by the lower of the design MAOP and the

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -5493,7 +5493,7 @@ def _execute_time_series_solver(
                 pump_shear_rate=pump_shear_rate,
                 forced_origin_detail=forced_detail_effective,
                 segment_floors=segment_floor_payload,
-                apply_baseline_detail=False,
+                apply_baseline_detail=bool(baseline_for_enforcement),
             )
 
             _ensure_result_dra_floor(

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -6,6 +6,10 @@ import math
 import re
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
+# Avoid exhausting inotify watchers on constrained systems by falling back to
+# Streamlit's polling-based file watcher before importing Streamlit itself.
+os.environ.setdefault("STREAMLIT_SERVER_FILE_WATCHER_TYPE", "poll")
+
 import streamlit as st
 import altair as alt
 import pipeline_model

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -3974,6 +3974,7 @@ def solve_pipeline(
     segment_floors: list[dict] | tuple[dict, ...] | None = None,
     *,
     apply_baseline_detail: bool = True,
+    reload_module: bool = True,
 ):
     """Wrapper around :mod:`pipeline_model` with origin pump enforcement."""
 
@@ -3981,7 +3982,9 @@ def solve_pipeline(
     import importlib
     import copy
 
-    importlib.reload(pipeline_model)
+    pipeline_mod = pipeline_model
+    if reload_module:
+        pipeline_mod = importlib.reload(pipeline_model)
 
     stations = copy.deepcopy(stations)
     first_pump = next((s for s in stations if s.get('is_pump')), None)
@@ -4011,7 +4014,7 @@ def solve_pipeline(
 
     baseline_requirement: dict | None = None
     try:
-        baseline_requirement = pipeline_model.compute_minimum_lacing_requirement(
+        baseline_requirement = pipeline_mod.compute_minimum_lacing_requirement(
             stations,
             terminal,
             max_flow_m3h=float(baseline_flow),
@@ -4229,7 +4232,7 @@ def solve_pipeline(
         # Delegate to the backend optimiser
         search_kwargs = _collect_search_depth_kwargs()
         if any(s.get('pump_types') for s in stations):
-            res = pipeline_model.solve_pipeline_with_types(
+            res = pipeline_mod.solve_pipeline_with_types(
                 stations,
                 terminal,
                 FLOW,
@@ -4251,7 +4254,7 @@ def solve_pipeline(
                 **search_kwargs,
             )
         else:
-            res = pipeline_model.solve_pipeline(
+            res = pipeline_mod.solve_pipeline(
                 stations,
                 terminal,
                 FLOW,
@@ -4416,6 +4419,7 @@ if auto_batch:
                         st.session_state.get("Ambient_temp", 25.0),
                         {},
                         pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                        reload_module=False,
                     )
                     row = {"Scenario": f"100% {product_table.iloc[0]['Product']}, 0% {product_table.iloc[1]['Product']}"}
                     for idx, stn in enumerate(stations_data, start=1):
@@ -4450,6 +4454,7 @@ if auto_batch:
                         st.session_state.get("Ambient_temp", 25.0),
                         {},
                         pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                        reload_module=False,
                     )
                     row = {"Scenario": f"0% {product_table.iloc[0]['Product']}, 100% {product_table.iloc[1]['Product']}"}
                     for idx, stn in enumerate(stations_data, start=1):
@@ -4495,6 +4500,7 @@ if auto_batch:
                             st.session_state.get("Ambient_temp", 25.0),
                             {},
                             pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                            reload_module=False,
                         )
                         row = {"Scenario": f"{pct_A}% {product_table.iloc[0]['Product']}, {pct_B}% {product_table.iloc[1]['Product']}"}
                         for idx, stn in enumerate(stations_data, start=1):
@@ -4534,6 +4540,7 @@ if auto_batch:
                             st.session_state.get("Ambient_temp", 25.0),
                             {},
                             pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                            reload_module=False,
                         )
                         for idx, stn in enumerate(stations_data, start=1):
                             key = stn['name'].lower().replace(' ', '_')
@@ -4586,6 +4593,7 @@ if auto_batch:
                             st.session_state.get("Ambient_temp", 25.0),
                             {},
                             pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                            reload_module=False,
                         )
                         for idx, stn in enumerate(stations_data, start=1):
                             key = stn['name'].lower().replace(' ', '_')
@@ -5573,6 +5581,7 @@ def _execute_time_series_solver(
                 forced_origin_detail=forced_detail_effective,
                 segment_floors=segment_floor_payload,
                 apply_baseline_detail=bool(baseline_for_enforcement),
+                reload_module=False,
             )
 
             _ensure_result_dra_floor(
@@ -8686,6 +8695,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                         st.session_state.get("Ambient_temp", 25.0),
                         this_linefill_df.to_dict(),
                         pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                        reload_module=False,
                     )
                     total_cost = power_cost = dra_cost = rh = eff = 0
                     for idx, stn in enumerate(stations_data):
@@ -8828,6 +8838,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     st.session_state.get("Ambient_temp", 25.0),
                     linefill_df.to_dict(),
                     pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                    reload_module=False,
                 )
                 total_cost, new_cost = 0, 0
                 for idx, stn in enumerate(stations_data):

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -2,6 +2,7 @@ import contextlib
 import copy
 import json
 import math
+import os
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -74,6 +75,21 @@ def solve_pipeline_with_types(*args, segment_slices=None, **kwargs):
     elif segment_slices is not None and "segment_slices" not in kwargs:
         kwargs["segment_slices"] = segment_slices
     return _solve_pipeline_with_types(*args, **kwargs)
+
+
+def test_app_sets_streamlit_file_watcher_to_poll(monkeypatch):
+    import importlib
+    import sys
+
+    monkeypatch.delenv("STREAMLIT_SERVER_FILE_WATCHER_TYPE", raising=False)
+    sys.modules.pop("pipeline_optimization_app", None)
+
+    import pipeline_optimization_app  # noqa: F401
+
+    assert os.environ.get("STREAMLIT_SERVER_FILE_WATCHER_TYPE") == "poll"
+
+    importlib.reload(pipeline_optimization_app)
+    assert os.environ.get("STREAMLIT_SERVER_FILE_WATCHER_TYPE") == "poll"
 
 
 def test_segment_hydraulics_cache_hits():

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -1563,6 +1563,70 @@ def test_segment_floor_ppm_map_handles_global_floor():
     entry = floor_entries[0]
     assert int(entry["station_idx"]) == 0
     assert entry["dra_ppm"] == pytest.approx(13.0)
+    assert entry["dra_ppm_exact"] == pytest.approx(13.0)
+    assert entry["length_km"] == pytest.approx(0.0)
+
+
+def test_segment_floor_ppm_map_overrides_inflated_ppm_strings():
+    import pipeline_optimization_app as app
+    from dra_utils import get_ppm_for_dr
+
+    stations = [
+        {
+            "name": "Paradip",
+            "D": 0.762,
+            "t": 0.0079248,
+            "max_dr": 30.0,
+        },
+        {
+            "name": "Balasore",
+            "D": 0.762,
+            "t": 0.0079248,
+            "max_dr": 30.0,
+        },
+    ]
+
+    baseline = {
+        "segments": [
+            {
+                "station_idx": 0,
+                "length_km": 158.0,
+                "dra_ppm": "162 ppm",
+                "dra_perc": 24.77987421383648,
+                "has_dra_facility": True,
+            },
+            {
+                "station_idx": 1,
+                "length_km": 170.0,
+                "dra_ppm": "104 ppm",
+                "dra_perc": 26.168224299065418,
+                "has_dra_facility": True,
+            },
+        ]
+    }
+
+    floor_entries = app._segment_floor_ppm_map(
+        baseline,
+        stations,
+        baseline_flow_m3h=3169.0,
+        baseline_visc_cst=15.0,
+    )
+
+    assert len(floor_entries) == 2
+
+    def _expected_ppm(seg_idx: int, perc: float) -> float:
+        diameter = stations[seg_idx]["D"] - 2 * stations[seg_idx]["t"]
+        velocity = app._flow_velocity_mps(3169.0, diameter)
+        return get_ppm_for_dr(15.0, perc, velocity, diameter)
+
+    first, second = floor_entries
+    exp_first = _expected_ppm(0, 24.77987421383648)
+    exp_second = _expected_ppm(1, 26.168224299065418)
+
+    assert first["dra_ppm_exact"] == pytest.approx(exp_first)
+    assert first["dra_ppm"] == pytest.approx(math.ceil(exp_first))
+    assert second["dra_ppm_exact"] == pytest.approx(exp_second)
+    assert second["dra_ppm"] == pytest.approx(math.ceil(exp_second))
 
 
 def test_compute_and_store_segment_floor_map_preserves_segments():
@@ -1625,6 +1689,76 @@ def test_compute_and_store_segment_floor_map_preserves_segments():
         0: pytest.approx(26.0),
         1: pytest.approx(14.0),
     }
+
+
+def test_compute_and_store_segment_floor_map_accepts_string_floors():
+    import pipeline_optimization_app as app
+    import streamlit as st
+
+    st.session_state.clear()
+
+    stations = [
+        {
+            "name": "Paradip",
+            "D": 0.762,
+            "t": 0.0079248,
+            "max_dr": 30.0,
+            "is_pump": True,
+        },
+        {
+            "name": "Balasore",
+            "D": 0.762,
+            "t": 0.0079248,
+            "max_dr": 30.0,
+            "is_pump": True,
+        },
+    ]
+
+    baseline_req = {
+        "segments": [
+            {
+                "station_idx": 0,
+                "length_km": "158 km",
+                "dra_ppm": "17.770130549595464 → 18 ppm",
+                "dra_ppm_unrounded": "17.770130549595464",
+                "dra_perc": "24.77987421383648%",
+                "has_dra_facility": True,
+            },
+            {
+                "station_idx": 1,
+                "length_km": "170 km",
+                "dra_ppm": "29.174453357539754 → 30 ppm",
+                "dra_ppm_unrounded": "29.174453357539754",
+                "dra_perc": "28.85514018691589%",
+                "has_dra_facility": True,
+            },
+        ]
+    }
+
+    floor_map = app.compute_and_store_segment_floor_map(
+        stations=stations,
+        global_inputs={
+            "baseline_requirement": baseline_req,
+            "baseline_flow_m3h": 3169.0,
+            "baseline_visc_cst": 15.0,
+        },
+        show_banner=False,
+    )
+
+    assert floor_map == {0: pytest.approx(18.0), 1: pytest.approx(30.0)}
+    stored = st.session_state.get("minimum_dra_floor_segments_raw")
+    assert isinstance(stored, list) and len(stored) == 2
+    assert stored[0]["dra_ppm"] == pytest.approx(18.0)
+    assert stored[0]["dra_ppm_exact"] == pytest.approx(17.770130549595464)
+    assert stored[1]["dra_ppm"] == pytest.approx(30.0)
+    assert stored[1]["dra_ppm_exact"] == pytest.approx(29.174453357539754)
+
+
+def test_coerce_positive_float_handles_large_arrow_targets():
+    import pipeline_optimization_app as app
+
+    assert app._coerce_positive_float("18 ppm → 162 ppm") == pytest.approx(18.0)
+    assert app._coerce_positive_float("17.770130549595464 → 18") == pytest.approx(18.0)
 
 
 def test_render_minimum_dra_floor_hint_uses_segment_details(monkeypatch):
@@ -2883,6 +3017,151 @@ def test_time_series_solver_enforces_when_head_untreated(monkeypatch):
     assert any(hour == 1 and ppm > 0.0 for hour, ppm in call_log)
 
 
+def test_time_series_solver_accepts_segment_index_segments(monkeypatch):
+    import pipeline_optimization_app as app
+    import streamlit as st
+
+    st.session_state.clear()
+
+    stations_base = [
+        {
+            "name": "Station A",
+            "is_pump": True,
+            "L": 12.0,
+            "D": 0.7,
+            "t": 0.007,
+            "max_pumps": 1,
+            "pump_names": ["Pump A1"],
+        },
+        {
+            "name": "Station B",
+            "is_pump": False,
+            "L": 18.0,
+            "D": 0.7,
+            "t": 0.007,
+        },
+    ]
+    term_data = {"name": "Terminal", "elev": 0.0, "min_residual": 10.0}
+    hours = [0]
+
+    vol_df = pd.DataFrame(
+        [
+            {
+                "Product": "Batch 1",
+                "Volume (m³)": 4000.0,
+                "Viscosity (cSt)": 2.5,
+                "Density (kg/m³)": 820.0,
+                app.INIT_DRA_COL: 0.0,
+            }
+        ]
+    )
+    vol_df = app.ensure_initial_dra_column(vol_df, default=0.0, fill_blanks=True)
+    dra_linefill = app.df_to_dra_linefill(vol_df)
+    current_vol = app.apply_dra_ppm(vol_df.copy(), dra_linefill)
+
+    baseline_segments = [
+        {
+            "segment_index": 0,
+            "length_km": 20.0,
+            "dra_ppm": 14.0,
+            "has_dra_facility": True,
+        },
+        {
+            "segment_index": 1,
+            "length_km": 18.0,
+            "dra_ppm": 6.0,
+            "has_dra_facility": True,
+        },
+    ]
+
+    st.session_state.update(
+        {
+            "stations": copy.deepcopy(stations_base),
+            "FLOW": 450.0,
+            "max_laced_flow_m3h": 450.0,
+            "max_laced_visc_cst": 3.0,
+            "max_laced_density_kgm3": 830.0,
+            "min_laced_suction_m": 0.0,
+            "RateDRA": 5.0,
+            "Price_HSD": 0.0,
+            "Fuel_density": 820.0,
+            "Ambient_temp": 25.0,
+            "MOP_kgcm2": 100.0,
+            "pump_shear_rate": 0.0,
+            "origin_lacing_baseline": {
+                "segments": copy.deepcopy(baseline_segments),
+                "enforceable": True,
+                "dra_ppm": 14.0,
+            },
+            "origin_lacing_segment_baseline": copy.deepcopy(baseline_segments),
+            "minimum_dra_floor_ppm": 14.0,
+            "minimum_dra_floor_ppm_by_segment": {0: 14.0, 1: 6.0},
+        }
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_solver(*solver_args, **solver_kwargs):
+        (
+            stations,
+            terminal,
+            flow,
+            kv_list,
+            rho_list,
+            segment_slices,
+            RateDRA,
+            Price_HSD,
+            fuel_density,
+            ambient_temp,
+            dra_linefill_in,
+            dra_reach_km,
+            mop_kgcm2,
+            *_,
+        ) = solver_args
+
+        captured["segment_floors"] = solver_kwargs.get("segment_floors")
+        captured["forced_origin_detail"] = solver_kwargs.get("forced_origin_detail")
+        return {
+            "error": False,
+            "total_cost": 9.5,
+            "linefill": copy.deepcopy(dra_linefill_in),
+            "dra_front_km": float(dra_reach_km),
+            "dra_ppm_station_a": 0.0,
+            "dra_ppm_station_b": 0.0,
+            "stations_used": copy.deepcopy(stations),
+        }
+
+    monkeypatch.setattr(app, "solve_pipeline", fake_solver)
+
+    result = app._execute_time_series_solver(
+        stations_base,
+        term_data,
+        hours,
+        flow_rate=450.0,
+        plan_df=None,
+        current_vol=current_vol,
+        dra_linefill=dra_linefill,
+        dra_reach_km=0.0,
+        RateDRA=5.0,
+        Price_HSD=0.0,
+        fuel_density=820.0,
+        ambient_temp=25.0,
+        mop_kgcm2=100.0,
+        pump_shear_rate=0.0,
+        total_length=sum(stn["L"] for stn in stations_base),
+        sub_steps=1,
+    )
+
+    floors = captured.get("segment_floors")
+    assert isinstance(floors, list) and floors
+    assert all("station_idx" in entry for entry in floors)
+    assert {entry["station_idx"] for entry in floors} == {0, 1}
+
+    report = result["reports"][0]["result"]
+    assert pytest.approx(report.get("floor_min_ppm_station_a", 0.0)) == 14.0
+    assert pytest.approx(report.get("dra_ppm_station_a", 0.0)) == 14.0
+
+
 def test_kv_rho_from_vol_returns_segment_slices() -> None:
     stations = [
         {"name": "Station A", "L": 6.0, "D": 0.7, "t": 0.007},
@@ -3156,6 +3435,70 @@ def test_solve_pipeline_enforces_baseline_with_full_shear(monkeypatch):
     forced_detail = captured.get("forced_origin_detail")
     assert isinstance(forced_detail, dict)
     assert forced_detail.get("dra_ppm") == pytest.approx(8.0)
+
+
+def test_dynamic_interval_solver_forwards_segment_floors(monkeypatch):
+    import pipeline_optimization_app as app
+
+    captured: dict[str, object] = {}
+
+    def fake_solver(*args, **kwargs):
+        captured.update(kwargs)
+        return {"linefill": [], "dra_front_km": 0.0, "error": False}
+
+    monkeypatch.setattr(app.pipeline_model, "solve_pipeline", fake_solver)
+
+    stations = [
+        {
+            "name": "Station A",
+            "L": 10.0,
+            "D": 0.7,
+            "t": 0.007,
+            "max_dr": 15.0,
+        }
+    ]
+    terminal = {"name": "Terminal", "elev": 0.0, "min_residual": 10.0}
+    kv_profile = [5.0]
+    rho_profile = [850.0]
+    segment_slices = [{"length_km": 10.0, "kv": 5.0, "rho": 850.0}]
+    baseline_segment_floors = [
+        {"station_idx": 0, "length_km": 10.0, "dra_ppm": 8.0, "dra_perc": 10.0}
+    ]
+    forced_detail = {
+        "dra_ppm": 8.0,
+        "dra_perc": 10.0,
+        "length_km": 10.0,
+        "segments": copy.deepcopy(baseline_segment_floors),
+    }
+
+    result = app._solve_dynamic_interval(
+        stations,
+        terminal,
+        1000.0,
+        kv_profile,
+        rho_profile,
+        segment_slices,
+        rate_dra=5.0,
+        diesel_price=0.0,
+        fuel_density=820.0,
+        ambient_temp=25.0,
+        dra_linefill=[],
+        dra_reach_km=200.0,
+        mop_kgcm2=90.0,
+        duration_hours=4.0,
+        pump_shear_rate=0.1,
+        baseline_segment_floors=baseline_segment_floors,
+        forced_origin_detail=forced_detail,
+    )
+
+    assert result.get("error") is False
+    forwarded_floors = captured.get("segment_floors")
+    assert isinstance(forwarded_floors, list) and forwarded_floors
+    assert forwarded_floors[0]["dra_ppm"] == pytest.approx(8.0)
+    assert forwarded_floors is not baseline_segment_floors
+    forwarded_detail = captured.get("forced_origin_detail")
+    assert forwarded_detail == forced_detail
+    assert forwarded_detail is not forced_detail
 
 
 def test_merge_segment_profiles_preserves_heterogeneity():


### PR DESCRIPTION
## Summary
- recompute per-segment DRA floor ppm from the stored drag-reduction percentages using the Burger equation so inflated ppm strings can no longer leak into the start-task floors
- translate locked DRA ppm values back into % drag reduction with the Burger equation when freezing downstream solver stations so both ppm and %DR remain consistent
- add regression coverage that feeds inflated ppm strings and confirms the segment floor mapper collapses them to the Burger-derived ppm values

## Testing
- pytest tests/test_pipeline_performance.py::test_segment_floor_ppm_map_overrides_inflated_ppm_strings tests/test_pipeline_performance.py::test_segment_floor_ppm_map_derives_from_percent

------
https://chatgpt.com/codex/tasks/task_e_68ec99738be483318e5f971424758e43