### PR TITLE
Preserve queued DRA slugs below baseline floors

### DIFF
--- a/docs/optimizer_search_explanation.txt
+++ b/docs/optimizer_search_explanation.txt
@@ -1,0 +1,82 @@
+Optimizer search depth and global optimality
+===========================================
+
+Overview
+--------
+The pipeline optimiser explores pumping and DRA schedules with a staged
+search.  Each stage (coarse, refinement, and "exhaustive") builds station
+configurations using dynamic programming.  After the solver enumerates all
+options for a station it sorts the partial solutions and prunes the list to
+keep only a limited set based on the advanced-search controls.  Because the
+pruning happens after every station expansion, the algorithm may discard an
+intermediate configuration that is temporarily more expensive yet would
+ultimately enable a cheaper downstream combination.  As a result, the solver
+cannot guarantee a true global minimum unless pruning is completely disabled,
+and the current implementation always keeps pruning to stay tractable.
+
+Pruning knobs
+-------------
+The advanced search depth settings influence how aggressively the solver
+trims partial states:
+
+* `state_top_k` limits how many station states survive at each stage.  When the
+  solver finishes evaluating a station, it keeps only the cheapest `state_top_k`
+  states for the next stage, discarding the rest.
+* `state_cost_margin` allows retaining extra states whose cost is within a
+  configurable margin of the cheapest survivor.  Any state outside this margin
+  is dropped.
+* `rpm_step`, `dra_step`, and `dp_step` affect how many discrete options are
+  generated before pruning, but the pruning still reduces the set to a manageable
+  size.
+
+Because the solver never retains every partial state, it is not an exact global
+search even when the discretisation steps are very small.
+
+Illustrative example
+--------------------
+Consider a simple two-station pipeline with one terminal:
+
+* Station A can run either Pump 1 (low cost, low head) or Pump 2 (higher cost,
+  high head).  Injecting additional DRA at A opens a cheaper downstream option
+  if Station B can run in an efficient mode.
+* Station B has two operating modes: a cheap low-head mode and a more expensive
+  high-head mode.  The low-head mode only works if Station A delivers enough
+  suction head; otherwise Station B must use the high-cost option.
+
+Suppose the solver processes stations in order (A then B) with `state_top_k = 1`
+so it keeps only the single cheapest partial state at each step:
+
+1. When evaluating Station A, Pump 1 plus minimum DRA looks cheapest because it
+   has the lowest immediate cost.  Pump 2 with extra DRA is slightly more
+   expensive at A alone, so it is pruned.
+2. Moving to Station B, the solver only sees the Pump 1 state from Station A.
+   Because that state does not provide enough suction, the low-head option at B
+   is infeasible and the solver must choose the expensive high-head mode.
+
+The globally optimal solution would have chosen Pump 2 with DRA at Station A,
+which would enable the low-cost mode at Station B, but that combination was
+pruned at Step 1.  Increasing `state_top_k` or widening `state_cost_margin`
+allows both Station A configurations to survive and gives the solver a chance to
+find the better global schedule.  Nevertheless, if the search controls remain
+restrictive the pruning logic can still eliminate the true optimum.
+
+Practical guidance
+------------------
+* To approximate a global search, increase `state_top_k` and `state_cost_margin`
+  so more partial solutions survive each stage.  This raises runtime and memory
+  usage, but it reduces the chance of pruning away the optimal path.
+* Fine discretisation (`rpm_step`, `dra_step`, `dp_step`) improves resolution but
+  does not by itself guarantee optimality; pruning still decides which
+  combinations continue through the search.
+* If a scenario is highly sensitive to intermediate pump choices, inspect the
+  solver logs for pruning messages and temporarily expand `state_top_k` to
+  confirm whether the reported solution changes.
+
+Conclusion
+----------
+The optimiser produces high-quality schedules subject to the dynamic-programming
+pruning rules.  Because pruning is integral to keeping the search tractable, the
+current design does not mathematically guarantee a global minimum for arbitrary
+advanced-depth settings.  Users who need results as close as possible to a
+global optimum should loosen the pruning thresholds and review the resulting
+solutions for stability.

--- a/docs/optimizer_search_explanation.txt
+++ b/docs/optimizer_search_explanation.txt
@@ -114,6 +114,15 @@ Practical guidance
 * **Diagnosing sensitivity.** Re-run the solver with looser settings and confirm
   that the reported cost does not change materially.  If it does, the previous
   configuration was likely pruning valuable states.
+* **Interpreting the "Search Footprint" panel.** After each solve the app now
+  reports how many combinations were generated, pruned, and retained for every
+  pass and station.  Large drops between the "Options" and "Retained" columns
+  indicate aggressive pruning, signalling that widening `state_top_k` or the
+  cost margin might be worthwhile for verification.
+* **Sensitivity badge.** When widening the DP limits leaves the cost unchanged,
+  a blue info banner appears to highlight that the optimiser explored a broader
+  search without finding a cheaper plan.  Use it as a quick confidence check
+  before sharing the results.
 
 In short, the advanced search depth panel lets you balance runtime against
 solution quality.  Smaller steps and broader pruning thresholds make the search

--- a/docs/optimizer_search_explanation.txt
+++ b/docs/optimizer_search_explanation.txt
@@ -1,82 +1,121 @@
-Optimizer search depth and global optimality
-===========================================
+Optimizer search depth explained
+================================
 
-Overview
---------
-The pipeline optimiser explores pumping and DRA schedules with a staged
-search.  Each stage (coarse, refinement, and "exhaustive") builds station
-configurations using dynamic programming.  After the solver enumerates all
-options for a station it sorts the partial solutions and prunes the list to
-keep only a limited set based on the advanced-search controls.  Because the
-pruning happens after every station expansion, the algorithm may discard an
-intermediate configuration that is temporarily more expensive yet would
-ultimately enable a cheaper downstream combination.  As a result, the solver
-cannot guarantee a true global minimum unless pruning is completely disabled,
-and the current implementation always keeps pruning to stay tractable.
+Why the optimiser needs search controls
+---------------------------------------
+The pipeline optimiser explores pumping and DRA schedules station by station
+using dynamic programming.  For every station it enumerates legal combinations
+of pump strings, speeds, bypass settings, and drag-reduction levels.  The search
+space can explode quickly, so after each enumeration the solver **prunes** the
+list of partial solutions according to the "Advanced search depth" controls in
+the app.  Pruning keeps runtime manageable, but it also means the optimiser does
+not always keep every theoretically possible path.  The settings described
+below let you decide how fine-grained the search grid is and how aggressively
+partial states are discarded.
 
-Pruning knobs
--------------
-The advanced search depth settings influence how aggressively the solver
-trims partial states:
+Glossary of parameters (plain-language view)
+-------------------------------------------
+* **Refinement RPM step** – how finely the solver slices each pump's permitted
+  speed band during the second (refinement) pass.  Smaller steps create more
+  speed options; larger steps evaluate fewer combinations.
+* **Refinement DRA step** – the step size (in % drag reduction) for mainline and
+  loop DRA grids during refinement.  The solver converts the %DR choices to PPM
+  using the viscosity table before evaluating costs.
+* **Coarse step multiplier** – the factor used to enlarge both step sizes during
+  the initial coarse pass.  A multiplier of 2.0 makes the coarse RPM and DRA
+  grids twice as wide as the refinement grids, so the first pass runs fast while
+  still scouting the full range.
+* **Max DP states retained (`state_top_k`)** – the maximum number of partial
+  states that can survive each station.  Think of this as "how many different
+  in-progress plans do we keep?"
+* **DP cost margin (`state_cost_margin`)** – how far (in currency) a partial plan
+  may be from the cheapest survivor and still be kept.  Wider margins mean more
+  slightly-worse states are preserved for later stations.
 
-* `state_top_k` limits how many station states survive at each stage.  When the
-  solver finishes evaluating a station, it keeps only the cheapest `state_top_k`
-  states for the next stage, discarding the rest.
-* `state_cost_margin` allows retaining extra states whose cost is within a
-  configurable margin of the cheapest survivor.  Any state outside this margin
-  is dropped.
-* `rpm_step`, `dra_step`, and `dp_step` affect how many discrete options are
-  generated before pruning, but the pruning still reduces the set to a manageable
-  size.
+Worked example: two stations, one hour
+--------------------------------------
+Consider a toy case with the following limits:
 
-Because the solver never retains every partial state, it is not an exact global
-search even when the discretisation steps are very small.
+* Station A allows pump speeds from 1 400 to 1 700 rpm.
+* Station B allows 1 500 to 1 800 rpm.
+* Both stations can inject between 0 % and 20 % drag reduction.
+* Advanced search depth values: RPM step = 50, DRA step = 2 %DR, coarse multiplier
+  = 2.0, `state_top_k` = 3, `state_cost_margin` = ₹ 5 000.
 
-Illustrative example
---------------------
-Consider a simple two-station pipeline with one terminal:
+### 1. Coarse pass grid
+The coarse pass multiplies the refinement step by 2.0, so the coarse RPM step is
+`50 × 2.0 = 100` rpm and the coarse DRA step is `2 × 2.0 = 4` %DR.  The allowed
+values therefore become:
 
-* Station A can run either Pump 1 (low cost, low head) or Pump 2 (higher cost,
-  high head).  Injecting additional DRA at A opens a cheaper downstream option
-  if Station B can run in an efficient mode.
-* Station B has two operating modes: a cheap low-head mode and a more expensive
-  high-head mode.  The low-head mode only works if Station A delivers enough
-  suction head; otherwise Station B must use the high-cost option.
+* Station A speeds: 1 400, 1 500, 1 600, 1 700 rpm.
+* Station B speeds: 1 500, 1 600, 1 700, 1 800 rpm.
+* DRA grid: 0, 4, 8, 12, 16, 20 %DR (each later converted to the nearest ppm).
 
-Suppose the solver processes stations in order (A then B) with `state_top_k = 1`
-so it keeps only the single cheapest partial state at each step:
+Suppose the solver evaluates all combinations for Station A and computes the
+hourly costs below (after including power and DRA chemical charges):
 
-1. When evaluating Station A, Pump 1 plus minimum DRA looks cheapest because it
-   has the lowest immediate cost.  Pump 2 with extra DRA is slightly more
-   expensive at A alone, so it is pruned.
-2. Moving to Station B, the solver only sees the Pump 1 state from Station A.
-   Because that state does not provide enough suction, the low-head option at B
-   is infeasible and the solver must choose the expensive high-head mode.
+| Option | Speed (rpm) | DRA (%DR) | Immediate hourly cost (₹) |
+| ------ | ----------- | --------- | ------------------------- |
+| A₁ | 1 400 | 4 | 95 000 |
+| A₂ | 1 500 | 8 | 97 000 |
+| A₃ | 1 600 | 0 | 100 000 |
+| A₄ | 1 700 | 12 | 104 000 |
 
-The globally optimal solution would have chosen Pump 2 with DRA at Station A,
-which would enable the low-cost mode at Station B, but that combination was
-pruned at Step 1.  Increasing `state_top_k` or widening `state_cost_margin`
-allows both Station A configurations to survive and gives the solver a chance to
-find the better global schedule.  Nevertheless, if the search controls remain
-restrictive the pruning logic can still eliminate the true optimum.
+The solver sorts the options by cost and keeps the cheapest ones subject to the
+pruning controls.  With `state_top_k = 3` and `state_cost_margin = 5 000`, the
+survivors are A₁, A₂, and A₃ (all within ₹ 5 000 of the best cost).  A₄ is
+discarded because it both exceeds the top‑3 limit and lies more than ₹ 5 000 above
+the cheapest option.
+
+When Station B is processed, the solver pairs each of the three surviving
+Station‑A states with every coarse RPM/DRA combination for B, computes the new
+hourly totals (including whatever costs were carried forward from A), and again
+prunes to the best three or those within ₹ 5 000 of the new best.  The cheapest
+survivor at the end of the coarse pass becomes the seed for the refinement pass.
+
+### 2. Refinement pass grid
+The refinement pass uses the original RPM and DRA steps (50 rpm and 2 %DR).  The
+allowed speed lists now include 1 450, 1 550, … etc., filling in the gaps between
+the coarse points.  Each surviving coarse state is re‑evaluated at this finer
+resolution, again pruning with the same `state_top_k` and `state_cost_margin`
+rules.  Because the refinement step halves the spacing, this pass can uncover a
+lower‑cost combination that sits between the coarse points—so long as the
+necessary coarse state was not pruned earlier.
+
+### 3. Exhaustive retry (same parameters, wider limits)
+If the refinement pass fails to find a feasible plan, the solver tries a final
+retry that increases the internal limits (for example by tripling
+`state_top_k`).  This pass still respects your RPM/DRA steps but allows more
+partial states to survive, improving the odds of success while remaining
+bounded.
+
+Why pruning means "not guaranteed global optimum"
+-------------------------------------------------
+Dynamic programming stores partial solutions indexed by downstream residual head
+and cost.  After each station, the solver applies the `state_top_k` and
+`state_cost_margin` filters.  Any combination that is temporarily more expensive
+than those thresholds disappears—even if it could lead to a cheaper final plan
+later.  Tightening the pruning (small `state_top_k`, narrow cost margin) speeds
+the run but risks discarding the eventual best solution.  Loosening the knobs
+keeps more possibilities but takes longer.
+
+Continuing the example, imagine that the real global optimum requires Station A
+at 1 600 rpm with 8 %DR and Station B at 1 650 rpm with 6 %DR, but the 1 600 rpm
+option cost ₹ 100 500 at Station A alone.  If `state_top_k` were set to 1 or the
+cost margin were too narrow, that option would vanish after Station A, so the
+solver would never discover the true optimum downstream.
 
 Practical guidance
 ------------------
-* To approximate a global search, increase `state_top_k` and `state_cost_margin`
-  so more partial solutions survive each stage.  This raises runtime and memory
-  usage, but it reduces the chance of pruning away the optimal path.
-* Fine discretisation (`rpm_step`, `dra_step`, `dp_step`) improves resolution but
-  does not by itself guarantee optimality; pruning still decides which
-  combinations continue through the search.
-* If a scenario is highly sensitive to intermediate pump choices, inspect the
-  solver logs for pruning messages and temporarily expand `state_top_k` to
-  confirm whether the reported solution changes.
+* **Need faster runs?** Increase the RPM/DRA steps or lower `state_top_k`; this
+  trims the search but may miss better answers.
+* **Need a more exhaustive search?** Decrease the steps, raise `state_top_k`, or
+  widen the cost margin so more near-optimal paths survive.
+* **Diagnosing sensitivity.** Re-run the solver with looser settings and confirm
+  that the reported cost does not change materially.  If it does, the previous
+  configuration was likely pruning valuable states.
 
-Conclusion
-----------
-The optimiser produces high-quality schedules subject to the dynamic-programming
-pruning rules.  Because pruning is integral to keeping the search tractable, the
-current design does not mathematically guarantee a global minimum for arbitrary
-advanced-depth settings.  Users who need results as close as possible to a
-global optimum should loosen the pruning thresholds and review the resulting
-solutions for stability.
+In short, the advanced search depth panel lets you balance runtime against
+solution quality.  Smaller steps and broader pruning thresholds make the search
+behave more like an exhaustive global optimisation, while larger steps and tight
+limits emphasise speed.

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1530,11 +1530,15 @@ def _update_mainline_dra(
         if pumped_remaining > 1e-9:
             pumped_portion.append((pumped_remaining, 0.0))
 
+    shear_existing = shear
+    if pump_running and shear_existing > 0.0 and is_origin and not apply_injection_shear:
+        shear_existing = 0.0
+
     def _apply_shear(ppm_val: float) -> float:
         ppm_float = float(ppm_val or 0.0)
         if ppm_float <= 0.0:
             return 0.0
-        if not pump_running or shear <= 0.0:
+        if not pump_running or shear_existing <= 0.0:
             return ppm_float
         dr_value = 0.0
         if kv > 0:
@@ -1543,14 +1547,14 @@ def _update_mainline_dra(
             except Exception:
                 dr_value = 0.0
         if dr_value > 0.0:
-            dr_value *= (1.0 - shear)
+            dr_value *= (1.0 - shear_existing)
             if dr_value <= 0.0:
                 return 0.0
             try:
                 return float(get_ppm_for_dr(kv, dr_value))
             except Exception:
-                return max(ppm_float * (1.0 - shear), 0.0)
-        return max(ppm_float * (1.0 - shear), 0.0)
+                return max(ppm_float * (1.0 - shear_existing), 0.0)
+        return max(ppm_float * (1.0 - shear_existing), 0.0)
 
     pumped_adjusted: list[tuple[float, float]] = []
     pumped_differs = False

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -182,6 +182,19 @@ def _station_allows_mixed_pump_types(stn: Mapping[str, object]) -> bool:
             return True
         if value in {'0', 'false', 'no', 'n', 'off'}:
             return False
+
+    pump_types = stn.get('pump_types')
+    if isinstance(pump_types, Mapping):
+        try:
+            avail_a = int(_coerce_float(pump_types.get('A', {}).get('available', 0), 0.0))
+        except Exception:
+            avail_a = 0
+        try:
+            avail_b = int(_coerce_float(pump_types.get('B', {}).get('available', 0), 0.0))
+        except Exception:
+            avail_b = 0
+        if avail_a > 0 and avail_b > 0:
+            return True
     return False
 
 
@@ -4304,7 +4317,6 @@ def solve_pipeline(
         if stn.get('is_pump', False):
             min_p = stn.get('min_pumps', 0)
             if not origin_enforced:
-                min_p = max(1, min_p)
                 origin_enforced = True
             max_p = stn.get('max_pumps', 2)
             rng = narrow_ranges.get(i - 1) if narrow_ranges else None
@@ -6160,8 +6172,6 @@ def solve_pipeline_with_types(
             allow_mixed_types = _station_allows_mixed_pump_types(stn)
             for numA, numB in combos:
                 total_units = numA + numB
-                if total_units <= 0:
-                    continue
                 if max_station_limit is not None and total_units > max_station_limit:
                     continue
                 if not allow_mixed_types and numA > 0 and numB > 0:
@@ -6170,18 +6180,17 @@ def solve_pipeline_with_types(
                 pdataB = stn['pump_types'].get('B', {})
                 for actA in range(numA + 1):
                     for actB in range(numB + 1):
-                        if actA + actB <= 0:
+                        total_active = actA + actB
+                        if max_station_limit is not None and total_active > max_station_limit:
                             continue
-                        if max_station_limit is not None and (actA + actB) > max_station_limit:
+                        if total_active < min_station_required:
                             continue
-                        if (actA + actB) < min_station_required:
+                        if not allow_mixed_types and actA > 0 and actB > 0:
                             continue
                         active_key = (actA, actB)
                         if active_key in seen_active:
                             continue
                         seen_active.add(active_key)
-                        if not allow_mixed_types and actA > 0 and actB > 0:
-                            continue
                         unit = copy.deepcopy(stn)
                         unit['pump_combo'] = {'A': availA, 'B': availB}
                         unit['active_combo'] = {'A': actA, 'B': actB}
@@ -6235,9 +6244,19 @@ def solve_pipeline_with_types(
                             unit['sfc'] = pdataA.get('sfc', unit.get('sfc', 0.0))
                             unit['sfc_mode'] = pdataA.get('sfc_mode', unit.get('sfc_mode', 'manual'))
                             unit['engine_params'] = pdataA.get('engine_params', unit.get('engine_params', {}))
-                        unit['max_pumps'] = actA + actB
-                        unit['min_pumps'] = actA + actB
+                        unit['max_pumps'] = total_active
+                        unit['min_pumps'] = total_active
                         expand_all(pos + 1, stn_acc + [unit], kv_acc + [kv], rho_acc + [rho], slices_acc + [current_slices])
+
+            if min_station_required <= 0:
+                zero_key = (0, 0)
+                if zero_key not in seen_active:
+                    unit = copy.deepcopy(stn)
+                    unit['pump_combo'] = {'A': availA, 'B': availB}
+                    unit['active_combo'] = {'A': 0, 'B': 0}
+                    unit['max_pumps'] = 0
+                    unit['min_pumps'] = 0
+                    expand_all(pos + 1, stn_acc + [unit], kv_acc + [kv], rho_acc + [rho], slices_acc + [current_slices])
         else:
             expand_all(
                 pos + 1,

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -3364,6 +3364,8 @@ def solve_pipeline(
     pass_trace: list[str] | None = None,
     forced_origin_detail: dict | None = None,
     segment_floors: list[dict] | tuple[dict, ...] | None = None,
+    telemetry: dict | None = None,
+    telemetry_pass: str | None = None,
 ) -> dict:
     """Enumerate feasible options across all stations to find the lowest-cost
     operating strategy.
@@ -3562,6 +3564,8 @@ def solve_pipeline(
                 _exhaustive_pass=_exhaustive_pass,
                 forced_origin_detail=forced_origin_detail,
                 segment_floors=segment_floors,
+                telemetry=telemetry,
+                telemetry_pass=telemetry_pass,
             )
         # Determine per-loop diameter equality flags.  For each looped
         # segment compute whether the inner diameters of the mainline and
@@ -3626,6 +3630,8 @@ def solve_pipeline(
                 _exhaustive_pass=_exhaustive_pass,
                 forced_origin_detail=forced_origin_detail,
                 segment_floors=segment_floors,
+                telemetry=telemetry,
+                telemetry_pass=telemetry_pass,
             )
             if res.get('error'):
                 continue
@@ -3706,6 +3712,9 @@ def solve_pipeline(
     # solution using the user-provided steps.  The recursion is controlled
     # by the ``_internal_pass`` flag to avoid infinite loops.
     # ------------------------------------------------------------------
+    if telemetry is not None and 'passes' not in telemetry:
+        telemetry['passes'] = {}
+
     if _internal_pass:
         pass_trace = None
     elif pass_trace is None:
@@ -3828,6 +3837,8 @@ def solve_pipeline(
                 state_cost_margin=state_cost_margin,
                 forced_origin_detail=forced_origin_detail,
                 segment_floors=segment_floors,
+                telemetry=telemetry,
+                telemetry_pass='coarse',
             )
             coarse_failed = bool(coarse_res.get("error"))
             if pass_trace is not None:
@@ -3868,6 +3879,8 @@ def solve_pipeline(
                 pass_trace=None,
                 forced_origin_detail=forced_origin_detail,
                 segment_floors=segment_floors,
+                telemetry=telemetry,
+                telemetry_pass='exhaustive',
             )
             if pass_trace is not None:
                 pass_trace.append('exhaustive')
@@ -4078,6 +4091,8 @@ def solve_pipeline(
                     state_cost_margin=min(state_cost_margin, REFINE_STATE_COST_MARGIN),
                     forced_origin_detail=forced_origin_detail,
                     segment_floors=segment_floors,
+                    telemetry=telemetry,
+                    telemetry_pass='refine',
                 )
                 if pass_trace is not None:
                     pass_trace.append('refine')
@@ -4944,6 +4959,28 @@ def solve_pipeline(
             baseline_floor.get('segments'),
         )
 
+    pass_entry: dict | None = None
+    stations_bucket: dict | None = None
+    pass_totals: dict | None = None
+    if telemetry and telemetry_pass:
+        passes_dict = telemetry.setdefault('passes', {})  # type: ignore[assignment]
+        pass_entry = passes_dict.setdefault(telemetry_pass, {})
+        stations_bucket = pass_entry.setdefault('stations', {})
+        pass_totals = pass_entry.setdefault(
+            'totals',
+            {
+                'options_generated': 0,
+                'candidates_evaluated': 0,
+                'states_created': 0,
+                'states_replaced': 0,
+                'bucket_survivors': 0,
+                'states_retained': 0,
+                'states_in': 0,
+                'runs': 0,
+            },
+        )
+        pass_totals['runs'] = pass_totals.get('runs', 0) + 1
+
     states: dict[int, dict] = {
         init_residual: {
             'cost': 0.0,
@@ -4964,6 +5001,33 @@ def solve_pipeline(
         best_by_residual: dict[int, object] = {}
         protected_counter = 0
         best_cost_station = float('inf')
+        station_stats: dict | None = None
+        if stations_bucket is not None:
+            station_name = stn_data.get('orig_name') or stn_data.get('name') or f"station_{stn_data.get('idx')}"
+            station_key = str(station_name)
+            station_stats = stations_bucket.setdefault(
+                station_key,
+                {
+                    'index': stn_data.get('idx'),
+                    'name': station_name,
+                    'runs': 0,
+                    'options_generated': 0,
+                    'states_in': 0,
+                    'candidates_evaluated': 0,
+                    'states_created': 0,
+                    'states_replaced': 0,
+                    'bucket_survivors': 0,
+                    'states_retained': 0,
+                    'pruned_after_topk': 0,
+                },
+            )
+            station_stats['runs'] = station_stats.get('runs', 0) + 1
+            options_len = len(stn_data.get('options', ()))
+            station_stats['options_generated'] += options_len
+            station_stats['states_in'] += len(states)
+            if pass_totals is not None:
+                pass_totals['options_generated'] += options_len
+                pass_totals['states_in'] += len(states)
         for state in states.values():
             flow_total = state.get('flow', segment_flows[0])
             dra_queue_prev_full = state.get('dra_queue_full')
@@ -4988,6 +5052,10 @@ def solve_pipeline(
                 d_inner_state,
             )
             for opt in stn_data['options']:
+                if station_stats is not None:
+                    station_stats['candidates_evaluated'] += 1
+                if pass_totals is not None:
+                    pass_totals['candidates_evaluated'] += 1
                 # -----------------------------------------------------------------
                 # Enforce bypass rules on loopline injection:
                 # if the previous station operated in bypass mode (Case‑G)
@@ -5764,6 +5832,14 @@ def solve_pipeline(
                         else:
                             new_states[key_to_use] = entry
                             best_by_residual[bucket] = key_to_use
+                        if station_stats is not None:
+                            station_stats['states_created'] += 1
+                            if existing is not None:
+                                station_stats['states_replaced'] += 1
+                        if pass_totals is not None:
+                            pass_totals['states_created'] += 1
+                            if existing is not None:
+                                pass_totals['states_replaced'] += 1
 
         if not new_states:
             return {"error": True, "message": f"No feasible operating point for {stn_data['orig_name']}"}
@@ -5772,6 +5848,11 @@ def solve_pipeline(
         # and globally prune to the top ``STATE_TOP_K`` states or those within
         # ``STATE_COST_MARGIN`` of the best.  This keeps the search space
         # manageable while preserving near-optimal candidates.
+        bucket_survivors = len(new_states)
+        if station_stats is not None:
+            station_stats['bucket_survivors'] += bucket_survivors
+        if pass_totals is not None:
+            pass_totals['bucket_survivors'] += bucket_survivors
         if _exhaustive_pass:
             items = sorted(new_states.items(), key=lambda kv: kv[1]['cost'])
             protected_items = [
@@ -5830,6 +5911,18 @@ def solve_pipeline(
                 if idx < state_top_k or data['cost'] <= threshold:
                     pruned[residual_key] = data
             states = pruned
+
+        if station_stats is not None:
+            station_stats['states_retained'] += len(states)
+            pruned_topk = bucket_survivors - len(states)
+            if pruned_topk > 0:
+                station_stats['pruned_after_topk'] += pruned_topk
+        if pass_totals is not None:
+            pass_totals['states_retained'] += len(states)
+            pruned_total = bucket_survivors - len(states)
+            if pruned_total > 0:
+                pass_totals.setdefault('pruned_after_topk', 0)
+                pass_totals['pruned_after_topk'] += pruned_total
 
     # Pick lowest-cost end state and, among equal-cost candidates,
     # prefer the one whose terminal residual head is closest to the
@@ -6111,6 +6204,7 @@ def solve_pipeline_with_types(
                 # Call solve_pipeline with explicit loop usage and disable
                 # internal enumeration.  This ensures the provided directives
                 # are respected even for split stations.
+                telemetry_payload: dict = {}
                 result = solve_pipeline(
                     stn_acc,
                     terminal,
@@ -6137,9 +6231,11 @@ def solve_pipeline_with_types(
                     state_cost_margin=state_cost_margin,
                     forced_origin_detail=forced_origin_detail,
                     segment_floors=segment_floors,
+                    telemetry=telemetry_payload,
                 )
                 if result.get("error"):
                     continue
+                result['search_telemetry'] = telemetry_payload
                 cost = result.get("total_cost", float('inf'))
                 if cost < best_cost:
                     # Preserve usage directive for later labelling

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -3407,7 +3407,7 @@ if auto_batch:
                 height=750,
                 plot_bgcolor='white',
             )
-            st.plotly_chart(fig, width='stretch')
+            st.plotly_chart(fig, use_container_width=True)
             st.info("Each line = one scenario. Hover to see full parameter set for each scenario.")
 else:
     st.session_state.pop('batch_df', None)
@@ -5345,7 +5345,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                 height=430,
                 margin=dict(l=0, r=0, t=40, b=0)
             )
-            st.plotly_chart(fig_grouped, width='stretch')
+            st.plotly_chart(fig_grouped, use_container_width=True)
     
             # DRA cost bar chart only ---
             st.markdown("<h4 style='font-weight:600; margin-top: 2em;'>DRA Cost</h4>", unsafe_allow_html=True)
@@ -5364,7 +5364,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                 showlegend=False,
                 margin=dict(l=0, r=0, t=30, b=0)
             )
-            st.plotly_chart(fig_dra, width='stretch')
+            st.plotly_chart(fig_dra, use_container_width=True)
     
             # --- Pie chart: Total cost distribution by station ---
             st.markdown("#### Cost Contribution by Station")
@@ -5382,7 +5382,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                 showlegend=False,
                 margin=dict(l=10, r=10, t=40, b=10)
             )
-            st.plotly_chart(fig_pie, width='stretch')
+            st.plotly_chart(fig_pie, use_container_width=True)
     
             # --- Trend line: Total cost vs. chainage ---
             st.markdown("#### Cost Accumulation Along Pipeline")
@@ -5408,7 +5408,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     font=dict(size=15),
                     height=350
                 )
-                st.plotly_chart(fig_line, width='stretch')
+                st.plotly_chart(fig_line, use_container_width=True)
     
             # --- Table: All cost heads, 2-decimal formatted ---
             df_cost_fmt = df_cost.copy()
@@ -5472,7 +5472,11 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     title="Head Loss per Segment",
                     height=400
                 )
-                st.plotly_chart(fig_h, width='stretch', key=f"perf_headloss_{uuid.uuid4().hex[:6]}")
+                st.plotly_chart(
+                    fig_h,
+                    use_container_width=True,
+                    key=f"perf_headloss_{uuid.uuid4().hex[:6]}"
+                )
                 st.dataframe(df_hloss.style.format({"Head Loss (m)": "{:.2f}"}), width='stretch', hide_index=True)
             
             # --- 2. Velocity & Reynolds ---
@@ -5510,7 +5514,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     legend=dict(font=dict(size=14)),
                     height=420
                 )
-                st.plotly_chart(fig_v, width='stretch')
+                st.plotly_chart(fig_v, use_container_width=True)
                 # Data table
                 st.dataframe(df_vel.style.format({"Velocity (m/s)":"{:.2f}", "Reynolds Number":"{:.0f}"}), width='stretch', hide_index=True)
             
@@ -5560,7 +5564,11 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                         legend=dict(font=dict(size=13)),
                         height=420
                     )
-                    st.plotly_chart(fig, width='stretch', key=f"char_curve_{i}_{key}_{uuid.uuid4().hex[:6]}")
+                    st.plotly_chart(
+                        fig,
+                        use_container_width=True,
+                        key=f"char_curve_{i}_{key}_{uuid.uuid4().hex[:6]}"
+                    )
     
             
             # --- 4. Pump Efficiency Curve (Eff vs Flow at various Speeds) ---
@@ -5608,7 +5616,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                         legend=dict(font=dict(size=13)),
                         height=420
                     )
-                    st.plotly_chart(fig, width='stretch')
+                    st.plotly_chart(fig, use_container_width=True)
             
             # --- 5. Pressure vs Pipeline Length ---
             with press_tab:
@@ -5734,7 +5742,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                 fig.update_xaxes(gridcolor="#e0e0e0", zeroline=False, showline=True, linewidth=1.5, linecolor='#1846d2', mirror=True)
                 fig.update_yaxes(gridcolor="#e0e0e0", zeroline=False, showline=True, linewidth=1.5, linecolor='#1846d2', mirror=True)
             
-                st.plotly_chart(fig, width='stretch')
+                st.plotly_chart(fig, use_container_width=True)
             
             # --- 6. Power vs Speed/Flow ---
             with power_tab:
@@ -5787,7 +5795,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                             font=dict(size=16),
                             height=400
                         )
-                        st.plotly_chart(fig_pwr, width='stretch')
+                        st.plotly_chart(fig_pwr, use_container_width=True)
                     else:
                         st.warning("DOL speed not specified; skipping Power vs Speed plot.")
                     # --- 2. Power vs Flow (various speeds) ---
@@ -5821,7 +5829,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                         font=dict(size=16),
                         height=400,
                     )
-                    st.plotly_chart(fig_pwr2, width='stretch')
+                    st.plotly_chart(fig_pwr2, use_container_width=True)
     
     # ---- Tab 4: System Curves ----
     import plotly.graph_objects as go
@@ -5898,7 +5906,11 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     margin=dict(l=10, r=10, t=60, b=30),
                     plot_bgcolor="#f5f8fc"
                 )
-                st.plotly_chart(fig_sys, width='stretch', key=f"sys_curve_{i}_{key}_{uuid.uuid4().hex[:6]}")
+                st.plotly_chart(
+                    fig_sys,
+                    use_container_width=True,
+                    key=f"sys_curve_{i}_{key}_{uuid.uuid4().hex[:6]}"
+                )
     
     
     # ---- Tab 5: Pump-System Interaction ----
@@ -6087,7 +6099,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     yaxis=dict(showgrid=True, gridwidth=1, gridcolor='rgba(80,100,230,0.13)'),
                     hovermode="closest",
                 )
-                st.plotly_chart(fig, width='stretch')
+                st.plotly_chart(fig, use_container_width=True)
     
     
     
@@ -6170,7 +6182,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     yaxis_title="% Drag Reduction",
                     legend=dict(orientation="h", y=-0.2),
                 )
-                st.plotly_chart(fig, width='stretch')
+                st.plotly_chart(fig, use_container_width=True)
             else:
                 st.info(f"No DRA applied at {stn['name']} (Optimal %DR = 0)")
     
@@ -6356,7 +6368,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
             margin=dict(l=30, r=30, b=30, t=80)
         )
     
-        st.plotly_chart(fig, width='stretch')
+        st.plotly_chart(fig, use_container_width=True)
         st.markdown("<div style='height: 40px;'></div>", unsafe_allow_html=True)
         st.markdown(
             """
@@ -6562,7 +6574,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                 )
             )
     
-            st.plotly_chart(fig3d, width='stretch')
+            st.plotly_chart(fig3d, use_container_width=True)
             st.markdown(
                 "<div style='text-align:center;color:#888;margin-top:1.1em;'>"
                 "Z-axis = Residual Head (mcl). Mesh surface interpolates between stations and peaks. <br>"
@@ -6668,7 +6680,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     progress.progress((i+1)/len(pvals))
                 fig = px.line(x=pvals, y=yvals, labels={"x": param, "y": output}, title=f"{output} vs {param} (Sensitivity)")
                 df_sens = pd.DataFrame({param: pvals, output: yvals})
-                st.plotly_chart(fig, width='stretch')
+                st.plotly_chart(fig, use_container_width=True)
                 st.dataframe(df_sens, width='stretch', hide_index=True)
                 st.download_button("Download CSV", df_sens.to_csv(index=False).encode(), file_name="sensitivity.csv")
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -37,6 +37,8 @@ if "max_laced_visc_cst" not in st.session_state:
     st.session_state["max_laced_visc_cst"] = 10.0
 if "min_laced_suction_m" not in st.session_state:
     st.session_state["min_laced_suction_m"] = 0.0
+if "laced_density_kgm3" not in st.session_state:
+    st.session_state["laced_density_kgm3"] = st.session_state.get("Fuel_density", 820.0)
 import pandas as pd
 import numpy as np
 import plotly.express as px
@@ -102,6 +104,216 @@ def ensure_initial_dra_column(
         df.loc[blank_mask, INIT_DRA_COL] = default
     return df
 
+
+def _default_segment_slices(
+    stations: list[dict], kv_list: list[float], rho_list: list[float]
+) -> list[list[dict]]:
+    """Return single-slice segment profiles for legacy distance tables."""
+
+    if not stations:
+        return []
+
+    fallback_kv = kv_list[0] if kv_list else 1.0
+    fallback_rho = rho_list[0] if rho_list else 850.0
+    slices: list[list[dict]] = []
+    for idx, stn in enumerate(stations):
+        length = float(stn.get("L", 0.0) or 0.0)
+        kv = kv_list[idx] if idx < len(kv_list) else fallback_kv
+        rho = rho_list[idx] if idx < len(rho_list) else fallback_rho
+        slices.append(
+            [
+                {
+                    "length_km": length,
+                    "kv": float(kv),
+                    "rho": float(rho),
+                }
+            ]
+        )
+    return slices
+
+
+def derive_segment_profiles(
+    linefill_df: pd.DataFrame | None, stations: list[dict]
+) -> tuple[list[float], list[float], list[list[dict]]]:
+    """Return per-segment viscosity/density lists and batch slices."""
+
+    kv_list, rho_list, segment_slices = map_linefill_to_segments(linefill_df, stations)
+    return kv_list, rho_list, segment_slices
+
+
+def map_linefill_to_segments(
+    linefill_df, stations
+) -> tuple[list[float], list[float], list[list[dict]]]:
+    """Map linefill properties onto each pipeline segment."""
+
+    if linefill_df is None or len(linefill_df) == 0:
+        kv_list = [1.0] * len(stations)
+        rho_list = [850.0] * len(stations)
+        segment_slices = _default_segment_slices(stations, kv_list, rho_list)
+        return kv_list, rho_list, segment_slices
+
+    cols = set(linefill_df.columns)
+
+    if "Start (km)" not in cols or "End (km)" not in cols:
+        if "Volume (m³)" in cols or "Volume" in cols:
+            return map_vol_linefill_to_segments(linefill_df, stations)
+        kv = float(linefill_df.iloc[-1].get("Viscosity (cSt)", 0.0))
+        rho = float(linefill_df.iloc[-1].get("Density (kg/m³)", 0.0))
+        kv_list = [kv] * len(stations)
+        rho_list = [rho] * len(stations)
+        segment_slices = _default_segment_slices(stations, kv_list, rho_list)
+        return kv_list, rho_list, segment_slices
+
+    cumlen = [0]
+    for stn in stations:
+        cumlen.append(cumlen[-1] + stn["L"])
+    viscs = []
+    dens = []
+    for i in range(len(stations)):
+        seg_start = cumlen[i]
+        seg_end = cumlen[i + 1]
+        found = False
+        for _, row in linefill_df.iterrows():
+            if row["Start (km)"] <= seg_start < row["End (km)"]:
+                viscs.append(row["Viscosity (cSt)"])
+                dens.append(row["Density (kg/m³)"])
+                found = True
+                break
+        if not found:
+            viscs.append(linefill_df.iloc[-1]["Viscosity (cSt)"])
+            dens.append(linefill_df.iloc[-1]["Density (kg/m³)"])
+    segment_slices = _default_segment_slices(stations, viscs, dens)
+    return viscs, dens, segment_slices
+
+
+def pipe_cross_section_area_m2(stations: list[dict]) -> float:
+    """Return pipe internal cross-sectional area (m²) using the first station."""
+
+    if not stations:
+        return 0.0
+    D = float(stations[0].get("D", 0.711))
+    t = float(stations[0].get("t", 0.007))
+    d_inner = max(D - 2.0 * t, 0.0)
+    return float((pi * d_inner**2) / 4.0)
+
+
+def map_vol_linefill_to_segments(
+    vol_table: pd.DataFrame | None, stations: list[dict]
+) -> tuple[list[float], list[float], list[list[dict]]]:
+    """Convert a volumetric linefill table to per-segment fluid properties."""
+
+    if not isinstance(vol_table, pd.DataFrame):
+        return derive_segment_profiles(pd.DataFrame(), stations)
+
+    if not stations:
+        return [], [], []
+
+    batches: list[dict[str, float]] = []
+    for _, r in vol_table.iterrows():
+        try:
+            vol_raw = r.get("Volume (m³)")
+        except AttributeError:
+            vol_raw = None
+        if vol_raw in (None, ""):
+            vol_raw = r.get("Volume")
+        try:
+            vol = float(vol_raw)
+        except (TypeError, ValueError):
+            vol = 0.0
+        if vol <= 0.0:
+            continue
+
+        try:
+            visc = float(r.get("Viscosity (cSt)", 0.0))
+        except (TypeError, ValueError):
+            visc = 0.0
+        try:
+            dens = float(r.get("Density (kg/m³)", 0.0))
+        except (TypeError, ValueError):
+            dens = 0.0
+
+        batches.append({"volume_m3": vol, "kv": visc, "rho": dens})
+
+    if not batches:
+        fallback_kv = 1.0
+        fallback_rho = 850.0
+        kv_list = [fallback_kv] * len(stations)
+        rho_list = [fallback_rho] * len(stations)
+        return kv_list, rho_list, _default_segment_slices(stations, kv_list, rho_list)
+
+    A = pipe_cross_section_area_m2(stations)
+    if A <= 0:
+        fallback_kv = batches[0]["kv"] if batches else 1.0
+        fallback_rho = batches[0]["rho"] if batches else 850.0
+        kv_list = [fallback_kv] * len(stations)
+        rho_list = [fallback_rho] * len(stations)
+        return kv_list, rho_list, _default_segment_slices(stations, kv_list, rho_list)
+
+    d_inner = sqrt((4.0 * A) / pi)
+    km_from_volume = pipeline_model._km_from_volume
+
+    for entry in batches:
+        entry["len_km"] = km_from_volume(entry["volume_m3"], d_inner)
+
+    # Map the volumetric batches onto each pipeline segment.
+    seg_kv: list[float] = []
+    seg_rho: list[float] = []
+    seg_slices: list[list[dict]] = []
+    seg_lengths = [float(s.get("L", 0.0) or 0.0) for s in stations]
+
+    i_batch = 0
+    remaining = batches[0]["len_km"] if batches else 0.0
+    kv_cur = batches[0]["kv"] if batches else 1.0
+    rho_cur = batches[0]["rho"] if batches else 850.0
+
+    for L in seg_lengths:
+        need = L
+        if L <= 0:
+            seg_kv.append(kv_cur)
+            seg_rho.append(rho_cur)
+            seg_slices.append([])
+            continue
+
+        segment_entries: list[dict] = []
+        # Consume from batches until this segment is filled from upstream to downstream
+        while need > 1e-9:
+            if remaining <= 1e-9:
+                i_batch += 1
+                if i_batch >= len(batches):
+                    # No more batches: extend with last known properties
+                    segment_entries.append(
+                        {"length_km": need, "kv": kv_cur, "rho": rho_cur}
+                    )
+                    need = 0.0
+                    break
+                remaining = batches[i_batch]["len_km"]
+                kv_cur = batches[i_batch]["kv"]
+                rho_cur = batches[i_batch]["rho"]
+                if remaining <= 1e-9:
+                    continue
+
+            take = min(need, remaining)
+            if take <= 0:
+                break
+
+            segment_entries.append(
+                {"length_km": take, "kv": kv_cur, "rho": rho_cur}
+            )
+            need -= take
+            remaining -= take
+
+        if not segment_entries:
+            segment_entries.append({"length_km": L, "kv": kv_cur, "rho": rho_cur})
+
+        seg_slices.append(segment_entries)
+        seg_kv.append(segment_entries[0]["kv"])
+        if L > 0:
+            avg_rho = sum(entry["length_km"] * entry["rho"] for entry in segment_entries) / L
+        else:
+            avg_rho = segment_entries[0]["rho"]
+        seg_rho.append(avg_rho)
+
+    return seg_kv, seg_rho, seg_slices
 
 def _summarise_baseline_requirement(
     baseline_requirement: Mapping[str, object] | None,
@@ -223,6 +435,7 @@ def _collect_segment_floors(
             "station_idx": station_idx,
             "length_km": float(seg_length),
             "dra_ppm": float(floor_ppm),
+            "enforce_queue": False,
         }
 
         try:
@@ -247,6 +460,150 @@ def _collect_segment_floors(
     segments = [item[2] for item in processed]
 
     return segments
+
+
+def _prepare_pipeline_context():
+    """Build station, terminal, and linefill data for optimisation helpers."""
+
+    stations_data = copy.deepcopy(st.session_state.get("stations", []))
+    term_data = {
+        "name": st.session_state.get("terminal_name", "Terminal"),
+        "elev": st.session_state.get("terminal_elev", 0.0),
+        "min_residual": st.session_state.get("terminal_head", 10.0),
+    }
+
+    linefill_df = st.session_state.get("linefill_df")
+    if isinstance(linefill_df, pd.DataFrame):
+        linefill_df = ensure_initial_dra_column(linefill_df, default=0.0, fill_blanks=True)
+    else:
+        linefill_df = pd.DataFrame()
+
+    vol_linefill = st.session_state.get("linefill_vol_df")
+    if isinstance(vol_linefill, pd.DataFrame) and len(vol_linefill) > 0:
+        vol_linefill = ensure_initial_dra_column(vol_linefill, default=0.0, fill_blanks=True)
+        try:
+            kv_list, rho_list, segment_slices = map_vol_linefill_to_segments(vol_linefill, stations_data)
+            linefill_df = vol_linefill
+        except Exception:
+            kv_list, rho_list, segment_slices = derive_segment_profiles(linefill_df, stations_data)
+    else:
+        kv_list, rho_list, segment_slices = derive_segment_profiles(linefill_df, stations_data)
+
+    for idx, stn in enumerate(stations_data, start=1):
+        if not stn.get("is_pump", False):
+            continue
+
+        stn.setdefault("name", f"Station {idx}")
+        stn.setdefault("max_dr", 0.0)
+        stn.setdefault("min_residual", 0.0)
+        stn.setdefault("loopline", False)
+        stn.setdefault("max_pumps", stn.get("available", 0))
+        stn.setdefault("min_pumps", 0)
+        pump_types = stn.get("pump_types") if isinstance(stn.get("pump_types"), Mapping) else None
+        if pump_types:
+            for ptype, pdata in pump_types.items():
+                if not isinstance(pdata, Mapping):
+                    continue
+                pdata.setdefault("available", pdata.get("count", 0))
+                if int(pdata.get("available", 0)) <= 0:
+                    continue
+                dfh = st.session_state.get(f"head_data_{idx}{ptype}")
+                dfe = st.session_state.get(f"eff_data_{idx}{ptype}")
+                pdata["head_data"] = dfh
+                pdata["eff_data"] = dfe
+        else:
+            dfh = st.session_state.get(f"head_data_{idx}")
+            dfe = st.session_state.get(f"eff_data_{idx}")
+            if dfh is None and "head_data" in stn:
+                dfh = pd.DataFrame(stn["head_data"])
+            if dfe is None and "eff_data" in stn:
+                dfe = pd.DataFrame(stn["eff_data"])
+            if dfh is not None and len(dfh) >= 3:
+                Qh = dfh.iloc[:, 0].values
+                Hh = dfh.iloc[:, 1].values
+                coeff = np.polyfit(Qh, Hh, 2)
+                stn["A"], stn["B"], stn["C"] = float(coeff[0]), float(coeff[1]), float(coeff[2])
+            if dfe is not None and len(dfe) >= 5:
+                Qe = dfe.iloc[:, 0].values
+                Ee = dfe.iloc[:, 1].values
+                coeff_e = np.polyfit(Qe, Ee, 4)
+                stn["P"], stn["Q"], stn["R"], stn["S"], stn["T"] = [float(c) for c in coeff_e]
+
+        if "forced_dra_detail" in stn and stn["forced_dra_detail"] is None:
+            stn.pop("forced_dra_detail")
+
+    return stations_data, term_data, linefill_df, kv_list, rho_list, segment_slices
+
+
+def _compute_and_store_baseline_requirement(
+    stations_data,
+    term_data,
+    kv_list,
+    rho_list,
+    segment_slices,
+):
+    """Recompute the DRA baseline using the current lacing inputs."""
+
+    baseline_flow = float(st.session_state.get("max_laced_flow_m3h", st.session_state.get("FLOW", 1000.0)) or 0.0)
+    baseline_visc_raw = st.session_state.get("max_laced_visc_cst", 0.0)
+    try:
+        baseline_visc = float(baseline_visc_raw)
+    except (TypeError, ValueError):
+        baseline_visc = 0.0
+    if baseline_visc <= 0.0:
+        try:
+            baseline_visc = float(max(kv_list or [1.0]))
+        except (TypeError, ValueError):
+            baseline_visc = 1.0
+
+    min_suction = float(st.session_state.get("min_laced_suction_m", 0.0) or 0.0)
+    fluid_density = float(
+        st.session_state.get("laced_density_kgm3", st.session_state.get("Fuel_density", 820.0)) or 0.0
+    )
+    mop_kgcm2 = float(st.session_state.get("MOP_kgcm2", 0.0) or 0.0)
+
+    baseline_requirement: dict | None = None
+    warnings: list = []
+    try:
+        baseline_requirement = pipeline_model.compute_minimum_lacing_requirement(
+            stations_data,
+            term_data,
+            max_flow_m3h=baseline_flow,
+            max_visc_cst=baseline_visc,
+            segment_slices=segment_slices,
+            min_suction_head=min_suction,
+            fluid_density=fluid_density,
+            mop_kgcm2=mop_kgcm2,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        st.error(f"Failed to compute baseline DRA floors: {exc}")
+        baseline_requirement = None
+
+    baseline_summary = _summarise_baseline_requirement(baseline_requirement)
+    enforceable = False
+    segments: list[dict[str, object]] | None = None
+    if isinstance(baseline_requirement, Mapping):
+        warnings = list(baseline_requirement.get("warnings") or [])
+        enforceable = bool(baseline_requirement.get("enforceable", True))
+        segments = _collect_segment_floors(baseline_requirement)
+        if not baseline_summary.get("has_positive_segments"):
+            enforceable = False
+
+    st.session_state["origin_lacing_baseline_warnings"] = copy.deepcopy(warnings)
+    st.session_state["origin_lacing_baseline_summary"] = baseline_summary
+
+    if enforceable and baseline_summary.get("has_positive_segments"):
+        st.session_state["origin_lacing_baseline"] = copy.deepcopy(baseline_requirement)
+        if segments:
+            st.session_state["origin_lacing_segment_baseline"] = copy.deepcopy(segments)
+        else:
+            st.session_state.pop("origin_lacing_segment_baseline", None)
+    else:
+        st.session_state.pop("origin_lacing_baseline", None)
+        st.session_state.pop("origin_lacing_segment_baseline", None)
+        enforceable = False
+
+    return baseline_requirement, baseline_summary, warnings, enforceable, segments
 
 
 def _get_linefill_snapshot_for_hour(
@@ -397,6 +754,10 @@ def restore_case_dict(loaded_data):
     st.session_state['min_laced_suction_m'] = loaded_data.get(
         'min_laced_suction_m',
         st.session_state.get('min_laced_suction_m', 0.0),
+    )
+    st.session_state['laced_density_kgm3'] = loaded_data.get(
+        'laced_density_kgm3',
+        st.session_state.get('laced_density_kgm3', st.session_state.get('Fuel_density', 820.0)),
     )
     if loaded_data.get("linefill_vol"):
         st.session_state["linefill_vol_df"] = pd.DataFrame(loaded_data["linefill_vol"])
@@ -577,6 +938,118 @@ with st.sidebar:
                 " SDH requirements."
             ),
         )
+        st.number_input(
+            "Fluid density for lacing (kg/m³)",
+            min_value=0.0,
+            value=float(st.session_state.get("laced_density_kgm3", st.session_state.get("Fuel_density", 820.0))),
+            step=1.0,
+            key="laced_density_kgm3",
+            help=(
+                "Density used to convert MOP/MAOP limits from kg/cm² to metres when "
+                "evaluating baseline lacing floors."
+            ),
+        )
+
+        if st.button("Calculate baseline DRA PPM", key="compute_baseline_dra", type="primary"):
+            (
+                stations_ctx,
+                term_ctx,
+                linefill_ctx,
+                kv_ctx,
+                rho_ctx,
+                segment_ctx,
+            ) = _prepare_pipeline_context()
+            (
+                _,
+                baseline_summary,
+                baseline_warnings,
+                enforceable,
+                _,
+            ) = _compute_and_store_baseline_requirement(
+                stations_ctx,
+                term_ctx,
+                kv_ctx,
+                rho_ctx,
+                segment_ctx,
+            )
+            if isinstance(linefill_ctx, pd.DataFrame):
+                st.session_state["linefill_df"] = linefill_ctx
+            if baseline_warnings:
+                for warning in baseline_warnings:
+                    message = warning.get("message") if isinstance(warning, Mapping) else None
+                    if message:
+                        st.warning(message)
+            segments_detail = st.session_state.get("origin_lacing_segment_baseline") if enforceable else None
+            if enforceable and baseline_summary.get("has_positive_segments"):
+                floor_ppm = float(baseline_summary.get("dra_ppm", 0.0) or 0.0)
+                st.success(
+                    f"Baseline DRA floors updated. Minimum enforced origin injection is {floor_ppm:.2f} ppm."
+                )
+                segment_rows: list[dict[str, object]] = []
+                if isinstance(segments_detail, Sequence):
+                    terminal_name = term_ctx.get("name") if isinstance(term_ctx, Mapping) else "Terminal"
+                    for seg in segments_detail:
+                        if not isinstance(seg, Mapping):
+                            continue
+                        try:
+                            station_idx = int(seg.get("station_idx", 0))
+                        except (TypeError, ValueError):
+                            station_idx = 0
+                        start_name = ""
+                        end_name = terminal_name
+                        if 0 <= station_idx < len(stations_ctx):
+                            start_name = stations_ctx[station_idx].get("name", f"Station {station_idx + 1}")
+                            if station_idx + 1 < len(stations_ctx):
+                                end_name = stations_ctx[station_idx + 1].get(
+                                    "name", f"Station {station_idx + 2}"
+                                )
+                        elif station_idx >= len(stations_ctx):
+                            start_name = stations_ctx[-1].get("name", f"Station {len(stations_ctx)}")
+                        segment_label = (
+                            f"{start_name} → {end_name}"
+                            if start_name and end_name
+                            else start_name or end_name
+                        )
+                        try:
+                            seg_length = float(seg.get("length_km", 0.0) or 0.0)
+                        except (TypeError, ValueError):
+                            seg_length = 0.0
+                        try:
+                            seg_ppm = float(seg.get("dra_ppm", 0.0) or 0.0)
+                        except (TypeError, ValueError):
+                            seg_ppm = 0.0
+                        try:
+                            seg_perc = float(seg.get("dra_perc", 0.0) or 0.0)
+                        except (TypeError, ValueError):
+                            seg_perc = 0.0
+                        try:
+                            seg_suction = float(seg.get("suction_head", 0.0) or 0.0)
+                        except (TypeError, ValueError):
+                            seg_suction = 0.0
+                        segment_rows.append(
+                            {
+                                "Segment": segment_label,
+                                "Length (km)": seg_length,
+                                "Baseline PPM": seg_ppm,
+                                "Baseline %DR": seg_perc,
+                                "Suction head (m)": seg_suction,
+                            }
+                        )
+                if segment_rows:
+                    seg_df = pd.DataFrame(segment_rows)
+                    seg_df = seg_df.round(
+                        {
+                            "Length (km)": 2,
+                            "Baseline PPM": 2,
+                            "Baseline %DR": 2,
+                            "Suction head (m)": 2,
+                        }
+                    )
+                    st.dataframe(seg_df, use_container_width=True, hide_index=True)
+                else:
+                    st.info("No segment-level floors were generated.")
+            else:
+                st.info("Baseline DRA floors cleared. No minimum injection will be enforced.")
 
         rpm_step_default = getattr(pipeline_model, "RPM_STEP", 25)
         dra_step_default = getattr(pipeline_model, "DRA_STEP", 2)
@@ -1234,6 +1707,7 @@ def get_full_case_dict():
         "max_laced_flow_m3h": st.session_state.get('max_laced_flow_m3h', st.session_state.get('FLOW', 1000.0)),
         "max_laced_visc_cst": st.session_state.get('max_laced_visc_cst', 10.0),
         "min_laced_suction_m": st.session_state.get('min_laced_suction_m', 0.0),
+        "laced_density_kgm3": st.session_state.get('laced_density_kgm3', st.session_state.get('Fuel_density', 820.0)),
         "linefill": st.session_state.get('linefill_df', pd.DataFrame()).to_dict(orient="records"),
         "linefill_vol": st.session_state.get('linefill_vol_df', pd.DataFrame()).to_dict(orient="records"),
         "day_plan": st.session_state.get('day_plan_df', pd.DataFrame()).to_dict(orient="records"),
@@ -1308,222 +1782,6 @@ st.sidebar.download_button(
     file_name="pipeline_case.json",
     mime="application/json"
 )
-
-def _default_segment_slices(
-    stations: list[dict], kv_list: list[float], rho_list: list[float]
-) -> list[list[dict]]:
-    """Return single-slice segment profiles for legacy distance tables.
-
-    Each station (segment) receives a single ``{"length_km", "kv", "rho"}``
-    dictionary so downstream consumers such as the hydraulic solver receive a
-    well-formed slice list even when only aggregate properties are available.
-    """
-
-    if not stations:
-        return []
-
-    fallback_kv = kv_list[0] if kv_list else 1.0
-    fallback_rho = rho_list[0] if rho_list else 850.0
-    slices: list[list[dict]] = []
-    for idx, stn in enumerate(stations):
-        length = float(stn.get("L", 0.0) or 0.0)
-        kv = kv_list[idx] if idx < len(kv_list) else fallback_kv
-        rho = rho_list[idx] if idx < len(rho_list) else fallback_rho
-        slices.append(
-            [
-                {
-                    "length_km": length,
-                    "kv": float(kv),
-                    "rho": float(rho),
-                }
-            ]
-        )
-    return slices
-
-
-def derive_segment_profiles(
-    linefill_df: pd.DataFrame | None, stations: list[dict]
-) -> tuple[list[float], list[float], list[list[dict]]]:
-    """Return per-segment viscosity/density lists and batch slices."""
-
-    kv_list, rho_list, segment_slices = map_linefill_to_segments(linefill_df, stations)
-    return kv_list, rho_list, segment_slices
-
-
-def map_linefill_to_segments(
-    linefill_df, stations
-) -> tuple[list[float], list[float], list[list[dict]]]:
-    """Map linefill properties onto each pipeline segment.
-
-    Accepts either a tabular linefill with "Start/End (km)" columns or a
-    volumetric table containing "Volume (m³)" information. In the latter case,
-    :func:`map_vol_linefill_to_segments` is used to derive segment properties.
-    """
-
-    if linefill_df is None or len(linefill_df) == 0:
-        # When no linefill information is provided, return conservative defaults
-        # rather than zeros.  Zero viscosities and densities result in
-        # non-physical conditions that cause the optimiser to reject all
-        # scenarios.  Here we assume a light refined product of 1.0 cSt and
-        # density 850 kg/m³ across all segments.
-        kv_list = [1.0] * len(stations)
-        rho_list = [850.0] * len(stations)
-        segment_slices = _default_segment_slices(stations, kv_list, rho_list)
-        return kv_list, rho_list, segment_slices
-
-    cols = set(linefill_df.columns)
-
-    # If Start/End columns are missing but volumetric info is present,
-    # delegate to volumetric mapper and return directly.
-    if "Start (km)" not in cols or "End (km)" not in cols:
-        if "Volume (m³)" in cols or "Volume" in cols:
-            return map_vol_linefill_to_segments(linefill_df, stations)
-        # Fallback: assume uniform properties from the last row
-        kv = float(linefill_df.iloc[-1].get("Viscosity (cSt)", 0.0))
-        rho = float(linefill_df.iloc[-1].get("Density (kg/m³)", 0.0))
-        kv_list = [kv] * len(stations)
-        rho_list = [rho] * len(stations)
-        segment_slices = _default_segment_slices(stations, kv_list, rho_list)
-        return kv_list, rho_list, segment_slices
-
-    cumlen = [0]
-    for stn in stations:
-        cumlen.append(cumlen[-1] + stn["L"])
-    viscs = []
-    dens = []
-    for i in range(len(stations)):
-        seg_start = cumlen[i]
-        seg_end = cumlen[i + 1]
-        found = False
-        for _, row in linefill_df.iterrows():
-            if row["Start (km)"] <= seg_start < row["End (km)"]:
-                viscs.append(row["Viscosity (cSt)"])
-                dens.append(row["Density (kg/m³)"])
-                found = True
-                break
-        if not found:
-            viscs.append(linefill_df.iloc[-1]["Viscosity (cSt)"])
-            dens.append(linefill_df.iloc[-1]["Density (kg/m³)"])
-    segment_slices = _default_segment_slices(stations, viscs, dens)
-    return viscs, dens, segment_slices
-
-# ==== NEW: Volumetric linefill helpers ====
-def pipe_cross_section_area_m2(stations: list[dict]) -> float:
-    """Return pipe internal cross-sectional area (m²) using the first station's D/t."""
-    if not stations:
-        return 0.0
-    D = float(stations[0].get("D", 0.711))
-    t = float(stations[0].get("t", 0.007))
-    d_inner = max(D - 2.0*t, 0.0)
-    return float((pi * d_inner**2) / 4.0)
-
-def map_vol_linefill_to_segments(
-    vol_table: pd.DataFrame, stations: list[dict]
-) -> tuple[list[float], list[float], list[list[dict]]]:
-    """Convert a volumetric linefill table to per-segment fluid properties.
-
-    The returned tuple contains three parallel sequences with one entry per
-    segment (station):
-
-    ``kv_list``
-        The viscosity of the upstream-most batch touching the segment.  This
-        preserves the historical behaviour used by DRA lookups and other UI
-        features that expect a single representative viscosity per segment.
-
-    ``rho_list``
-        A length-weighted average density across the batches occupying the
-        segment.  This is used when converting heads to pressures.
-
-    ``segment_slices``
-        A list of ``{"length_km", "kv", "rho"}`` dictionaries describing the
-        sequence of batches that span the segment.  These slices are later fed
-        into the hydraulic solver so Darcy–Weisbach losses can be accumulated
-        over the heterogeneous fluid profile instead of assuming a single
-        viscosity.
-
-    Assumes uniform diameter along the pipeline (uses first station ``D``/``t``)
-    to convert volumes to kilometres.
-    """
-    A = pipe_cross_section_area_m2(stations)
-    if A <= 0:
-        raise ValueError("Invalid pipe area (check D and t).")
-    d_inner = sqrt((4.0 * A) / pi)
-    km_from_volume = pipeline_model._km_from_volume
-
-    # Compute lengths occupied by each batch
-    # Expected columns: Product, Volume (m³), Viscosity (cSt), Density (kg/m³)
-    batches = []
-    for _, r in vol_table.iterrows():
-        vol = float(r.get("Volume (m³)", 0.0) or r.get("Volume", 0.0) or 0.0)
-        if vol <= 0:
-            continue
-        length_km = km_from_volume(vol, d_inner)
-        visc = float(r.get("Viscosity (cSt)", 0.0))
-        dens = float(r.get("Density (kg/m³)", 0.0))
-        batches.append({"len_km": length_km, "kv": visc, "rho": dens})
-
-    # Map to segments (each station defines a segment length L)
-    seg_kv: list[float] = []
-    seg_rho: list[float] = []
-    seg_slices: list[list[dict]] = []
-    seg_lengths = [s.get("L", 0.0) for s in stations]
-    i_batch = 0
-    remaining = batches[0]["len_km"] if batches else 0.0
-    kv_cur = batches[0]["kv"] if batches else 1.0
-    rho_cur = batches[0]["rho"] if batches else 850.0
-
-    for L in seg_lengths:
-        need = L
-        if L <= 0:
-            seg_kv.append(kv_cur)
-            seg_rho.append(rho_cur)
-            seg_slices.append([])
-            continue
-        segment_entries: list[dict] = []
-        # Consume from batches until we cover this segment upstream-to-downstream
-        while need > 1e-9:
-            if remaining <= 1e-9:
-                i_batch += 1
-                if i_batch >= len(batches):
-                    # If we ran out, extend with last known properties
-                    segment_entries.append({
-                        "length_km": need,
-                        "kv": kv_cur,
-                        "rho": rho_cur,
-                    })
-                    need = 0.0
-                    break
-                else:
-                    remaining = batches[i_batch]["len_km"]
-                    kv_cur = batches[i_batch]["kv"]
-                    rho_cur = batches[i_batch]["rho"]
-                    if remaining <= 1e-9:
-                        continue
-            take = min(need, remaining)
-            if take <= 0:
-                break
-            segment_entries.append({
-                "length_km": take,
-                "kv": kv_cur,
-                "rho": rho_cur,
-            })
-            need -= take
-            remaining -= take
-        if not segment_entries:
-            segment_entries.append({
-                "length_km": L,
-                "kv": kv_cur,
-                "rho": rho_cur,
-            })
-        seg_slices.append(segment_entries)
-        seg_kv.append(segment_entries[0]["kv"])
-        if L > 0:
-            avg_rho = sum(entry["length_km"] * entry["rho"] for entry in segment_entries) / L
-        else:
-            avg_rho = segment_entries[0]["rho"]
-        seg_rho.append(avg_rho)
-
-    return seg_kv, seg_rho, seg_slices
 
 
 def _normalise_segment_entries(
@@ -1994,7 +2252,8 @@ def get_speed_display_map(
         else:
             values.setdefault(norm, np.nan)
     elif aggregated_val is not None:
-        for norm in suffixes:
+        if len(suffixes) == 1:
+            norm = suffixes[0]
             current = values.get(norm)
             if current is None or (isinstance(current, float) and np.isnan(current)):
                 values[norm] = aggregated_val
@@ -2142,6 +2401,105 @@ def build_summary_dataframe(
     return df_sum
 
 
+def _normalise_queue_segments(
+    segments: Sequence[Mapping[str, object] | Sequence[object]] | None,
+) -> list[tuple[float, float]]:
+    """Return queue segments as ``(length_km, ppm)`` tuples."""
+
+    if not segments:
+        return []
+
+    normalised: list[tuple[float, float]] = []
+    for entry in segments:
+        if isinstance(entry, Mapping):
+            length_raw = entry.get("length_km", 0.0)
+            ppm_raw = entry.get("dra_ppm", 0.0)
+        elif isinstance(entry, Sequence) and len(entry) >= 2:
+            length_raw, ppm_raw = entry[0], entry[1]
+        else:
+            continue
+
+        try:
+            length_val = float(length_raw or 0.0)
+        except (TypeError, ValueError):
+            length_val = 0.0
+        if length_val <= 0.0:
+            continue
+
+        try:
+            ppm_val = float(ppm_raw or 0.0)
+        except (TypeError, ValueError):
+            ppm_val = 0.0
+        if ppm_val <= 0.0:
+            continue
+
+        normalised.append((length_val, ppm_val))
+
+    return normalised
+
+
+def _build_profiles_from_queue(
+    queue_segments: Sequence[Mapping[str, object] | Sequence[object]] | None,
+    stations: Sequence[Mapping[str, object]] | None,
+) -> dict[str, list[tuple[float, float]]]:
+    """Slice ``queue_segments`` per station to build downstream profiles."""
+
+    if not stations:
+        return {}
+
+    queue = _normalise_queue_segments(queue_segments)
+    if not queue:
+        return {}
+
+    profiles: dict[str, list[tuple[float, float]]] = {}
+    offset = 0.0
+
+    for idx, stn in enumerate(stations):
+        try:
+            seg_length = float(stn.get("L", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            seg_length = 0.0
+        if seg_length <= 0.0:
+            offset += 0.0
+            continue
+
+        seg_start = offset
+        seg_end = offset + seg_length
+        entries: list[tuple[float, float]] = []
+
+        cursor = 0.0
+        for length_val, ppm_val in queue:
+            next_cursor = cursor + length_val
+            overlap_start = max(cursor, seg_start)
+            overlap_end = min(next_cursor, seg_end)
+            overlap = overlap_end - overlap_start
+            if overlap > 1e-9 and ppm_val > 0.0:
+                entries.append((overlap, ppm_val))
+            cursor = next_cursor
+            if cursor >= seg_end - 1e-9:
+                break
+
+        treated = sum(length for length, _ppm in entries)
+        if seg_length - treated > 1e-6:
+            fallback = stn.get("fallback_dra_ppm", 0.0)
+            try:
+                fallback_val = float(fallback or 0.0)
+            except (TypeError, ValueError):
+                fallback_val = 0.0
+            if fallback_val > 0.0:
+                entries.append((seg_length - treated, fallback_val))
+
+        if entries:
+            merged = pipeline_model._merge_queue(entries)  # type: ignore[attr-defined]
+            key = stn.get("name", f"station_{idx}")
+            key_norm = str(key).lower().replace(" ", "_")
+            profiles[key_norm] = merged
+
+        offset += seg_length
+
+    return profiles
+
+
 def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
     """Return per-station details used in the daily schedule table.
 
@@ -2163,6 +2521,10 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             return float(value)
         except (TypeError, ValueError):
             return None
+
+    override_profiles = res.get('dra_profile_override') if isinstance(res, Mapping) else None
+    if not isinstance(override_profiles, Mapping):
+        override_profiles = {}
 
     for idx, stn in enumerate(stations_seq):
         name = stn['name'] if isinstance(stn, dict) else str(stn)
@@ -2235,27 +2597,36 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
         }
 
         profile_entries: list[tuple[float, float]] = []
-        raw_profile = res.get(f"dra_profile_{key}")
-        if isinstance(raw_profile, (list, tuple)):
-            for entry in raw_profile:
-                if isinstance(entry, dict):
-                    length_val = entry.get('length_km', 0.0)
-                    ppm_val = entry.get('dra_ppm', 0.0)
-                elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
-                    length_val, ppm_val = entry[0], entry[1]
-                else:
-                    continue
-                try:
-                    length_f = float(length_val or 0.0)
-                except (TypeError, ValueError):
-                    length_f = 0.0
-                try:
-                    ppm_f = float(ppm_val or 0.0)
-                except (TypeError, ValueError):
-                    ppm_f = 0.0
-                if length_f <= 0:
+        override_entry = override_profiles.get(key)
+        if isinstance(override_entry, list):
+            for length_val, ppm_val in override_entry:
+                length_f = float(length_val or 0.0)
+                ppm_f = float(ppm_val or 0.0)
+                if length_f <= 0.0 or ppm_f <= 0.0:
                     continue
                 profile_entries.append((length_f, ppm_f))
+        else:
+            raw_profile = res.get(f"dra_profile_{key}")
+            if isinstance(raw_profile, (list, tuple)):
+                for entry in raw_profile:
+                    if isinstance(entry, dict):
+                        length_val = entry.get('length_km', 0.0)
+                        ppm_val = entry.get('dra_ppm', 0.0)
+                    elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
+                        length_val, ppm_val = entry[0], entry[1]
+                    else:
+                        continue
+                    try:
+                        length_f = float(length_val or 0.0)
+                    except (TypeError, ValueError):
+                        length_f = 0.0
+                    try:
+                        ppm_f = float(ppm_val or 0.0)
+                    except (TypeError, ValueError):
+                        ppm_f = 0.0
+                    if length_f <= 0:
+                        continue
+                    profile_entries.append((length_f, ppm_f))
 
         treated_length = _float_or_none(res.get(f"dra_treated_length_{key}"))
         if treated_length is None:
@@ -2436,6 +2807,8 @@ def _collect_search_depth_kwargs() -> dict[str, float | int]:
         "state_cost_margin": state_cost_margin,
     }
 
+
+
 def solve_pipeline(
     stations,
     terminal,
@@ -2474,46 +2847,29 @@ def solve_pipeline(
     if pump_shear_rate is None:
         pump_shear_rate = st.session_state.get("pump_shear_rate", 0.0)
 
-    baseline_flow = st.session_state.get("max_laced_flow_m3h", FLOW)
-    baseline_visc = st.session_state.get("max_laced_visc_cst", max(KV_list or [1.0]))
+    baseline_requirement = copy.deepcopy(st.session_state.get("origin_lacing_baseline"))
+    baseline_segments_state = st.session_state.get("origin_lacing_segment_baseline")
+    baseline_summary = st.session_state.get("origin_lacing_baseline_summary")
+    if not isinstance(baseline_summary, Mapping):
+        baseline_summary = _summarise_baseline_requirement(baseline_requirement)
+        if isinstance(baseline_summary, Mapping):
+            st.session_state["origin_lacing_baseline_summary"] = baseline_summary
 
-    baseline_requirement: dict | None = None
-    try:
-        baseline_requirement = pipeline_model.compute_minimum_lacing_requirement(
-            stations,
-            terminal,
-            max_flow_m3h=float(baseline_flow),
-            max_visc_cst=float(baseline_visc),
-            segment_slices=segment_slices,
-            min_suction_head=float(st.session_state.get("min_laced_suction_m", 0.0)),
-        )
-    except Exception:
-        baseline_requirement = None
-
-    baseline_enforceable = True
-    baseline_warnings: list = []
-    baseline_segments: list[dict] | None = None
-    baseline_summary = _summarise_baseline_requirement(baseline_requirement)
-    if isinstance(baseline_requirement, dict):
-        baseline_warnings = baseline_requirement.get("warnings") or []
-        for warning in baseline_warnings:
-            message = warning.get("message") if isinstance(warning, dict) else None
-            if message:
-                st.warning(message)
+    baseline_enforceable = False
+    if isinstance(baseline_requirement, Mapping) and baseline_summary.get("has_positive_segments"):
         baseline_enforceable = bool(baseline_requirement.get("enforceable", True))
-        segment_floors = _collect_segment_floors(baseline_requirement)
-        if segment_floors:
-            baseline_segments = copy.deepcopy(segment_floors)
-        if baseline_enforceable and baseline_summary.get("has_positive_segments"):
-            st.session_state["origin_lacing_baseline"] = copy.deepcopy(baseline_requirement)
+
+    baseline_segments: list[dict] | None = None
+    if baseline_enforceable:
+        if isinstance(baseline_segments_state, Sequence) and baseline_segments_state:
+            baseline_segments = [copy.deepcopy(seg) for seg in baseline_segments_state]
         else:
-            st.session_state.pop("origin_lacing_baseline", None)
-    else:
-        st.session_state.pop("origin_lacing_baseline", None)
-    if baseline_enforceable and baseline_segments:
-        st.session_state["origin_lacing_segment_baseline"] = copy.deepcopy(baseline_segments)
-    else:
-        st.session_state.pop("origin_lacing_segment_baseline", None)
+            computed_segments = _collect_segment_floors(baseline_requirement)
+            if computed_segments:
+                baseline_segments = computed_segments
+                st.session_state["origin_lacing_segment_baseline"] = copy.deepcopy(computed_segments)
+            else:
+                baseline_enforceable = False
 
     def _combine_origin_detail(
         base_detail: dict | None,
@@ -2549,6 +2905,9 @@ def solve_pipeline(
         if base.get("segments") and "segments" not in user:
             user["segments"] = copy.deepcopy(base["segments"])
 
+        if "enforce_queue" not in user and "enforce_queue" in base:
+            user["enforce_queue"] = base["enforce_queue"]
+
         return user or None
 
     baseline_for_enforcement: dict | None = None
@@ -2570,6 +2929,7 @@ def solve_pipeline(
             if length_floor > 0.0:
                 base_detail["length_km"] = length_floor
         if base_detail:
+            base_detail["enforce_queue"] = False
             baseline_for_enforcement = base_detail
     baseline_segment_floors = baseline_segments if (baseline_enforceable and baseline_segments) else None
     forced_detail_effective = _combine_origin_detail(baseline_for_enforcement, forced_origin_detail)
@@ -3835,6 +4195,13 @@ def _execute_time_series_solver(
         for k, val in dra_cost_acc.items():
             res[f"dra_cost_{k}"] = val
         res["total_cost"] = block_cost
+
+        queue_segments = res.get("dra_segments") if isinstance(res, Mapping) else None
+        if isinstance(queue_segments, list):
+            profile_override = _build_profiles_from_queue(queue_segments, stations_base)
+            if profile_override:
+                res["dra_profile_override"] = profile_override
+
         reports.append(
             {
                 "time": hr % 24,
@@ -3912,103 +4279,42 @@ def _build_enforced_origin_warning(
 def run_all_updates():
     """Invalidate caches, rebuild station data and solve for the global optimum."""
     invalidate_results()
-    stations_data = st.session_state.stations
-    term_data = {
-        "name": st.session_state.get("terminal_name", "Terminal"),
-        "elev": st.session_state.get("terminal_elev", 0.0),
-        "min_residual": st.session_state.get("terminal_head", 10.0),
-    }
-    linefill_df = st.session_state.get("linefill_df")
-    if not isinstance(linefill_df, pd.DataFrame):
-        linefill_df = pd.DataFrame()
-    else:
-        linefill_df = ensure_initial_dra_column(linefill_df, default=0.0, fill_blanks=True)
-
-    vol_linefill = st.session_state.get("linefill_vol_df")
-    if isinstance(vol_linefill, pd.DataFrame) and len(vol_linefill) > 0:
-        vol_linefill = ensure_initial_dra_column(vol_linefill, default=0.0, fill_blanks=True)
-        kv_list, rho_list, segment_slices = map_vol_linefill_to_segments(
-            vol_linefill, stations_data
-        )
-        linefill_df = vol_linefill
-    else:
-        kv_list, rho_list, segment_slices = derive_segment_profiles(
-            linefill_df, stations_data
-        )
-
-    for idx, stn in enumerate(stations_data, start=1):
-        if stn.get("is_pump", False):
-            if "pump_types" in stn:
-                for ptype in ["A", "B"]:
-                    if ptype not in stn["pump_types"]:
-                        continue
-                    if stn["pump_types"][ptype].get("available", 0) == 0:
-                        continue
-                    dfh = st.session_state.get(f"head_data_{idx}{ptype}")
-                    dfe = st.session_state.get(f"eff_data_{idx}{ptype}")
-                    stn["pump_types"][ptype]["head_data"] = dfh
-                    stn["pump_types"][ptype]["eff_data"] = dfe
-            else:
-                dfh = st.session_state.get(f"head_data_{idx}")
-                dfe = st.session_state.get(f"eff_data_{idx}")
-                if dfh is None and "head_data" in stn:
-                    dfh = pd.DataFrame(stn["head_data"])
-                if dfe is None and "eff_data" in stn:
-                    dfe = pd.DataFrame(stn["eff_data"])
-                if dfh is not None and len(dfh) >= 3:
-                    Qh = dfh.iloc[:, 0].values
-                    Hh = dfh.iloc[:, 1].values
-                    coeff = np.polyfit(Qh, Hh, 2)
-                    stn["A"], stn["B"], stn["C"] = float(coeff[0]), float(coeff[1]), float(coeff[2])
-                if dfe is not None and len(dfe) >= 5:
-                    Qe = dfe.iloc[:, 0].values
-                    Ee = dfe.iloc[:, 1].values
-                    coeff_e = np.polyfit(Qe, Ee, 4)
-                    stn["P"], stn["Q"], stn["R"], stn["S"], stn["T"] = [float(c) for c in coeff_e]
+    (
+        stations_data,
+        term_data,
+        linefill_df,
+        kv_list,
+        rho_list,
+        segment_slices,
+    ) = _prepare_pipeline_context()
+    if isinstance(linefill_df, pd.DataFrame):
+        st.session_state["linefill_df"] = linefill_df
 
     search_kwargs = _collect_search_depth_kwargs()
     forced_detail = st.session_state.get("origin_enforced_detail")
     if not isinstance(forced_detail, dict):
         forced_detail = None
 
-    baseline_flow = st.session_state.get("max_laced_flow_m3h", st.session_state.get("FLOW", 1000.0))
-    baseline_visc = st.session_state.get("max_laced_visc_cst", max(kv_list or [1.0]))
-    baseline_requirement = None
-    try:
-        baseline_requirement = pipeline_model.compute_minimum_lacing_requirement(
-            stations_data,
-            term_data,
-            max_flow_m3h=float(baseline_flow),
-            max_visc_cst=float(baseline_visc),
-            segment_slices=segment_slices,
-            min_suction_head=float(st.session_state.get("min_laced_suction_m", 0.0)),
-        )
-    except Exception:
-        baseline_requirement = None
-    baseline_enforceable = True
-    baseline_warnings: list = []
-    baseline_segments: list[dict] | None = None
-    baseline_summary = _summarise_baseline_requirement(baseline_requirement)
-    if isinstance(baseline_requirement, dict):
-        baseline_warnings = baseline_requirement.get("warnings") or []
+    baseline_requirement = st.session_state.get("origin_lacing_baseline")
+    baseline_summary = st.session_state.get("origin_lacing_baseline_summary")
+    if not isinstance(baseline_summary, Mapping):
+        baseline_summary = _summarise_baseline_requirement(baseline_requirement)
+        st.session_state["origin_lacing_baseline_summary"] = baseline_summary
+    baseline_warnings = st.session_state.get("origin_lacing_baseline_warnings", [])
+    if baseline_warnings:
         for warning in baseline_warnings:
-            message = warning.get("message") if isinstance(warning, dict) else None
+            message = warning.get("message") if isinstance(warning, Mapping) else None
             if message:
                 st.warning(message)
+
+    baseline_enforceable = False
+    if isinstance(baseline_requirement, Mapping) and baseline_summary.get("has_positive_segments"):
         baseline_enforceable = bool(baseline_requirement.get("enforceable", True))
-        segment_floors = _collect_segment_floors(baseline_requirement)
-        if segment_floors:
-            baseline_segments = copy.deepcopy(segment_floors)
-        if baseline_enforceable and baseline_summary.get("has_positive_segments"):
-            st.session_state["origin_lacing_baseline"] = copy.deepcopy(baseline_requirement)
-        else:
-            st.session_state.pop("origin_lacing_baseline", None)
-    else:
-        st.session_state.pop("origin_lacing_baseline", None)
-    if baseline_enforceable and baseline_segments:
-        st.session_state["origin_lacing_segment_baseline"] = copy.deepcopy(baseline_segments)
-    else:
-        st.session_state.pop("origin_lacing_segment_baseline", None)
+
+    baseline_segments_state = st.session_state.get("origin_lacing_segment_baseline")
+    baseline_segments: list[dict[str, object]] | None = None
+    if baseline_enforceable and isinstance(baseline_segments_state, Sequence):
+        baseline_segments = [copy.deepcopy(seg) for seg in baseline_segments_state]
 
     def _normalise_segments_for_detail(detail_obj: Mapping[str, object] | None) -> list[dict[str, object]]:
         segments_out: list[dict[str, object]] = []
@@ -5477,7 +5783,7 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                 rough = stn['rough']
                 L_seg = stn['L']
                 elev_i = stn['elev']
-                max_dr = int(stn.get('max_dr', 40))
+                max_dr = max(int(stn.get('max_dr', 40)), 0)
                 kv_list, _, _ = map_linefill_to_segments(linefill_df, stations_data)
                 visc = kv_list[i-1]
                 flows = np.linspace(0, st.session_state.get("FLOW", 1000.0), 101)
@@ -5491,18 +5797,28 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                     Re_vals = np.zeros_like(v_vals)
                     f_vals = np.zeros_like(v_vals)
                 # Professional gradient: from blue to red
-                n_curves = (max_dr // pipeline_model.DRA_STEP) + 1
+                dra_step = max(getattr(pipeline_model, "DRA_STEP", 2), 1)
+                dra_levels = list(range(0, max_dr + dra_step, dra_step))
+                if not dra_levels:
+                    dra_levels = [0]
+                n_curves = len(dra_levels)
                 color_palette = [
                     "#1565C0", "#1976D2", "#1E88E5", "#3949AB", "#8E24AA",
                     "#D81B60", "#F4511E", "#F9A825", "#43A047", "#00897B"
                 ]
-                color_idx = np.linspace(0, len(color_palette)-1, n_curves).astype(int)
+                if n_curves <= 0:
+                    color_idx = np.array([0])
+                    n_curves = 1
+                else:
+                    color_idx = np.linspace(0, len(color_palette) - 1, n_curves).astype(int)
                 fig_sys = go.Figure()
-                for j, dra in enumerate(range(0, max_dr + pipeline_model.DRA_STEP, pipeline_model.DRA_STEP)):
+                for j, dra in enumerate(dra_levels):
                     DH = f_vals * ((L_seg*1000.0)/d_inner_i) * (v_vals**2/(2*9.81)) * (1-dra/100.0)
                     SDH_vals = elev_i + DH
                     # Fix: safe indexing for palette if only 1 curve
-                    color = color_palette[color_idx[j]] if n_curves > 1 else color_palette[0]
+                    palette_idx = color_idx[j] if n_curves > 1 else color_idx[0]
+                    palette_idx = min(max(int(palette_idx), 0), len(color_palette) - 1)
+                    color = color_palette[palette_idx]
                     fig_sys.add_trace(go.Scatter(
                         x=flows, y=SDH_vals,
                         mode='lines',

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -2979,6 +2979,131 @@ def _collect_search_depth_kwargs() -> dict[str, float | int]:
     }
 
 
+PASS_LABELS = {
+    "coarse": "Coarse grid",
+    "exhaustive": "Full grid",
+    "refine": "Refinement window",
+}
+PASS_ORDER = ["coarse", "exhaustive", "refine"]
+
+
+def _record_search_history(result: Mapping[str, object], params: Mapping[str, object]) -> None:
+    """Store the latest optimisation parameters and cost for sensitivity badges."""
+
+    if not isinstance(result, Mapping) or not isinstance(params, Mapping):
+        return
+    try:
+        cost_val = float(result.get("total_cost", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        cost_val = 0.0
+    entry = {"params": dict(params), "cost": cost_val}
+    history = st.session_state.setdefault("search_history", [])
+    history.append(entry)
+    if len(history) > 8:
+        del history[0]
+
+
+def render_search_footprint(result: Mapping[str, object] | None) -> None:
+    """Display per-pass search statistics when telemetry is available."""
+
+    if not isinstance(result, Mapping):
+        return
+    telemetry = result.get("search_telemetry")
+    if not isinstance(telemetry, Mapping):
+        return
+    passes = telemetry.get("passes")
+    if not isinstance(passes, Mapping) or not passes:
+        return
+
+    st.markdown("#### Search Footprint")
+    for pass_key in PASS_ORDER:
+        data = passes.get(pass_key)
+        if not isinstance(data, Mapping):
+            continue
+        totals = data.get("totals", {})
+        stations = data.get("stations", {})
+        label = PASS_LABELS.get(pass_key, pass_key.title())
+
+        options_total = int(float(totals.get("options_generated", 0) or 0))
+        candidates_total = int(float(totals.get("candidates_evaluated", 0) or 0))
+        survivors_total = int(float(totals.get("states_retained", 0) or 0))
+        bucket_total = int(float(totals.get("bucket_survivors", 0) or 0))
+        pruned_total = int(float(totals.get("pruned_after_topk", 0) or 0))
+        runs_total = max(int(float(totals.get("runs", 1) or 1)), 1)
+
+        summary = (
+            f"{label} pass evaluated {options_total} unique pump/DRA combinations "
+            f"and {candidates_total} dynamic-programming transitions. "
+            f"After pruning, {survivors_total} states survived out of {bucket_total} bucket candidates"
+        )
+        if pruned_total > 0:
+            summary += f", removing {pruned_total} via top-k or cost filters."
+        else:
+            summary += "."
+        st.markdown(f"**{summary}**")
+
+        if isinstance(stations, Mapping) and stations:
+            rows: list[dict[str, object]] = []
+            for stats in stations.values():
+                if not isinstance(stats, Mapping):
+                    continue
+                rows.append(
+                    {
+                        "Station": stats.get("name", "Station"),
+                        "Runs": int(float(stats.get("runs", runs_total) or runs_total)),
+                        "Options": int(float(stats.get("options_generated", 0) or 0)),
+                        "States in": int(float(stats.get("states_in", 0) or 0)),
+                        "Candidates": int(float(stats.get("candidates_evaluated", 0) or 0)),
+                        "New states": int(float(stats.get("states_created", 0) or 0)),
+                        "Replacements": int(float(stats.get("states_replaced", 0) or 0)),
+                        "Bucket survivors": int(float(stats.get("bucket_survivors", 0) or 0)),
+                        "Retained": int(float(stats.get("states_retained", 0) or 0)),
+                        "Pruned top-k": int(float(stats.get("pruned_after_topk", 0) or 0)),
+                    }
+                )
+            if rows:
+                df = pd.DataFrame(rows)
+                numeric_cols = [col for col in df.columns if col != "Station"]
+                df = df.sort_values("Station")
+                df_display = df.style.format({col: "{:.0f}" for col in numeric_cols})
+                st.dataframe(df_display, hide_index=True, use_container_width=True)
+
+    st.caption(
+        "Telemetry counts reflect the advanced search depth settings. "
+        "See the Advanced Search explanation for details on the pruning logic."
+    )
+
+
+def render_sensitivity_badge(history: Sequence[Mapping[str, object]] | None) -> None:
+    """Show a badge when DP thresholds were widened without changing cost."""
+
+    if not history or len(history) < 2:
+        return
+    prev = history[-2]
+    curr = history[-1]
+    try:
+        prev_cost = float(prev.get("cost", 0.0) or 0.0)
+        curr_cost = float(curr.get("cost", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return
+    if abs(curr_cost - prev_cost) > 1e-3:
+        return
+    prev_params = prev.get("params", {})
+    curr_params = curr.get("params", {})
+    if not isinstance(prev_params, Mapping) or not isinstance(curr_params, Mapping):
+        return
+    prev_topk = float(prev_params.get("state_top_k", 0) or 0)
+    curr_topk = float(curr_params.get("state_top_k", 0) or 0)
+    prev_margin = float(prev_params.get("state_cost_margin", 0) or 0)
+    curr_margin = float(curr_params.get("state_cost_margin", 0) or 0)
+    if curr_topk <= prev_topk and curr_margin <= prev_margin:
+        return
+    st.info(
+        f"🧪 Sensitivity check: widening DP limits to top_k={curr_topk:.0f}, margin={curr_margin:.0f} "
+        "did not change the optimal cost.",
+    )
+
+
 
 def solve_pipeline(
     stations,
@@ -3110,6 +3235,7 @@ def solve_pipeline(
     try:
         # Delegate to the backend optimiser
         search_kwargs = _collect_search_depth_kwargs()
+        telemetry_payload: dict = {}
         if any(s.get('pump_types') for s in stations):
             res = pipeline_model.solve_pipeline_with_types(
                 stations,
@@ -3131,6 +3257,7 @@ def solve_pipeline(
                 forced_origin_detail=forced_detail_effective,
                 segment_floors=baseline_segment_floors,
                 **search_kwargs,
+                telemetry=telemetry_payload,
             )
         else:
             res = pipeline_model.solve_pipeline(
@@ -3153,7 +3280,11 @@ def solve_pipeline(
                 forced_origin_detail=forced_detail_effective,
                 segment_floors=baseline_segment_floors,
                 **search_kwargs,
+                telemetry=telemetry_payload,
             )
+        if isinstance(res, Mapping):
+            res = dict(res)
+            res['search_telemetry'] = telemetry_payload
         # Append a human-readable flow pattern name based on loop usage
         if not res.get("error"):
             usage = res.get("loop_usage", [])
@@ -4662,6 +4793,7 @@ def run_all_updates():
 
     start_time = time.perf_counter()
     with st.spinner("Solving optimization..."):
+        telemetry_payload: dict = {}
         res = pipeline_model.solve_pipeline_with_types(
             stations_data,
             term_data,
@@ -4680,6 +4812,7 @@ def run_all_updates():
             pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
             forced_origin_detail=copy.deepcopy(forced_detail_effective) if forced_detail_effective else None,
             **search_kwargs,
+            telemetry=telemetry_payload,
         )
     elapsed = time.perf_counter() - start_time
     if not res or res.get("error"):
@@ -4689,7 +4822,9 @@ def run_all_updates():
         st.error(msg)
         return
     _store_run_duration("Start task", elapsed)
+    res["search_telemetry"] = telemetry_payload
     st.session_state["last_res"] = copy.deepcopy(res)
+    _record_search_history(res, search_kwargs)
     st.session_state["last_stations_data"] = copy.deepcopy(res.get("stations_used", stations_data))
     st.session_state["last_term_data"] = copy.deepcopy(term_data)
     st.session_state["last_linefill"] = copy.deepcopy(linefill_df)
@@ -5100,11 +5235,13 @@ if not auto_batch:
 
         st.session_state["last_plan_start"] = flow_df["Start"].min()
         st.session_state["last_plan_hours"] = (flow_df["End"].max() - flow_df["Start"].min()).total_seconds() / 3600.0
-        st.session_state["last_res"] = copy.deepcopy(reports[-1]["result"])
+        final_res = reports[-1]["result"]
+        st.session_state["last_res"] = copy.deepcopy(final_res)
         st.session_state["last_stations_data"] = copy.deepcopy(stations_base)
         st.session_state["last_term_data"] = copy.deepcopy(term_data)
         st.session_state["last_linefill"] = copy.deepcopy(current_vol)
         _store_run_duration("Run Dynamic Pumping Plan Optimizer", elapsed)
+        _record_search_history(final_res, _collect_search_depth_kwargs())
 
         station_tables = []
         for rec in reports:
@@ -5232,6 +5369,9 @@ if not auto_batch and st.session_state.get("run_mode") == "instantaneous":
                 df_sum.round(2).to_csv(index=False, float_format="%.2f").encode(),
                 file_name="results.csv",
             )
+
+            render_sensitivity_badge(st.session_state.get("search_history"))
+            render_search_footprint(res)
 
             baseline_flow = st.session_state.get("max_laced_flow_m3h")
             baseline_visc = st.session_state.get("max_laced_visc_cst")

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -83,18 +83,20 @@ INIT_DRA_COL = "Initial DRA (ppm)"
 BUTTON_STYLE = """
 <style>
 div[data-testid="stButton"] > button[kind="primary"] {
-    background-color: #A34726;
-    color: #ffffff;
-    border: none;
-    box-shadow: none;
+    background: var(--primary-color);
+    color: var(--secondary-background-color);
+    border: 1px solid transparent;
+    border-radius: 12px;
+    box-shadow: 0 3px 18px #00000022;
+    font-weight: 600;
+    transition: filter 0.19s ease-in-out, transform 0.19s ease-in-out;
 }
 div[data-testid="stButton"] > button[kind="primary"]:hover {
-    background-color: #8F3E22;
-    color: #ffffff;
+    filter: brightness(0.92);
 }
 div[data-testid="stButton"] > button[kind="primary"]:active {
-    background-color: #7F371F;
-    color: #ffffff;
+    filter: brightness(0.85);
+    transform: translateY(1px);
 }
 div[data-testid="stDownloadButton"] > button {
     background-color: #0F2A5F;

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1480,6 +1480,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
             if stn['is_pump']:
                 stn.setdefault('pump_types', {})
                 pump_tabs = st.tabs(["Type A", "Type B"])
+                enabled_types: dict[str, bool] = {}
                 for tab_idx, ptype in enumerate(['A', 'B']):
                     with pump_tabs[tab_idx]:
                             pdata = stn.get('pump_types', {}).get(ptype, {})
@@ -1499,7 +1500,9 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                             if not enabled or avail == 0:
                                 st.info("Pump type disabled")
                                 stn.setdefault('pump_types', {})[ptype] = {'available': 0}
+                                enabled_types[ptype] = False
                                 continue
+                            enabled_types[ptype] = True
 
                             names = pdata.get('names', [])
                             if len(names) < avail:
@@ -1687,6 +1690,7 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                         all_names.extend(pn[:avail])
                     stn['pump_names'] = all_names
                     stn['pump_name'] = all_names[0] if all_names else ''
+                    stn['allow_mixed_pump_types'] = bool(enabled_types.get('A') and enabled_types.get('B'))
             else:
                 st.info("Not a pumping station. No pump data required.")
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -83,23 +83,31 @@ INIT_DRA_COL = "Initial DRA (ppm)"
 BUTTON_STYLE = """
 <style>
 div[data-testid="stButton"] > button[kind="primary"] {
-    background-color: #d97706;
+    background-color: #A34726;
     color: #ffffff;
     border: none;
     box-shadow: none;
 }
 div[data-testid="stButton"] > button[kind="primary"]:hover {
-    background-color: #b45309;
+    background-color: #8F3E22;
+    color: #ffffff;
+}
+div[data-testid="stButton"] > button[kind="primary"]:active {
+    background-color: #7F371F;
     color: #ffffff;
 }
 div[data-testid="stDownloadButton"] > button {
-    background-color: #1d4ed8;
+    background-color: #0F2A5F;
     color: #ffffff;
     border: none;
     box-shadow: none;
 }
 div[data-testid="stDownloadButton"] > button:hover {
-    background-color: #1e3a8a;
+    background-color: #0C2149;
+    color: #ffffff;
+}
+div[data-testid="stDownloadButton"] > button:active {
+    background-color: #091935;
     color: #ffffff;
 }
 </style>
@@ -722,14 +730,22 @@ st.set_page_config(page_title="Pipeline Optima™", layout="wide", initial_sideb
 #Custom Styles
 st.markdown("""
     <style>
-    .stButton > button,
-    .stDownloadButton > button {
-        background: var(--primary-color);
-        color: var(--secondary-background-color);
+    .stButton > button {
+        background: #A34726;
+        color: #ffffff;
         font-weight: 600;
         border: 1px solid transparent;
         border-radius: 12px;
-        box-shadow: 0 3px 18px #00000022;
+        box-shadow: none;
+        transition: filter 0.19s ease-in-out, transform 0.19s ease-in-out;
+    }
+    .stDownloadButton > button {
+        background: #0F2A5F;
+        color: #ffffff;
+        font-weight: 600;
+        border: 1px solid transparent;
+        border-radius: 12px;
+        box-shadow: none;
         transition: filter 0.19s ease-in-out, transform 0.19s ease-in-out;
     }
     .stButton > button:hover,

--- a/scripts/dra_lacing_walkthrough.py
+++ b/scripts/dra_lacing_walkthrough.py
@@ -1,0 +1,181 @@
+"""Generate a step-by-step DRA lacing walkthrough for an A–B–C pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from pipeline_model import (
+    _merge_queue,
+    _prepare_dra_queue_consumption,
+    _queue_total_length,
+    _segment_profile_from_queue,
+    _take_queue_front,
+    _trim_queue_front,
+    _update_mainline_dra,
+    _volume_from_km,
+)
+
+
+def _normalise_queue(
+    entries: Sequence[Sequence[float]] | Sequence[dict],
+) -> tuple[tuple[float, float], ...]:
+    normalised: list[tuple[float, float]] = []
+    for entry in entries:
+        if not entry:
+            continue
+        if isinstance(entry, dict):
+            length = float(entry.get("length_km", 0.0) or 0.0)
+            ppm = float(entry.get("dra_ppm", 0.0) or 0.0)
+        else:
+            length = float(entry[0])
+            ppm = float(entry[1]) if len(entry) > 1 else 0.0
+        if length <= 0:
+            continue
+        normalised.append((length, ppm))
+    merged = _merge_queue(normalised)
+    return tuple((float(length), float(ppm)) for length, ppm in merged if float(length) > 0)
+
+
+def _format_profile(
+    profile: Iterable[tuple[float, float]],
+    *,
+    limit: int | None = None,
+) -> str:
+    parts: list[str] = []
+    for length, ppm in profile:
+        length = float(length)
+        ppm = float(ppm)
+        if length <= 1e-9:
+            continue
+        parts.append(f"{length:4.1f} km @ {ppm:4.1f} ppm")
+    if not parts:
+        return "0.0 km (untreated)"
+    if limit is not None and limit > 0 and len(parts) > limit:
+        remaining = len(parts) - limit
+        display = parts[:limit] + [f"… (+{remaining} more)"]
+    else:
+        display = parts
+    return "; ".join(display)
+
+
+def main() -> None:
+    flow_m3h = 1000.0
+    hours = 1.0
+    stn_a = {
+        "idx": 0,
+        "name": "Station A",
+        "L": 40.0,
+        "d_inner": 0.33,
+        "kv": 3.0,
+        "dra_injector_position": "downstream",
+    }
+    stn_b = {
+        "idx": 1,
+        "name": "Station B",
+        "L": 60.0,
+        "d_inner": 0.33,
+        "kv": 3.0,
+        "dra_injector_position": "downstream",
+    }
+
+    opt_a = {"dra_ppm_main": 8.0, "nop": 1}
+    opt_b = {"dra_ppm_main": 4.0, "nop": 1}
+
+    queue_full: tuple[tuple[float, float], ...] = ((100.0, 0.0),)
+
+    header = (
+        "| Hour | A injection (ppm) | B injection (ppm) | A→B treated profile | "
+        "B→C treated profile | Downstream queue after B | Treated length (km) | "
+        "Linefill volume (m³) |"
+    )
+    separator = (
+        "| ---: | ---: | ---: | --- | --- | --- | ---: | ---: |"
+    )
+    print(header)
+    print(separator)
+
+    for hour in range(1, 7):
+        queue_inlet_a = queue_full
+        pre_a = _prepare_dra_queue_consumption(
+            queue_inlet_a, stn_a["L"], flow_m3h, hours, stn_a["d_inner"]
+        )
+        dra_seg_a, queue_after_list_a, inj_a, _ = _update_mainline_dra(
+            queue_inlet_a,
+            stn_a,
+            opt_a,
+            stn_a["L"],
+            flow_m3h,
+            hours,
+            pump_running=True,
+            pump_shear_rate=0.0,
+            dra_shear_factor=0.0,
+            shear_injection=False,
+            is_origin=True,
+            precomputed=pre_a,
+        )
+        queue_after_full_a = _normalise_queue(queue_after_list_a)
+        queue_after_inlet_a = _trim_queue_front(queue_after_full_a, stn_a["L"])
+
+        total_prev_full = _queue_total_length(queue_after_full_a)
+        total_prev_inlet = _queue_total_length(queue_after_inlet_a)
+        upstream_length = max(total_prev_full - total_prev_inlet, 0.0)
+        prefix_entries = _take_queue_front(queue_after_full_a, upstream_length)
+
+        pre_b = _prepare_dra_queue_consumption(
+            queue_after_inlet_a, stn_b["L"], flow_m3h, hours, stn_b["d_inner"]
+        )
+        dra_seg_b, queue_after_list_b, inj_b, _ = _update_mainline_dra(
+            queue_after_inlet_a,
+            stn_b,
+            opt_b,
+            stn_b["L"],
+            flow_m3h,
+            hours,
+            pump_running=True,
+            pump_shear_rate=0.20,
+            dra_shear_factor=0.0,
+            shear_injection=False,
+            is_origin=False,
+            precomputed=pre_b,
+        )
+        queue_after_body_b = _normalise_queue(queue_after_list_b)
+        combined_after_b = tuple(prefix_entries) + tuple(queue_after_body_b)
+        queue_after_full_b = _normalise_queue(combined_after_b)
+        queue_after_inlet_b = _trim_queue_front(queue_after_full_b, stn_b["L"])
+
+        queue_full = queue_after_full_b
+
+        profile_a = _segment_profile_from_queue(queue_after_full_b, 0.0, stn_a["L"])
+        profile_b = _segment_profile_from_queue(queue_after_full_b, stn_a["L"], stn_b["L"])
+
+        linefill_summary = _format_profile(queue_after_full_b, limit=4)
+        a_profile_summary = _format_profile(profile_a, limit=4)
+        b_profile_summary = _format_profile(profile_b, limit=4)
+
+        treated_length = sum(
+            float(length)
+            for length, ppm in queue_after_full_b
+            if float(ppm) > 1e-9
+        )
+        linefill_volume = _volume_from_km(
+            _queue_total_length(queue_after_full_b), stn_a["d_inner"]
+        )
+
+        print(
+            f"| {hour:>4} | {inj_a:>7.2f} | {inj_b:>7.2f} | {a_profile_summary} | "
+            f"{b_profile_summary} | {linefill_summary} | {treated_length:>6.1f} | "
+            f"{linefill_volume:>10.1f} |"
+        )
+
+        queue_full = queue_after_full_b
+        queue_inlet_a = queue_after_inlet_b
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow the queue-floor helper to skip raising positive ppm slices when applying fallback baselines so newly injected slugs keep their requested strength
- reuse the relaxed floor handling when repopulating queues from fallback or inferred ppm levels during mainline updates
- add regression coverage to confirm sub-baseline injections remain visible downstream whenever no explicit floor is enforced

## Testing
- pytest tests/test_pipeline_performance.py::test_update_mainline_dra_retains_lower_injection_than_baseline -q
- pytest tests/test_pipeline_performance.py::test_dra_profile_preserves_baseline_after_injection -q
- pytest tests/test_pipeline_performance.py::test_segment_floors_overlay_queue_minimum -q
- pytest tests/test_pipeline_performance.py -q

------
https://chatgpt.com/codex/tasks/task_e_68fb02b14e5c83319084403bc7a101e6