### PR TITLE
Fix DRA profile to preserve zero slug when injection fails

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1823,6 +1823,25 @@ def _update_mainline_dra(
     else:
         profile_source = tuple()
 
+    has_explicit_zero = False
+    if profile_source:
+        for entry in profile_source:
+            if not entry:
+                continue
+            try:
+                length_val = float(entry[0] if len(entry) > 0 else 0.0)
+            except (TypeError, ValueError):
+                length_val = 0.0
+            if length_val <= 0.0:
+                continue
+            try:
+                ppm_val = float(entry[1] if len(entry) > 1 else 0.0)
+            except (TypeError, ValueError):
+                ppm_val = 0.0
+            if ppm_val <= 0.0:
+                has_explicit_zero = True
+                break
+
     zero_fill_ppm = 0.0
     if not floor_requires_injection:
         if floor_segments:
@@ -1849,8 +1868,11 @@ def _update_mainline_dra(
             continue
         profile_total += length
         ppm_val = float(entry[1] if len(entry) > 1 else 0.0)
-        if ppm_val <= 0.0 and zero_fill_ppm > 0.0:
-            ppm_val = zero_fill_ppm
+        if ppm_val <= 0.0:
+            if zero_fill_ppm > 0.0 and not has_explicit_zero:
+                ppm_val = zero_fill_ppm
+            else:
+                ppm_val = 0.0
         if ppm_val <= 0.0:
             continue
         if dra_segments and abs(dra_segments[-1][1] - ppm_val) <= 1e-9:
@@ -1860,7 +1882,7 @@ def _update_mainline_dra(
             dra_segments.append((length, ppm_val))
 
     remaining_length = max(segment_length - min(profile_total, segment_length), 0.0)
-    if remaining_length > 1e-9 and zero_fill_ppm > 0.0:
+    if remaining_length > 1e-9 and zero_fill_ppm > 0.0 and not has_explicit_zero:
         if dra_segments and abs(dra_segments[-1][1] - zero_fill_ppm) <= 1e-9:
             prev_len, _ = dra_segments[-1]
             dra_segments[-1] = (prev_len + remaining_length, zero_fill_ppm)

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1876,6 +1876,11 @@ def _update_mainline_dra(
             else:
                 ppm_val = 0.0
         if ppm_val <= 0.0:
+            if dra_segments and abs(dra_segments[-1][1]) <= 1e-9:
+                prev_len, _ = dra_segments[-1]
+                dra_segments[-1] = (prev_len + length, 0.0)
+            else:
+                dra_segments.append((length, 0.0))
             continue
         if dra_segments and abs(dra_segments[-1][1] - ppm_val) <= 1e-9:
             prev_len, _ = dra_segments[-1]
@@ -5799,9 +5804,10 @@ def solve_pipeline(
                             ppm_f = 0.0
                         if length_f <= 0.0:
                             continue
-                        if ppm_f <= 0.0:
-                            continue
-                        profile_entries.append({'length_km': length_f, 'dra_ppm': ppm_f})
+                        profile_entries.append({
+                            'length_km': length_f,
+                            'dra_ppm': ppm_f if ppm_f > 0.0 else 0.0,
+                        })
 
                     treated_profile_length = sum(
                         entry['length_km']

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1587,10 +1587,10 @@ def _update_mainline_dra(
             continue
         ppm_input = float(ppm_val or 0.0)
         zero_output = False
-        if is_origin and inj_effective <= 0.0:
+        if inj_effective <= 0.0:
             if pump_running:
                 zero_output = True
-            elif flow_m3h <= 0.0:
+            elif is_origin and flow_m3h <= 0.0:
                 zero_output = True
         if zero_output:
             ppm_out = 0.0

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1610,6 +1610,8 @@ def _update_mainline_dra(
         for length, _ppm in pumped_portion
         if float(length or 0.0) > 0.0
     )
+    if pump_running and inj_effective <= 0.0 and pumped_length_total > 1e-9:
+        pumped_differs = True
     segments_defined = bool(floor_segments)
     floor_defined = bool(floor_specified and (floor_length > 0.0 or segments_defined))
     enforceable_floor = bool(

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -4369,6 +4369,38 @@ def test_update_mainline_dra_inserts_zero_slug_when_origin_skips_injection() -> 
     assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
 
 
+def test_update_mainline_dra_inserts_zero_slug_when_midline_skips_injection() -> None:
+    """Midline stations should also forward untreated fluid when skipping DRA."""
+
+    diameter_inner = 0.7461504
+    segment_length = 158.0
+    flow_m3h = 2600.0
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter_inner)
+
+    queue_initial = [{"length_km": segment_length, "dra_ppm": 6.0}]
+    station = {"idx": 2, "is_pump": True, "d_inner": diameter_inner}
+
+    dra_segments, queue_after, inj_ppm, requires_injection = _update_mainline_dra(
+        queue_initial,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+    )
+
+    assert inj_ppm == pytest.approx(0.0, rel=1e-9)
+    assert requires_injection is False
+    assert queue_after
+    assert queue_after[0]["length_km"] == pytest.approx(pumped_length, rel=1e-6)
+    assert queue_after[0]["dra_ppm"] == pytest.approx(0.0, abs=1e-9)
+
+    treated_length = sum(length for length, _ppm in dra_segments)
+    assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
+
+
 def test_update_mainline_dra_uses_fallback_when_queue_empty() -> None:
     """Fallback ppm should repopulate baseline when the queue is empty."""
 

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -4365,7 +4365,10 @@ def test_update_mainline_dra_inserts_zero_slug_when_origin_skips_injection() -> 
     assert queue_after[0]["length_km"] == pytest.approx(pumped_length, rel=1e-6)
     assert queue_after[0]["dra_ppm"] == pytest.approx(0.0, abs=1e-9)
 
-    treated_length = sum(length for length, _ppm in dra_segments)
+    assert dra_segments
+    assert dra_segments[0][0] == pytest.approx(pumped_length, rel=1e-6)
+    assert dra_segments[0][1] == pytest.approx(0.0, abs=1e-9)
+    treated_length = sum(length for length, ppm in dra_segments if ppm > 0)
     assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
 
 
@@ -4397,7 +4400,10 @@ def test_update_mainline_dra_inserts_zero_slug_when_midline_skips_injection() ->
     assert queue_after[0]["length_km"] == pytest.approx(pumped_length, rel=1e-6)
     assert queue_after[0]["dra_ppm"] == pytest.approx(0.0, abs=1e-9)
 
-    treated_length = sum(length for length, _ppm in dra_segments)
+    assert dra_segments
+    assert dra_segments[0][0] == pytest.approx(pumped_length, rel=1e-6)
+    assert dra_segments[0][1] == pytest.approx(0.0, abs=1e-9)
+    treated_length = sum(length for length, ppm in dra_segments if ppm > 0)
     assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
 
 
@@ -4413,7 +4419,7 @@ def test_update_mainline_dra_advects_zero_slug_across_hours() -> None:
     queue_initial = [{"length_km": segment_length + 30.0, "dra_ppm": 6.0}]
     station = {"idx": 1, "is_pump": True, "d_inner": diameter_inner}
 
-    _, queue_hour1, _, _ = _update_mainline_dra(
+    dra_segments_hour1, queue_hour1, _, _ = _update_mainline_dra(
         queue_initial,
         station,
         {"nop": 1, "dra_ppm_main": 0.0},
@@ -4423,7 +4429,7 @@ def test_update_mainline_dra_advects_zero_slug_across_hours() -> None:
         pump_running=True,
     )
 
-    _, queue_hour2, _, _ = _update_mainline_dra(
+    dra_segments_hour2, queue_hour2, _, _ = _update_mainline_dra(
         queue_hour1,
         station,
         {"nop": 1, "dra_ppm_main": 0.0},
@@ -4432,6 +4438,14 @@ def test_update_mainline_dra_advects_zero_slug_across_hours() -> None:
         hours,
         pump_running=True,
     )
+
+    assert dra_segments_hour1
+    assert dra_segments_hour1[0][0] == pytest.approx(pumped_length, rel=1e-6)
+    assert dra_segments_hour1[0][1] == pytest.approx(0.0, abs=1e-9)
+
+    assert dra_segments_hour2
+    assert dra_segments_hour2[0][0] == pytest.approx(2 * pumped_length, rel=1e-6)
+    assert dra_segments_hour2[0][1] == pytest.approx(0.0, abs=1e-9)
 
     def zero_front_length(queue: list[dict]) -> float:
         for entry in queue:

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -4336,6 +4336,39 @@ def test_update_mainline_dra_retains_lower_injection_than_baseline() -> None:
     assert dra_segments[1][1] == pytest.approx(4.0, rel=1e-6)
 
 
+def test_update_mainline_dra_inserts_zero_slug_when_origin_skips_injection() -> None:
+    """Origin stations should propagate untreated fluid when DRA is unavailable."""
+
+    diameter_inner = 0.7461504
+    segment_length = 158.0
+    flow_m3h = 2600.0
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter_inner)
+
+    queue_initial = [{"length_km": segment_length, "dra_ppm": 6.0}]
+    station = {"idx": 0, "is_pump": True, "d_inner": diameter_inner}
+
+    dra_segments, queue_after, inj_ppm, requires_injection = _update_mainline_dra(
+        queue_initial,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+        is_origin=True,
+    )
+
+    assert inj_ppm == pytest.approx(0.0, rel=1e-9)
+    assert requires_injection is False
+    assert queue_after
+    assert queue_after[0]["length_km"] == pytest.approx(pumped_length, rel=1e-6)
+    assert queue_after[0]["dra_ppm"] == pytest.approx(0.0, abs=1e-9)
+
+    treated_length = sum(length for length, _ppm in dra_segments)
+    assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
+
+
 def test_update_mainline_dra_uses_fallback_when_queue_empty() -> None:
     """Fallback ppm should repopulate baseline when the queue is empty."""
 

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -4401,6 +4401,61 @@ def test_update_mainline_dra_inserts_zero_slug_when_midline_skips_injection() ->
     assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
 
 
+def test_update_mainline_dra_advects_zero_slug_across_hours() -> None:
+    """Untreated slugs from midline stations should advance each hour."""
+
+    diameter_inner = 0.7461504
+    segment_length = 170.0
+    flow_m3h = 2600.0
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter_inner)
+
+    queue_initial = [{"length_km": segment_length + 30.0, "dra_ppm": 6.0}]
+    station = {"idx": 1, "is_pump": True, "d_inner": diameter_inner}
+
+    _, queue_hour1, _, _ = _update_mainline_dra(
+        queue_initial,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+    )
+
+    _, queue_hour2, _, _ = _update_mainline_dra(
+        queue_hour1,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+    )
+
+    def zero_front_length(queue: list[dict]) -> float:
+        for entry in queue:
+            ppm = float(entry.get("dra_ppm", 0.0) or 0.0)
+            if ppm <= 1e-9:
+                return float(entry.get("length_km", 0.0) or 0.0)
+            if entry.get("length_km", 0.0):
+                break
+        return 0.0
+
+    zero_hour1 = zero_front_length(queue_hour1)
+    zero_hour2 = zero_front_length(queue_hour2)
+
+    assert zero_hour1 == pytest.approx(pumped_length, rel=1e-6)
+    assert zero_hour2 == pytest.approx(2 * pumped_length, rel=1e-6)
+
+    treated_after_hour2 = sum(
+        entry["length_km"]
+        for entry in queue_hour2
+        if entry["length_km"] > 0 and entry["dra_ppm"] > 1e-9
+    )
+    assert treated_after_hour2 == pytest.approx(segment_length + 30.0 - zero_hour2, rel=1e-6)
+
+
 def test_update_mainline_dra_uses_fallback_when_queue_empty() -> None:
     """Fallback ppm should repopulate baseline when the queue is empty."""
 


### PR DESCRIPTION
## Summary
- prevent the DRA queue formatter from replacing explicit zero-ppm slices when no injection occurs
- add a regression test confirming an origin station emits an untreated slug if DRA is unavailable

## Testing
- pytest tests/test_pipeline_performance.py::test_update_mainline_dra_inserts_zero_slug_when_origin_skips_injection

------
https://chatgpt.com/codex/tasks/task_e_6901f99b83808331bd36967ecf6395dc