### PR TITLE
Preserve untreated DRA slugs in station profiles

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1587,10 +1587,10 @@ def _update_mainline_dra(
             continue
         ppm_input = float(ppm_val or 0.0)
         zero_output = False
-        if is_origin and inj_effective <= 0.0:
+        if inj_effective <= 0.0:
             if pump_running:
                 zero_output = True
-            elif flow_m3h <= 0.0:
+            elif is_origin and flow_m3h <= 0.0:
                 zero_output = True
         if zero_output:
             ppm_out = 0.0
@@ -1610,6 +1610,8 @@ def _update_mainline_dra(
         for length, _ppm in pumped_portion
         if float(length or 0.0) > 0.0
     )
+    if pump_running and inj_effective <= 0.0 and pumped_length_total > 1e-9:
+        pumped_differs = True
     segments_defined = bool(floor_segments)
     floor_defined = bool(floor_specified and (floor_length > 0.0 or segments_defined))
     enforceable_floor = bool(
@@ -1823,6 +1825,25 @@ def _update_mainline_dra(
     else:
         profile_source = tuple()
 
+    has_explicit_zero = False
+    if profile_source:
+        for entry in profile_source:
+            if not entry:
+                continue
+            try:
+                length_val = float(entry[0] if len(entry) > 0 else 0.0)
+            except (TypeError, ValueError):
+                length_val = 0.0
+            if length_val <= 0.0:
+                continue
+            try:
+                ppm_val = float(entry[1] if len(entry) > 1 else 0.0)
+            except (TypeError, ValueError):
+                ppm_val = 0.0
+            if ppm_val <= 0.0:
+                has_explicit_zero = True
+                break
+
     zero_fill_ppm = 0.0
     if not floor_requires_injection:
         if floor_segments:
@@ -1849,9 +1870,17 @@ def _update_mainline_dra(
             continue
         profile_total += length
         ppm_val = float(entry[1] if len(entry) > 1 else 0.0)
-        if ppm_val <= 0.0 and zero_fill_ppm > 0.0:
-            ppm_val = zero_fill_ppm
         if ppm_val <= 0.0:
+            if zero_fill_ppm > 0.0 and not has_explicit_zero:
+                ppm_val = zero_fill_ppm
+            else:
+                ppm_val = 0.0
+        if ppm_val <= 0.0:
+            if dra_segments and abs(dra_segments[-1][1]) <= 1e-9:
+                prev_len, _ = dra_segments[-1]
+                dra_segments[-1] = (prev_len + length, 0.0)
+            else:
+                dra_segments.append((length, 0.0))
             continue
         if dra_segments and abs(dra_segments[-1][1] - ppm_val) <= 1e-9:
             prev_len, _ = dra_segments[-1]
@@ -1860,7 +1889,7 @@ def _update_mainline_dra(
             dra_segments.append((length, ppm_val))
 
     remaining_length = max(segment_length - min(profile_total, segment_length), 0.0)
-    if remaining_length > 1e-9 and zero_fill_ppm > 0.0:
+    if remaining_length > 1e-9 and zero_fill_ppm > 0.0 and not has_explicit_zero:
         if dra_segments and abs(dra_segments[-1][1] - zero_fill_ppm) <= 1e-9:
             prev_len, _ = dra_segments[-1]
             dra_segments[-1] = (prev_len + remaining_length, zero_fill_ppm)
@@ -5775,9 +5804,10 @@ def solve_pipeline(
                             ppm_f = 0.0
                         if length_f <= 0.0:
                             continue
-                        if ppm_f <= 0.0:
-                            continue
-                        profile_entries.append({'length_km': length_f, 'dra_ppm': ppm_f})
+                        profile_entries.append({
+                            'length_km': length_f,
+                            'dra_ppm': ppm_f if ppm_f > 0.0 else 0.0,
+                        })
 
                     treated_profile_length = sum(
                         entry['length_km']
@@ -5794,13 +5824,11 @@ def solve_pipeline(
                         if profile_entries
                         else 0.0
                     )
-                    if inj_ppm_main <= 0.0:
-                        treated_profile_length = 0.0
-                        if not profile_entries or all(
-                            entry['dra_ppm'] <= 0.0 for entry in profile_entries
-                        ):
-                            inlet_ppm_profile = 0.0
-                            outlet_ppm_profile = 0.0
+                    if not profile_entries or all(
+                        entry['dra_ppm'] <= 0.0 for entry in profile_entries
+                    ):
+                        inlet_ppm_profile = 0.0
+                        outlet_ppm_profile = 0.0
                     record.update({
                         f"dra_profile_{stn_data['name']}": profile_entries,
                         f"dra_treated_length_{stn_data['name']}": treated_profile_length,

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -3095,8 +3095,6 @@ def _normalise_queue_segments(
             ppm_val = float(ppm_raw or 0.0)
         except (TypeError, ValueError):
             ppm_val = 0.0
-        if ppm_val <= 0.0:
-            continue
 
         normalised.append((length_val, ppm_val))
 
@@ -3138,21 +3136,21 @@ def _build_profiles_from_queue(
             overlap_start = max(cursor, seg_start)
             overlap_end = min(next_cursor, seg_end)
             overlap = overlap_end - overlap_start
-            if overlap > 1e-9 and ppm_val > 0.0:
+            if overlap > 1e-9:
                 entries.append((overlap, ppm_val))
             cursor = next_cursor
             if cursor >= seg_end - 1e-9:
                 break
 
-        treated = sum(length for length, _ppm in entries)
-        if seg_length - treated > 1e-6:
+        covered = sum(length for length, _ppm in entries)
+        if seg_length - covered > 1e-6:
             fallback = stn.get("fallback_dra_ppm", 0.0)
             try:
                 fallback_val = float(fallback or 0.0)
             except (TypeError, ValueError):
                 fallback_val = 0.0
             if fallback_val > 0.0:
-                entries.append((seg_length - treated, fallback_val))
+                entries.append((seg_length - covered, fallback_val))
 
         if entries:
             merged = pipeline_model._merge_queue(entries)  # type: ignore[attr-defined]

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -4884,6 +4884,34 @@ def test_build_profiles_from_queue_slices_per_station() -> None:
     assert balasore[0][1] == pytest.approx(6.0, rel=1e-6)
 
 
+def test_build_profiles_from_queue_preserves_zero_segments() -> None:
+    import pipeline_optimization_app as app
+
+    queue = [
+        {"length_km": 45.0, "dra_ppm": 0.0},
+        {"length_km": 30.0, "dra_ppm": 8.0},
+    ]
+
+    stations = [
+        {"name": "Paradip", "L": 30.0, "fallback_dra_ppm": 12.0},
+        {"name": "Balasore", "L": 25.0, "fallback_dra_ppm": 6.0},
+    ]
+
+    profiles = app._build_profiles_from_queue(queue, stations)
+    paradip = profiles.get("paradip")
+    assert paradip is not None
+    assert len(paradip) == 1
+    assert paradip[0][0] == pytest.approx(30.0, rel=1e-6)
+    assert paradip[0][1] == pytest.approx(0.0, abs=1e-9)
+
+    balasore = profiles.get("balasore")
+    assert balasore is not None
+    assert balasore[0][0] == pytest.approx(15.0, rel=1e-6)
+    assert balasore[0][1] == pytest.approx(0.0, abs=1e-9)
+    assert balasore[1][0] == pytest.approx(10.0, rel=1e-6)
+    assert balasore[1][1] == pytest.approx(8.0, rel=1e-6)
+
+
 def test_build_station_table_uses_override_profiles() -> None:
     import pipeline_optimization_app as app
     import pandas as pd

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -4336,6 +4336,204 @@ def test_update_mainline_dra_retains_lower_injection_than_baseline() -> None:
     assert dra_segments[1][1] == pytest.approx(4.0, rel=1e-6)
 
 
+def test_update_mainline_dra_inserts_zero_slug_when_origin_skips_injection() -> None:
+    """Origin stations should propagate untreated fluid when DRA is unavailable."""
+
+    diameter_inner = 0.7461504
+    segment_length = 158.0
+    flow_m3h = 2600.0
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter_inner)
+
+    queue_initial = [{"length_km": segment_length, "dra_ppm": 6.0}]
+    station = {"idx": 0, "is_pump": True, "d_inner": diameter_inner}
+
+    dra_segments, queue_after, inj_ppm, requires_injection = _update_mainline_dra(
+        queue_initial,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+        is_origin=True,
+    )
+
+    assert inj_ppm == pytest.approx(0.0, rel=1e-9)
+    assert requires_injection is False
+    assert queue_after
+    assert queue_after[0]["length_km"] == pytest.approx(pumped_length, rel=1e-6)
+    assert queue_after[0]["dra_ppm"] == pytest.approx(0.0, abs=1e-9)
+
+    assert dra_segments
+    assert dra_segments[0][0] == pytest.approx(pumped_length, rel=1e-6)
+    assert dra_segments[0][1] == pytest.approx(0.0, abs=1e-9)
+    treated_length = sum(length for length, ppm in dra_segments if ppm > 0)
+    assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
+
+
+def test_update_mainline_dra_inserts_zero_slug_when_midline_skips_injection() -> None:
+    """Midline stations should also forward untreated fluid when skipping DRA."""
+
+    diameter_inner = 0.7461504
+    segment_length = 158.0
+    flow_m3h = 2600.0
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter_inner)
+
+    queue_initial = [{"length_km": segment_length, "dra_ppm": 6.0}]
+    station = {"idx": 2, "is_pump": True, "d_inner": diameter_inner}
+
+    dra_segments, queue_after, inj_ppm, requires_injection = _update_mainline_dra(
+        queue_initial,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+    )
+
+    assert inj_ppm == pytest.approx(0.0, rel=1e-9)
+    assert requires_injection is False
+    assert queue_after
+    assert queue_after[0]["length_km"] == pytest.approx(pumped_length, rel=1e-6)
+    assert queue_after[0]["dra_ppm"] == pytest.approx(0.0, abs=1e-9)
+
+    assert dra_segments
+    assert dra_segments[0][0] == pytest.approx(pumped_length, rel=1e-6)
+    assert dra_segments[0][1] == pytest.approx(0.0, abs=1e-9)
+    treated_length = sum(length for length, ppm in dra_segments if ppm > 0)
+    assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
+
+
+def test_update_mainline_dra_advects_zero_slug_across_hours() -> None:
+    """Untreated slugs from midline stations should advance each hour."""
+
+    diameter_inner = 0.7461504
+    segment_length = 170.0
+    flow_m3h = 2600.0
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter_inner)
+
+    queue_initial = [{"length_km": segment_length + 30.0, "dra_ppm": 6.0}]
+    station = {"idx": 1, "is_pump": True, "d_inner": diameter_inner}
+
+    dra_segments_hour1, queue_hour1, _, _ = _update_mainline_dra(
+        queue_initial,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+    )
+
+    dra_segments_hour2, queue_hour2, _, _ = _update_mainline_dra(
+        queue_hour1,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+    )
+
+    assert dra_segments_hour1
+    assert dra_segments_hour1[0][0] == pytest.approx(pumped_length, rel=1e-6)
+    assert dra_segments_hour1[0][1] == pytest.approx(0.0, abs=1e-9)
+
+    assert dra_segments_hour2
+    assert dra_segments_hour2[0][0] == pytest.approx(2 * pumped_length, rel=1e-6)
+    assert dra_segments_hour2[0][1] == pytest.approx(0.0, abs=1e-9)
+
+    def zero_front_length(queue: list[dict]) -> float:
+        for entry in queue:
+            ppm = float(entry.get("dra_ppm", 0.0) or 0.0)
+            if ppm <= 1e-9:
+                return float(entry.get("length_km", 0.0) or 0.0)
+            if entry.get("length_km", 0.0):
+                break
+        return 0.0
+
+    zero_hour1 = zero_front_length(queue_hour1)
+    zero_hour2 = zero_front_length(queue_hour2)
+
+    assert zero_hour1 == pytest.approx(pumped_length, rel=1e-6)
+    assert zero_hour2 == pytest.approx(2 * pumped_length, rel=1e-6)
+
+    treated_after_hour2 = sum(
+        entry["length_km"]
+        for entry in queue_hour2
+        if entry["length_km"] > 0 and entry["dra_ppm"] > 1e-9
+    )
+    assert treated_after_hour2 == pytest.approx(segment_length + 30.0 - zero_hour2, rel=1e-6)
+
+
+def test_station_record_preserves_zero_segments_without_injection() -> None:
+    """Reporting profiles must expose the untreated front when no DRA is injected."""
+
+    diameter_inner = 0.7461504
+    segment_length = 158.0
+    flow_m3h = 2600.0
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter_inner)
+
+    queue_initial = [{"length_km": segment_length, "dra_ppm": 6.0}]
+    station = {
+        "idx": 0,
+        "is_pump": True,
+        "d_inner": diameter_inner,
+        "L": segment_length,
+        "kv": 6.0,
+        "rough": 4e-5,
+        "name": "station_a",
+        "rho": 850.0,
+    }
+
+    _segments, queue_after, inj_ppm, _ = _update_mainline_dra(
+        queue_initial,
+        station,
+        {"nop": 1, "dra_ppm_main": 0.0},
+        segment_length,
+        flow_m3h,
+        hours,
+        pump_running=True,
+        is_origin=True,
+    )
+
+    assert inj_ppm == pytest.approx(0.0, abs=1e-9)
+
+    queue_after_full = _merge_queue(
+        tuple(
+            (float(entry["length_km"]), float(entry["dra_ppm"]))
+            for entry in queue_after
+            if float(entry["length_km"]) > 0.0
+        )
+    )
+    profile_source = _segment_profile_from_queue(queue_after_full, 0.0, segment_length)
+    profile_entries = [
+        {
+            "length_km": float(length),
+            "dra_ppm": float(ppm) if float(ppm) > 0.0 else 0.0,
+        }
+        for length, ppm in profile_source
+        if float(length) > 0.0
+    ]
+
+    assert profile_entries, "Expected profile to contain at least one slice"
+    assert profile_entries[0]["dra_ppm"] == pytest.approx(0.0, abs=1e-9)
+    treated_length = sum(
+        entry["length_km"]
+        for entry in profile_entries
+        if entry["dra_ppm"] > 0.0
+    )
+    untreated_length = segment_length - treated_length
+
+    assert treated_length == pytest.approx(segment_length - pumped_length, rel=1e-6)
+    assert untreated_length == pytest.approx(pumped_length, rel=1e-6)
+
+
 def test_update_mainline_dra_uses_fallback_when_queue_empty() -> None:
     """Fallback ppm should repopulate baseline when the queue is empty."""
 


### PR DESCRIPTION
## Summary
- keep the reported station DRA profile from collapsing when the optimiser skips injection so untreated slugs remain visible
- add a regression test that verifies the station profile exposes the zero-ppm front and treated length shrinks accordingly

## Testing
- pytest tests/test_pipeline_performance.py::test_update_mainline_dra_advects_zero_slug_across_hours tests/test_pipeline_performance.py::test_station_record_preserves_zero_segments_without_injection -q
- pytest tests/test_pipeline_performance.py::test_dra_profile_reflects_hourly_push_examples -q

------
https://chatgpt.com/codex/tasks/task_e_6901f99b83808331bd36967ecf6395dc