### PR TITLE
Add DRA fallback handling and zero-profile reporting

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -185,16 +185,17 @@ def _station_allows_mixed_pump_types(stn: Mapping[str, object]) -> bool:
 
     pump_types = stn.get('pump_types')
     if isinstance(pump_types, Mapping):
-        try:
-            avail_a = int(_coerce_float(pump_types.get('A', {}).get('available', 0), 0.0))
-        except Exception:
-            avail_a = 0
-        try:
-            avail_b = int(_coerce_float(pump_types.get('B', {}).get('available', 0), 0.0))
-        except Exception:
-            avail_b = 0
-        if avail_a > 0 and avail_b > 0:
-            return True
+        nested_flag = pump_types.get('allow_mixed_pump_types')
+        if isinstance(nested_flag, bool):
+            return nested_flag
+        if isinstance(nested_flag, (int, float)):
+            return bool(nested_flag)
+        if isinstance(nested_flag, str):
+            value = nested_flag.strip().lower()
+            if value in {'1', 'true', 'yes', 'y', 'on'}:
+                return True
+            if value in {'0', 'false', 'no', 'n', 'off'}:
+                return False
     return False
 
 
@@ -4221,7 +4222,8 @@ def solve_pipeline(
                     continue
                 if floor_dr < 0:
                     floor_dr = 0
-                floor_ranges[idx] = {"dra_main": (floor_dr, floor_dr)}
+                if floor_dr > 0:
+                    floor_ranges[idx] = {"dra_main": (floor_dr, floor_dr)}
             if floor_ranges:
                 floor_result = solve_pipeline(
                     stations,
@@ -4573,6 +4575,7 @@ def solve_pipeline(
                 if floor_perc_min_int > 0:
                     fixed_val = max(fixed_val, floor_perc_min_int)
                 dra_main_vals = [fixed_val]
+                dra_grid_min = dra_grid_max = fixed_val
             else:
                 dr_min, dr_max = 0, max_dr_main
                 if rng and 'dra_main' in rng:
@@ -5786,6 +5789,7 @@ def solve_pipeline(
                             f"drag_reduction_loop_{stn_data['name']}": eff_dra_loop,
                         })
                     profile_entries: list[dict[str, float]] = []
+                    include_zero_profile = inj_ppm_main <= 0.0
                     for length, ppm in segment_profile_raw:
                         try:
                             length_f = float(length or 0.0)
@@ -5797,9 +5801,19 @@ def solve_pipeline(
                             ppm_f = 0.0
                         if length_f <= 0.0:
                             continue
-                        if ppm_f <= 0.0:
+                        if ppm_f <= 0.0 and not include_zero_profile:
                             continue
                         profile_entries.append({'length_km': length_f, 'dra_ppm': ppm_f})
+                    if include_zero_profile and not profile_entries:
+                        pumped_profile_length = _km_from_volume(flow_total * hours, stn_data['d_inner'])
+                        if seg_length_total > 0.0:
+                            pumped_profile_length = min(max(pumped_profile_length, 0.0), seg_length_total)
+                        else:
+                            pumped_profile_length = max(pumped_profile_length, 0.0)
+                        if pumped_profile_length > 0.0:
+                            profile_entries.append(
+                                {'length_km': pumped_profile_length, 'dra_ppm': 0.0}
+                            )
 
                     treated_profile_length = sum(
                         entry['length_km']

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1665,16 +1665,13 @@ def _update_mainline_dra(
             for length, ppm in pumped_adjusted
             if float(length or 0.0) > 0.0
         ]
-        if inj_effective > 0.0:
-            tail_queue = list(remaining_queue)
-        else:
-            tail_queue = list(existing_queue) if pumped_differs else list(remaining_queue)
     else:
         advected_portion = pumped_adjusted
-        if inj_effective > 0.0:
-            tail_queue = list(remaining_queue)
-        else:
-            tail_queue = list(existing_queue) if pumped_differs else list(remaining_queue)
+
+    if inj_effective > 0.0:
+        tail_queue = list(remaining_queue)
+    else:
+        tail_queue = list(existing_queue)
 
     combined_entries: list[tuple[float, float]] = []
     if pump_running and inj_effective > 0.0 and head_length > 0.0:
@@ -1735,7 +1732,10 @@ def _update_mainline_dra(
                 rest_entries = rest_entries[1:]
 
             zero_capacity = max(pipeline_length - inj_length, 0.0)
-            target_zero_length = min(initial_zero_prefix + head_length, zero_capacity)
+            if inj_effective > 0.0:
+                target_zero_length = min(initial_zero_prefix, zero_capacity)
+            else:
+                target_zero_length = min(initial_zero_prefix + head_length, zero_capacity)
             if target_zero_length < zero_front_pre:
                 target_zero_length = zero_front_pre
 
@@ -1793,25 +1793,34 @@ def _update_mainline_dra(
                 ),
             )
     elif inj_effective > 0.0:
-        inferred_ppm = 0.0
-        for _len_existing, ppm_existing in reversed(existing_queue):
-            if ppm_existing > 0.0:
-                inferred_ppm = ppm_existing
-                break
-        inferred_length = target_length if target_length > 0 else segment_length
-        if inferred_ppm > 0.0 and inferred_length > 0.0 and merged_queue:
-            merged_with_inferred = _ensure_queue_floor(
-                merged_queue,
-                inferred_length,
-                inferred_ppm,
-                None,
-                enforce_positive_floor=False,
-            )
-            merged_queue = tuple(
-                (float(length), float(ppm))
-                for length, ppm in merged_with_inferred
-                if float(length or 0.0) > 0.0
-            )
+        has_zero_segment = any(
+            float(ppm or 0.0) <= 0.0 for length, ppm in merged_queue if float(length or 0.0) > 0.0
+        )
+        try:
+            station_idx = int(stn_data.get('idx', -1))
+        except (TypeError, ValueError):
+            station_idx = -1
+        preserve_zero_segment = has_zero_segment and station_idx == 0
+        if not preserve_zero_segment:
+            inferred_ppm = 0.0
+            for _len_existing, ppm_existing in reversed(existing_queue):
+                if ppm_existing > 0.0:
+                    inferred_ppm = ppm_existing
+                    break
+            inferred_length = target_length if target_length > 0 else segment_length
+            if inferred_ppm > 0.0 and inferred_length > 0.0 and merged_queue:
+                merged_with_inferred = _ensure_queue_floor(
+                    merged_queue,
+                    inferred_length,
+                    inferred_ppm,
+                    None,
+                    enforce_positive_floor=False,
+                )
+                merged_queue = tuple(
+                    (float(length), float(ppm))
+                    for length, ppm in merged_with_inferred
+                    if float(length or 0.0) > 0.0
+                )
 
     queue_after = [
         {'length_km': float(length), 'dra_ppm': float(ppm)}
@@ -5790,6 +5799,20 @@ def solve_pipeline(
                         })
                     profile_entries: list[dict[str, float]] = []
                     include_zero_profile = inj_ppm_main <= 0.0
+                    if not include_zero_profile:
+                        try:
+                            station_idx = int(stn_data.get('idx', -1))
+                        except (TypeError, ValueError):
+                            station_idx = -1
+                        if station_idx == 0:
+                            for _length_val, ppm_val in segment_profile_raw:
+                                try:
+                                    ppm_check = float(ppm_val or 0.0)
+                                except (TypeError, ValueError):
+                                    ppm_check = 0.0
+                                if ppm_check <= 0.0:
+                                    include_zero_profile = True
+                                    break
                     for length, ppm in segment_profile_raw:
                         try:
                             length_f = float(length or 0.0)

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -5038,48 +5038,46 @@ def _execute_time_series_solver(
         return tested[key]
 
     with st.spinner("Computing max achievable flow"):
-        baseline = _run_cached(0.0)
-        if baseline.get("error"):
-            best_result: dict | None = None
-            best_flow = 0.0
-        else:
-            best_result = baseline
-            best_flow = 0.0
-        low = 0.0
-        high = flow_request
-        tolerance = max(flow_request * 1e-3, 0.5)
-        if baseline.get("error"):
-            pass
-        for _ in range(25):
-            if high - low <= tolerance:
+        step_size = float(st.session_state.get("flow_fallback_step_m3h", 50.0) or 50.0)
+        if not math.isfinite(step_size) or step_size <= 0.0:
+            step_size = 50.0
+
+        def _snap_down(value: float) -> float:
+            if step_size <= 0.0:
+                return max(float(value), 0.0)
+            steps = math.floor(max(float(value), 0.0) / step_size)
+            snapped = steps * step_size
+            return round(snapped, 6)
+
+        best_result: dict | None = None
+        best_flow = 0.0
+
+        candidate = _snap_down(flow_request)
+        if math.isclose(candidate, flow_request, rel_tol=1e-9, abs_tol=1e-9):
+            candidate = _snap_down(candidate - step_size)
+        tested_steps: set[float] = set()
+
+        while candidate >= 0.0:
+            candidate = max(candidate, 0.0)
+            key = round(candidate, 6)
+            if key in tested_steps and candidate > 0.0:
+                candidate = _snap_down(candidate - step_size)
+                continue
+            tested_steps.add(key)
+            cand_res = _run_cached(candidate)
+            if not cand_res.get("error"):
+                best_result = cand_res
+                best_flow = candidate
                 break
-            mid = 0.5 * (low + high)
-            mid_res = _run_cached(mid)
-            if mid_res.get("error"):
-                high = mid
-            else:
-                low = mid
-                best_result = mid_res
-                best_flow = mid
-        if best_result is not None and not best_result.get("error"):
-            final_res = _run_cached(low)
-            if not final_res.get("error"):
-                best_result = final_res
-                best_flow = low
-            upper_candidate = min(high, flow_request)
-            upper_floor = int(math.floor(upper_candidate)) if upper_candidate > 0 else 0
-            best_floor = int(math.floor(best_flow)) if best_flow > 0 else 0
-            if upper_floor > best_floor:
-                for candidate in range(upper_floor, best_floor, -1):
-                    if candidate <= 0:
-                        break
-                    int_res = _run_cached(float(candidate))
-                    if not int_res.get("error"):
-                        best_result = int_res
-                        best_flow = float(candidate)
-                        break
-        else:
-            best_flow = 0.0
+            if candidate <= 0.0:
+                break
+            candidate = _snap_down(candidate - step_size)
+
+        if best_result is None:
+            zero_res = _run_cached(0.0)
+            if not zero_res.get("error"):
+                best_result = zero_res
+                best_flow = 0.0
 
     if best_result is None or best_result.get("error"):
         result.setdefault("flow_achieved_m3h", 0.0)
@@ -5094,9 +5092,11 @@ def _execute_time_series_solver(
     best_result["flow_achieved_m3h"] = best_flow
     best_result["flow_total_achieved_m3"] = achieved_total
     best_result["flow_fallback_applied"] = True
+    trimmed_total = max(total_requested - achieved_total, 0.0)
     best_result["flow_fallback_note"] = (
         f"Target hourly flow {flow_request:.2f} m³/h was infeasible. "
-        f"Optimized for {best_flow:.2f} m³/h ({achieved_total:.0f} m³ total)."
+        f"Optimized for {best_flow:.2f} m³/h ({achieved_total:.0f} m³ total). "
+        f"Trimmed {trimmed_total:.0f} m³ from the end of the pumping schedule."
     )
     return best_result
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -59,6 +59,7 @@ import pandas as pd
 import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
+import math
 from math import isclose, pi, sqrt
 import hashlib
 import uuid
@@ -4665,7 +4666,7 @@ def _format_plan_injection_label(
     return label
 
 
-def _execute_time_series_solver(
+def _execute_time_series_solver_core(
     stations_base: list[dict],
     term_data: dict,
     hours: list[int],
@@ -4952,6 +4953,152 @@ def _execute_time_series_solver(
         "enforced_origin_actions": enforced_actions,
     }
     return result
+
+
+def _execute_time_series_solver(
+    stations_base: list[dict],
+    term_data: dict,
+    hours: list[int],
+    *,
+    flow_rate: float,
+    plan_df: pd.DataFrame | None,
+    current_vol: pd.DataFrame,
+    dra_linefill: list[dict],
+    dra_reach_km: float,
+    RateDRA: float,
+    Price_HSD: float,
+    fuel_density: float,
+    ambient_temp: float,
+    mop_kgcm2: float | None,
+    pump_shear_rate: float,
+    total_length: float,
+    sub_steps: int = 1,
+) -> dict:
+    import copy
+
+    hours_list = list(hours)
+    flow_request = float(flow_rate or 0.0)
+
+    plan_template = plan_df.copy() if isinstance(plan_df, pd.DataFrame) else None
+    current_template = current_vol.copy() if hasattr(current_vol, "copy") else current_vol
+    dra_linefill_template = copy.deepcopy(dra_linefill)
+    dra_reach_template = float(dra_reach_km)
+
+    def _run_solver(flow_target: float) -> dict:
+        return _execute_time_series_solver_core(
+            stations_base,
+            term_data,
+            hours_list,
+            flow_rate=flow_target,
+            plan_df=plan_template.copy() if isinstance(plan_template, pd.DataFrame) else None,
+            current_vol=current_template.copy() if hasattr(current_template, "copy") else current_template,
+            dra_linefill=copy.deepcopy(dra_linefill_template),
+            dra_reach_km=dra_reach_template,
+            RateDRA=RateDRA,
+            Price_HSD=Price_HSD,
+            fuel_density=fuel_density,
+            ambient_temp=ambient_temp,
+            mop_kgcm2=mop_kgcm2,
+            pump_shear_rate=pump_shear_rate,
+            total_length=total_length,
+            sub_steps=sub_steps,
+        )
+
+    result = _run_solver(flow_request)
+
+    hours_count = len(hours_list)
+    total_requested = flow_request * hours_count
+    result["flow_request_m3h"] = flow_request
+    result["flow_total_requested_m3"] = total_requested
+    if not result.get("error"):
+        result["flow_achieved_m3h"] = flow_request
+        result["flow_total_achieved_m3"] = total_requested
+        result["flow_fallback_applied"] = False
+        return result
+
+    error_text = str(result.get("error", ""))
+    should_attempt_fallback = (
+        flow_request > 0.0
+        and hours_count > 1
+        and "no feasible" in error_text.lower()
+    )
+    if not should_attempt_fallback:
+        result.setdefault("flow_achieved_m3h", 0.0)
+        result.setdefault("flow_total_achieved_m3", 0.0)
+        result.setdefault("flow_fallback_applied", False)
+        return result
+
+    tested: dict[float, dict] = {}
+
+    def _run_cached(flow_target: float) -> dict:
+        flow_clean = max(float(flow_target or 0.0), 0.0)
+        key = round(flow_clean, 6)
+        if key not in tested:
+            tested[key] = _run_solver(flow_clean)
+        return tested[key]
+
+    with st.spinner("Computing max achievable flow"):
+        baseline = _run_cached(0.0)
+        if baseline.get("error"):
+            best_result: dict | None = None
+            best_flow = 0.0
+        else:
+            best_result = baseline
+            best_flow = 0.0
+        low = 0.0
+        high = flow_request
+        tolerance = max(flow_request * 1e-3, 0.5)
+        if baseline.get("error"):
+            pass
+        for _ in range(25):
+            if high - low <= tolerance:
+                break
+            mid = 0.5 * (low + high)
+            mid_res = _run_cached(mid)
+            if mid_res.get("error"):
+                high = mid
+            else:
+                low = mid
+                best_result = mid_res
+                best_flow = mid
+        if best_result is not None and not best_result.get("error"):
+            final_res = _run_cached(low)
+            if not final_res.get("error"):
+                best_result = final_res
+                best_flow = low
+            upper_candidate = min(high, flow_request)
+            upper_floor = int(math.floor(upper_candidate)) if upper_candidate > 0 else 0
+            best_floor = int(math.floor(best_flow)) if best_flow > 0 else 0
+            if upper_floor > best_floor:
+                for candidate in range(upper_floor, best_floor, -1):
+                    if candidate <= 0:
+                        break
+                    int_res = _run_cached(float(candidate))
+                    if not int_res.get("error"):
+                        best_result = int_res
+                        best_flow = float(candidate)
+                        break
+        else:
+            best_flow = 0.0
+
+    if best_result is None or best_result.get("error"):
+        result.setdefault("flow_achieved_m3h", 0.0)
+        result.setdefault("flow_total_achieved_m3", 0.0)
+        result.setdefault("flow_fallback_applied", False)
+        return result
+
+    best_result = copy.deepcopy(best_result)
+    achieved_total = best_flow * hours_count
+    best_result["flow_request_m3h"] = flow_request
+    best_result["flow_total_requested_m3"] = total_requested
+    best_result["flow_achieved_m3h"] = best_flow
+    best_result["flow_total_achieved_m3"] = achieved_total
+    best_result["flow_fallback_applied"] = True
+    best_result["flow_fallback_note"] = (
+        f"Target hourly flow {flow_request:.2f} m³/h was infeasible. "
+        f"Optimized for {best_flow:.2f} m³/h ({achieved_total:.0f} m³ total)."
+    )
+    return best_result
 
 
 def _build_enforced_origin_warning(
@@ -5375,6 +5522,10 @@ if not auto_batch:
             "Run Hourly Flow Rate Optimizer" if is_hourly else "Run Daily Pumping Schedule Optimizer",
             elapsed,
         )
+
+        fallback_note = solver_result.get("flow_fallback_note")
+        if fallback_note:
+            st.info(fallback_note)
 
         if solver_result.get("backtracked"):
             warn_msg = _build_enforced_origin_warning(

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -5061,7 +5061,10 @@ def _execute_time_series_solver(
             candidate = max(candidate, 0.0)
             key = round(candidate, 6)
             if key in tested_steps and candidate > 0.0:
-                candidate = _snap_down(candidate - step_size)
+                next_candidate = _snap_down(candidate - step_size)
+                if math.isclose(next_candidate, candidate, rel_tol=1e-12, abs_tol=1e-12):
+                    break
+                candidate = next_candidate
                 continue
             tested_steps.add(key)
             cand_res = _run_cached(candidate)
@@ -5071,7 +5074,10 @@ def _execute_time_series_solver(
                 break
             if candidate <= 0.0:
                 break
-            candidate = _snap_down(candidate - step_size)
+            next_candidate = _snap_down(candidate - step_size)
+            if math.isclose(next_candidate, candidate, rel_tol=1e-12, abs_tol=1e-12):
+                break
+            candidate = next_candidate
 
         if best_result is None:
             zero_res = _run_cached(0.0)

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -2108,6 +2108,105 @@ def test_time_series_solver_reports_error_without_plan(monkeypatch):
     assert result["backtracked"] is False
 
 
+def test_time_series_solver_computes_max_feasible_flow(monkeypatch):
+    import copy
+    import pipeline_optimization_app as app
+
+    stations_base = [
+        {
+            "name": "Station A",
+            "is_pump": True,
+            "L": 20.0,
+            "D": 0.7,
+            "t": 0.007,
+            "max_pumps": 1,
+        }
+    ]
+    term_data = {"name": "Terminal", "elev": 0.0, "min_residual": 10.0}
+    hours = [(7 + h) % 24 for h in range(24)]
+
+    vol_df = pd.DataFrame(
+        [
+            {
+                "Product": "Batch 1",
+                "Volume (m³)": 12000.0,
+                "Viscosity (cSt)": 2.5,
+                "Density (kg/m³)": 820.0,
+                app.INIT_DRA_COL: 0.0,
+            }
+        ]
+    )
+    vol_df = app.ensure_initial_dra_column(vol_df, default=0.0, fill_blanks=True)
+    dra_linefill = app.df_to_dra_linefill(vol_df)
+    current_vol = app.apply_dra_ppm(vol_df.copy(), dra_linefill)
+
+    attempts: list[float] = []
+
+    def fake_solver(*solver_args, **solver_kwargs):
+        (
+            stations,
+            terminal,
+            flow,
+            kv_list,
+            rho_list,
+            segment_slices,
+            RateDRA,
+            Price_HSD,
+            fuel_density,
+            ambient_temp,
+            dra_linefill_in,
+            dra_reach_km,
+            mop_kgcm2,
+            *_,
+        ) = solver_args
+
+        attempts.append(float(flow))
+        if flow > 2400.0:
+            return {"error": True, "message": "No feasible pump combination found for stations."}
+
+        return {
+            "error": False,
+            "total_cost": float(flow) * 0.1,
+            "linefill": copy.deepcopy(dra_linefill_in),
+            "dra_front_km": float(dra_reach_km),
+        }
+
+    monkeypatch.setattr(app, "solve_pipeline", fake_solver)
+    monkeypatch.setattr(app.st, "spinner", _null_spinner)
+
+    result = app._execute_time_series_solver(
+        stations_base,
+        term_data,
+        hours,
+        flow_rate=3000.0,
+        plan_df=vol_df.copy(),
+        current_vol=current_vol,
+        dra_linefill=dra_linefill,
+        dra_reach_km=0.0,
+        RateDRA=5.0,
+        Price_HSD=0.0,
+        fuel_density=820.0,
+        ambient_temp=25.0,
+        mop_kgcm2=100.0,
+        pump_shear_rate=0.0,
+        total_length=sum(stn["L"] for stn in stations_base),
+        sub_steps=1,
+    )
+
+    assert result["error"] is None
+    assert result.get("flow_fallback_applied") is True
+    assert result.get("flow_request_m3h") == pytest.approx(3000.0)
+    achieved_flow = float(result.get("flow_achieved_m3h", 0.0))
+    assert achieved_flow == pytest.approx(2400.0, abs=5.0)
+    assert achieved_flow >= 0.0
+    total_hours = len(hours)
+    assert result.get("flow_total_achieved_m3") == pytest.approx(achieved_flow * total_hours, rel=1e-6)
+    assert any(flow > 2400.0 for flow in attempts)
+    assert any(flow <= 2400.0 for flow in attempts)
+    note = result.get("flow_fallback_note", "")
+    assert "2400" in note or "2,400" in note
+
+
 def test_time_series_solver_enforces_when_head_untreated(monkeypatch):
     import pipeline_optimization_app as app
 
@@ -4421,6 +4520,63 @@ def test_update_mainline_dra_uses_fallback_when_queue_empty() -> None:
     assert dra_segments_baseline[0][0] == pytest.approx(segment_length, rel=1e-6)
     assert dra_segments_baseline[0][1] == pytest.approx(4.0, rel=1e-6)
     assert queue_after_baseline and queue_after_baseline[0]["dra_ppm"] == pytest.approx(4.0, rel=1e-6)
+
+
+def test_pipeline_profile_reports_zero_when_uninjected() -> None:
+    stations = [
+        {
+            "name": "Station A",
+            "is_pump": True,
+            "min_pumps": 1,
+            "max_pumps": 1,
+            "MinRPM": 1000,
+            "DOL": 2800,
+            "pump_type": "type1",
+            "A": 0.0,
+            "B": 0.0,
+            "C": 190.0,
+            "P": 0.0,
+            "Q": 0.0,
+            "R": 0.0,
+            "S": 0.0,
+            "T": 82.0,
+            "L": 40.0,
+            "d": 0.7,
+            "rough": 0.00004,
+            "elev": 0.0,
+            "min_residual": 25,
+            "max_dr": 0,
+            "power_type": "Grid",
+            "rate": 0.0,
+        }
+    ]
+    terminal = {"name": "Terminal", "elev": 0.0, "min_residual": 25}
+
+    result = solve_pipeline(
+        stations,
+        terminal,
+        FLOW=1600.0,
+        KV_list=[1.8],
+        rho_list=[845.0],
+        RateDRA=5.0,
+        Price_HSD=0.0,
+        Fuel_density=0.85,
+        Ambient_temp=25.0,
+        linefill=[{"volume": 9000.0, "dra_ppm": 0.0}],
+        dra_reach_km=0.0,
+        hours=1.0,
+        start_time="00:00",
+        enumerate_loops=False,
+        rpm_step=50,
+        dra_step=2,
+    )
+
+    assert not result.get("error"), result.get("message")
+    profile = result.get("dra_profile_station_a") or []
+    assert profile, "Expected zero-ppm profile entry"
+    first_entry = profile[0]
+    assert first_entry["dra_ppm"] == pytest.approx(0.0, abs=1e-9)
+    assert first_entry["length_km"] > 0.0
 
 
 def test_update_mainline_dra_preserves_prior_slug_with_downstream_injection() -> None:

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -2160,7 +2160,13 @@ def test_time_series_solver_computes_max_feasible_flow(monkeypatch):
             *_,
         ) = solver_args
 
-        attempts.append(float(flow))
+        start_time = str(solver_kwargs.get("start_time", "00:00"))
+        try:
+            hour = int(start_time.split(":")[0])
+        except (ValueError, TypeError):
+            hour = -1
+        if hour == hours[0] % 24:
+            attempts.append(float(flow))
         if flow > 2400.0:
             return {"error": True, "message": "No feasible pump combination found for stations."}
 
@@ -2197,14 +2203,17 @@ def test_time_series_solver_computes_max_feasible_flow(monkeypatch):
     assert result.get("flow_fallback_applied") is True
     assert result.get("flow_request_m3h") == pytest.approx(3000.0)
     achieved_flow = float(result.get("flow_achieved_m3h", 0.0))
-    assert achieved_flow == pytest.approx(2400.0, abs=5.0)
+    assert achieved_flow == pytest.approx(2400.0, abs=1e-6)
     assert achieved_flow >= 0.0
     total_hours = len(hours)
     assert result.get("flow_total_achieved_m3") == pytest.approx(achieved_flow * total_hours, rel=1e-6)
-    assert any(flow > 2400.0 for flow in attempts)
-    assert any(flow <= 2400.0 for flow in attempts)
+
+    expected_attempts = [3000.0] + [3000.0 - 50.0 * i for i in range(1, 13)]
+    assert attempts == pytest.approx(expected_attempts)
+
     note = result.get("flow_fallback_note", "")
     assert "2400" in note or "2,400" in note
+    assert "Trimmed" in note
 
 
 def test_time_series_solver_enforces_when_head_untreated(monkeypatch):

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -4357,6 +4357,66 @@ def test_dra_profile_reflects_hourly_push_examples() -> None:
     _assert_profile(profile_b_no_injection, [(2.0, 0.0), (18.0, 10.0)])
 
 
+def test_dra_profile_accumulates_zero_slug_until_injection() -> None:
+    """Zero-injection hours should build a growing untreated front at the origin."""
+
+    segment_length = 158.0
+    flow_m3h = 3000.0
+    diameter = 0.7386975636894871
+    hours = 1.0
+    pumped_length = _km_from_volume(flow_m3h * hours, diameter)
+
+    station = {"idx": 0, "is_pump": True, "d_inner": diameter, "L": segment_length}
+
+    queue: list[dict[str, float]] = [{"length_km": segment_length, "dra_ppm": 5.0}]
+
+    def _advance(queue_in: list[dict[str, float]], inj_ppm: float) -> tuple[list[dict[str, float]], list[tuple[float, float]]]:
+        dra_segments, queue_after, _, _ = _update_mainline_dra(
+            queue_in,
+            station,
+            {"nop": 1, "dra_ppm_main": inj_ppm},
+            segment_length,
+            flow_m3h,
+            hours,
+            pump_running=True,
+            is_origin=True,
+        )
+        assert not dra_segments or isinstance(dra_segments, list)
+        merged_queue = tuple(
+            (float(entry["length_km"]), float(entry["dra_ppm"]))
+            for entry in queue_after
+            if float(entry["length_km"]) > 0.0
+        )
+        profile = [
+            (float(length), float(ppm))
+            for length, ppm in _segment_profile_from_queue(merged_queue, 0.0, segment_length)
+        ]
+        return queue_after, profile
+
+    queue, profile_hour1 = _advance(queue, 0.0)
+    assert len(profile_hour1) == 2
+    assert profile_hour1[0][0] == pytest.approx(pumped_length, rel=1e-6)
+    assert profile_hour1[0][1] == pytest.approx(0.0, abs=1e-6)
+    assert profile_hour1[1][0] == pytest.approx(segment_length - pumped_length, rel=1e-6)
+    assert profile_hour1[1][1] == pytest.approx(5.0, rel=1e-6)
+
+    queue, profile_hour2 = _advance(queue, 0.0)
+    assert len(profile_hour2) == 2
+    assert profile_hour2[0][0] == pytest.approx(2 * pumped_length, rel=1e-6)
+    assert profile_hour2[0][1] == pytest.approx(0.0, abs=1e-6)
+    assert profile_hour2[1][0] == pytest.approx(segment_length - 2 * pumped_length, rel=1e-6)
+    assert profile_hour2[1][1] == pytest.approx(5.0, rel=1e-6)
+
+    queue, profile_hour3 = _advance(queue, 3.0)
+    assert len(profile_hour3) == 3
+    assert profile_hour3[0][0] == pytest.approx(pumped_length, rel=1e-6)
+    assert profile_hour3[0][1] == pytest.approx(3.0, rel=1e-6)
+    assert profile_hour3[1][0] == pytest.approx(2 * pumped_length, rel=1e-6)
+    assert profile_hour3[1][1] == pytest.approx(0.0, abs=1e-6)
+    assert profile_hour3[2][0] == pytest.approx(segment_length - 3 * pumped_length, rel=1e-6)
+    assert profile_hour3[2][1] == pytest.approx(5.0, rel=1e-6)
+
+
 def test_dra_profile_preserves_baseline_after_injection() -> None:
     """Injected slugs should overlay a pre-laced baseline across the segment."""
 


### PR DESCRIPTION
## Summary
- ensure stations without DRA default to a zero-ppm profile entry and tighten DRA search bounds when fixed reductions are present
- add a fallback pass to the time-series solver that searches for the maximum feasible hourly throughput and surfaces a spinner message while running
- extend regression coverage for the fallback flow search and uninjected profile reporting, and default mixed pump types to opt-in only

## Testing
- pytest tests/test_pipeline_performance.py::test_time_series_solver_computes_max_feasible_flow
- pytest tests/test_pipeline_performance.py::test_compute_minimum_lacing_requirement_respects_single_type_series
- pytest tests/test_pipeline_performance.py::test_pipeline_profile_reports_zero_when_uninjected


------
https://chatgpt.com/codex/tasks/task_e_6902c8d97c8c8331a15824e6640dfce7