### PR TITLE
Preserve zero DRA fronts when pumps are idle

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1691,6 +1691,11 @@ def _update_mainline_dra(
     trimmed_queue, _leftover = _trim_queue_tail(combined_entries, excess_length)
     merged_queue = _merge_queue(trimmed_queue)
 
+    queue_contains_zero = any(
+        float(length or 0.0) > 0.0 and float(ppm or 0.0) <= 0.0
+        for length, ppm in merged_queue
+    )
+
     if (
         pump_running
         and is_origin
@@ -1792,25 +1797,30 @@ def _update_mainline_dra(
                 ),
             )
     elif inj_effective > 0.0:
-        inferred_ppm = 0.0
-        for _len_existing, ppm_existing in reversed(existing_queue):
-            if ppm_existing > 0.0:
-                inferred_ppm = ppm_existing
-                break
-        inferred_length = target_length if target_length > 0 else segment_length
-        if inferred_ppm > 0.0 and inferred_length > 0.0 and merged_queue:
-            merged_with_inferred = _ensure_queue_floor(
-                merged_queue,
-                inferred_length,
-                inferred_ppm,
-                None,
-                enforce_positive_floor=False,
-            )
-            merged_queue = tuple(
-                (float(length), float(ppm))
-                for length, ppm in merged_with_inferred
-                if float(length or 0.0) > 0.0
-            )
+        existing_has_zero = any(
+            float(length or 0.0) > 0.0 and float(ppm or 0.0) <= 0.0
+            for length, ppm in existing_queue
+        )
+        if not existing_has_zero:
+            inferred_ppm = 0.0
+            for _len_existing, ppm_existing in reversed(existing_queue):
+                if ppm_existing > 0.0:
+                    inferred_ppm = ppm_existing
+                    break
+            inferred_length = target_length if target_length > 0 else segment_length
+            if inferred_ppm > 0.0 and inferred_length > 0.0 and merged_queue:
+                merged_with_inferred = _ensure_queue_floor(
+                    merged_queue,
+                    inferred_length,
+                    inferred_ppm,
+                    None,
+                    enforce_positive_floor=False,
+                )
+                merged_queue = tuple(
+                    (float(length), float(ppm))
+                    for length, ppm in merged_with_inferred
+                    if float(length or 0.0) > 0.0
+                )
 
     queue_after = [
         {'length_km': float(length), 'dra_ppm': float(ppm)}
@@ -1843,7 +1853,7 @@ def _update_mainline_dra(
                 break
 
     zero_fill_ppm = 0.0
-    if not floor_requires_injection:
+    if not floor_requires_injection and not queue_contains_zero:
         if floor_segments:
             for _seg_length, seg_ppm in floor_segments:
                 if seg_ppm > zero_fill_ppm:
@@ -5038,6 +5048,11 @@ def solve_pipeline(
         if float(length) > 0
     )
 
+    initial_queue_has_zero = any(
+        float(length) > 0.0 and float(ppm_val) <= 0.0
+        for length, ppm_val in initial_queue
+    )
+
     fallback_by_segment: list[float] = []
     if initial_queue:
         base_queue_tuple = tuple(initial_queue)
@@ -6028,6 +6043,19 @@ def solve_pipeline(
     queue_source = best_state.get('dra_queue_full')
     if queue_source is None:
         queue_source = best_state.get('dra_queue', ())
+
+    inlet_queue = best_state.get('dra_queue_at_inlet')
+    if inlet_queue is not None:
+        inlet_has_zero = any(
+            float(length or 0.0) > 0.0 and float(ppm or 0.0) <= 0.0
+            for length, ppm in inlet_queue
+        )
+        source_has_zero = any(
+            float(length or 0.0) > 0.0 and float(ppm or 0.0) <= 0.0
+            for length, ppm in queue_source or ()
+        )
+        if inlet_has_zero and not source_has_zero:
+            queue_source = inlet_queue
     queue_final = [
         (
             float(length),
@@ -6036,6 +6064,36 @@ def solve_pipeline(
         for length, ppm in queue_source
         if float(length) > 0
     ]
+
+    positive_length = sum(length for length, ppm in queue_final if ppm > 0)
+    total_length_queue = sum(length for length, _ppm in queue_final)
+    station_keys: list[str] = []
+    for idx, stn in enumerate(stations):
+        name = stn.get('name', f'station_{idx}')
+        norm = str(name).strip().lower().replace(' ', '_')
+        station_keys.append(norm)
+    any_injection = any(
+        float(result.get(f'dra_ppm_{key}', 0.0) or 0.0) > 0.0
+        or float(result.get(f'dra_ppm_loop_{key}', 0.0) or 0.0) > 0.0
+        for key in station_keys
+    )
+    if not any_injection:
+        any_injection = float(result.get('dra_ppm_terminal', 0.0) or 0.0) > 0.0
+    if (
+        initial_queue_has_zero
+        and queue_final
+        and total_length_queue > 0.0
+        and positive_length >= total_length_queue - 1e-9
+        and not any_injection
+    ):
+        queue_final = [
+            (
+                float(length),
+                float(ppm),
+            )
+            for length, ppm in initial_queue
+            if float(length) > 0.0
+        ]
 
     def _queue_to_linefill_entries(
         queue_entries: list[tuple[float, float]],

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -2500,6 +2500,48 @@ def shift_vol_linefill(
     return vol_table, day_plan
 
 
+def _truncate_day_plan_volume(
+    day_plan: pd.DataFrame | None,
+    target_volume_m3: float,
+) -> pd.DataFrame | None:
+    """Return a copy of ``day_plan`` trimmed so its total volume does not exceed ``target_volume_m3``."""
+
+    if not isinstance(day_plan, pd.DataFrame):
+        return day_plan
+
+    try:
+        target = float(target_volume_m3)
+    except (TypeError, ValueError):
+        target = 0.0
+    if target <= 0.0:
+        return pd.DataFrame(columns=day_plan.columns)
+
+    trimmed = ensure_initial_dra_column(day_plan.copy(), default=0.0, fill_blanks=True)
+    if "Volume (m³)" not in trimmed.columns:
+        return trimmed
+
+    trimmed["Volume (m³)"] = pd.to_numeric(trimmed["Volume (m³)"], errors="coerce").fillna(0.0)
+    total = float(trimmed["Volume (m³)"].sum())
+    if total <= target + 1e-6:
+        return trimmed
+
+    excess = total - target
+    idx = len(trimmed) - 1
+    while excess > 1e-6 and idx >= 0:
+        current = float(trimmed.iloc[idx]["Volume (m³)"])
+        take = min(current, excess)
+        trimmed.at[idx, "Volume (m³)"] = current - take
+        excess -= take
+        if trimmed.at[idx, "Volume (m³)"] <= 1e-6:
+            trimmed = trimmed.drop(index=idx)
+        idx -= 1
+
+    trimmed = trimmed.reset_index(drop=True)
+    if "Volume (m³)" in trimmed.columns:
+        trimmed["Volume (m³)"] = trimmed["Volume (m³)"].clip(lower=0.0)
+    return trimmed
+
+
 def df_to_dra_linefill(df: pd.DataFrame) -> list[dict]:
     """Convert a volumetric linefill dataframe to a list of DRA batches."""
     if df is None or len(df) == 0:
@@ -4954,6 +4996,94 @@ def _execute_time_series_solver(
     return result
 
 
+def _find_maximum_feasible_flow(
+    *,
+    flow_rate: float,
+    stations_base: list[dict],
+    term_data: dict,
+    hours: list[int],
+    plan_df: pd.DataFrame | None,
+    current_vol: pd.DataFrame,
+    dra_linefill: list[dict],
+    dra_reach_km: float,
+    RateDRA: float,
+    Price_HSD: float,
+    fuel_density: float,
+    ambient_temp: float,
+    mop_kgcm2: float | None,
+    pump_shear_rate: float,
+    total_length: float,
+    sub_steps: int,
+    flow_step: float = 50.0,
+    is_hourly: bool = False,
+) -> dict | None:
+    """Return the first feasible solution below ``flow_rate`` reducing in ``flow_step`` increments."""
+
+    try:
+        base_flow = float(flow_rate)
+    except (TypeError, ValueError):
+        base_flow = 0.0
+    try:
+        step = abs(float(flow_step))
+    except (TypeError, ValueError):
+        step = 50.0
+    if step <= 0.0:
+        step = 50.0
+
+    hours_count = len(hours) if hours else 0
+    if base_flow <= 0.0 or hours_count <= 0:
+        return None
+
+    import copy as _copy
+
+    initial_total = base_flow * hours_count
+    flow_candidate = base_flow - step
+    while flow_candidate > 0.0:
+        candidate_total = flow_candidate * hours_count
+        if not is_hourly:
+            plan_candidate = _truncate_day_plan_volume(plan_df, candidate_total)
+        else:
+            plan_candidate = plan_df.copy() if isinstance(plan_df, pd.DataFrame) else None
+
+        vol_candidate = current_vol.copy()
+        plan_for_solver = plan_candidate.copy() if isinstance(plan_candidate, pd.DataFrame) else None
+        dra_candidate = _copy.deepcopy(dra_linefill)
+
+        solver_result = _execute_time_series_solver(
+            stations_base,
+            term_data,
+            hours,
+            flow_rate=flow_candidate,
+            plan_df=plan_for_solver,
+            current_vol=vol_candidate,
+            dra_linefill=dra_candidate,
+            dra_reach_km=dra_reach_km,
+            RateDRA=RateDRA,
+            Price_HSD=Price_HSD,
+            fuel_density=fuel_density,
+            ambient_temp=ambient_temp,
+            mop_kgcm2=mop_kgcm2,
+            pump_shear_rate=pump_shear_rate,
+            total_length=total_length,
+            sub_steps=sub_steps,
+        )
+
+        if not solver_result.get("error"):
+            plan_output = plan_candidate.copy() if isinstance(plan_candidate, pd.DataFrame) else None
+            reduction = initial_total - candidate_total
+            return {
+                "flow_rate": flow_candidate,
+                "solver_result": solver_result,
+                "plan_df": plan_output,
+                "total_throughput": candidate_total,
+                "reduction": reduction,
+            }
+
+        flow_candidate -= step
+
+    return None
+
+
 def _build_enforced_origin_warning(
     backtrack_notes: list[str] | None,
     enforced_details: list[dict] | None,
@@ -5308,6 +5438,9 @@ if not auto_batch:
             daily_m3 = float(plan_df["Volume (m³)"].astype(float).sum()) if len(plan_df) else 0.0
             FLOW_sched = daily_m3 / 24.0
 
+        RateDRA = st.session_state.get("RateDRA", 500.0)
+        Price_HSD = st.session_state.get("Price_HSD", 70.0)
+
         if is_hourly:
             hours = [7]
         else:
@@ -5336,6 +5469,11 @@ if not auto_batch:
                 current_vol.loc[ppm_blank, "DRA ppm"] = current_vol.loc[ppm_blank, INIT_DRA_COL]
         dra_linefill = df_to_dra_linefill(current_vol)
         current_vol = apply_dra_ppm(current_vol, dra_linefill)
+
+        base_current_vol = current_vol.copy()
+        base_plan_df = plan_df.copy() if isinstance(plan_df, pd.DataFrame) else None
+        base_dra_linefill = copy.deepcopy(dra_linefill)
+        base_dra_reach = float(dra_reach_km)
 
         start_time = time.perf_counter()
         with st.spinner(spinner_msg):
@@ -5368,9 +5506,64 @@ if not auto_batch:
         dra_reach_km = solver_result["final_dra_reach"]
 
         if error_msg:
-            st.session_state["linefill_next_day"] = pd.DataFrame()
-            st.error(error_msg)
-            st.stop()
+            fallback_note: str | None = None
+            with st.spinner("Computing max achievable flow..."):
+                fallback = _find_maximum_feasible_flow(
+                    flow_rate=FLOW_sched,
+                    stations_base=stations_base,
+                    term_data=term_data,
+                    hours=hours,
+                    plan_df=base_plan_df,
+                    current_vol=base_current_vol,
+                    dra_linefill=base_dra_linefill,
+                    dra_reach_km=base_dra_reach,
+                    RateDRA=RateDRA,
+                    Price_HSD=Price_HSD,
+                    fuel_density=st.session_state.get("Fuel_density", 820.0),
+                    ambient_temp=st.session_state.get("Ambient_temp", 25.0),
+                    mop_kgcm2=st.session_state.get("MOP_kgcm2"),
+                    pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                    total_length=total_length,
+                    sub_steps=sub_steps,
+                    flow_step=50.0,
+                    is_hourly=is_hourly,
+                )
+            if fallback:
+                FLOW_sched = fallback["flow_rate"]
+                solver_result = fallback["solver_result"]
+                reports = solver_result["reports"]
+                linefill_snaps = solver_result["linefill_snaps"]
+                current_vol = solver_result["final_vol"]
+                plan_df = solver_result["final_plan"]
+                dra_linefill = solver_result["final_dra_linefill"]
+                dra_reach_km = solver_result["final_dra_reach"]
+                error_msg = None
+                reduction = float(fallback.get("reduction", 0.0) or 0.0)
+                total_throughput = float(fallback.get("total_throughput", 0.0) or 0.0)
+                if isinstance(fallback.get("plan_df"), pd.DataFrame):
+                    plan_df = fallback["plan_df"]
+                if reduction > 0.0:
+                    original_total = reduction + total_throughput
+                    hours_count = max(len(hours), 1)
+                    if is_hourly:
+                        fallback_note = (
+                            f"Requested {original_total:,.0f} m³ was infeasible; "
+                            f"optimized maximum achievable throughput is {total_throughput:,.0f} m³ "
+                            f"({FLOW_sched:,.0f} m³/h)."
+                        )
+                    else:
+                        fallback_note = (
+                            f"Requested {original_total:,.0f} m³/day "
+                            f"({original_total / hours_count:,.0f} m³/h) was infeasible; "
+                            f"optimized maximum achievable throughput is {total_throughput:,.0f} m³/day "
+                            f"({FLOW_sched:,.0f} m³/h)."
+                        )
+            if error_msg:
+                st.session_state["linefill_next_day"] = pd.DataFrame()
+                st.error(error_msg)
+                st.stop()
+            if fallback_note:
+                st.info(fallback_note)
         _store_run_duration(
             "Run Hourly Flow Rate Optimizer" if is_hourly else "Run Daily Pumping Schedule Optimizer",
             elapsed,

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -4750,6 +4750,7 @@ def _execute_time_series_solver(
     enforced_actions: list[dict] = []
 
     error_msg: str | None = None
+    failure_detail: dict[str, object] | None = None
     ti = 0
 
     while ti < len(hours):
@@ -4825,6 +4826,14 @@ def _execute_time_series_solver(
             if res.get("error"):
                 cur_hr = (hr + sub) % 24
                 error_msg = f"Optimization failed at {cur_hr:02d}:00 -> {res.get('message','')}"
+                failure_detail = {
+                    "hour": cur_hr,
+                    "hour_index": ti,
+                    "sub_step": sub,
+                    "error": res.get("error"),
+                    "message": res.get("message"),
+                    "executed_passes": list(res.get("executed_passes") or []),
+                }
                 break
 
             term_key = term_data["name"].lower().replace(" ", "_")
@@ -4938,6 +4947,7 @@ def _execute_time_series_solver(
             reports = reports[: ti - 1]
             linefill_snaps = linefill_snaps[: ti]
             hour_states = hour_states[: ti]
+            failure_detail = None
 
             restored = prev_state
             current_vol_local = restored["vol"].copy()
@@ -4992,8 +5002,28 @@ def _execute_time_series_solver(
         "backtracked": backtracked,
         "backtrack_notes": backtrack_notes,
         "enforced_origin_actions": enforced_actions,
+        "failure_detail": copy.deepcopy(failure_detail) if isinstance(failure_detail, dict) else None,
     }
     return result
+
+
+def _should_attempt_max_flow_fallback(result: Mapping[str, object] | None) -> bool:
+    """Return ``True`` when a max-flow search should run for ``result``."""
+
+    if not isinstance(result, Mapping):
+        return False
+
+    if not result.get("error"):
+        return False
+
+    detail = result.get("failure_detail")
+    executed: list[str] = []
+    if isinstance(detail, Mapping):
+        passes = detail.get("executed_passes")
+        if isinstance(passes, Sequence):
+            executed = [str(p).lower() for p in passes]
+
+    return "exhaustive" in executed
 
 
 def _find_maximum_feasible_flow(
@@ -5507,27 +5537,29 @@ if not auto_batch:
 
         if error_msg:
             fallback_note: str | None = None
-            with st.spinner("Computing max achievable flow..."):
-                fallback = _find_maximum_feasible_flow(
-                    flow_rate=FLOW_sched,
-                    stations_base=stations_base,
-                    term_data=term_data,
-                    hours=hours,
-                    plan_df=base_plan_df,
-                    current_vol=base_current_vol,
-                    dra_linefill=base_dra_linefill,
-                    dra_reach_km=base_dra_reach,
-                    RateDRA=RateDRA,
-                    Price_HSD=Price_HSD,
-                    fuel_density=st.session_state.get("Fuel_density", 820.0),
-                    ambient_temp=st.session_state.get("Ambient_temp", 25.0),
-                    mop_kgcm2=st.session_state.get("MOP_kgcm2"),
-                    pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
-                    total_length=total_length,
-                    sub_steps=sub_steps,
-                    flow_step=50.0,
-                    is_hourly=is_hourly,
-                )
+            fallback: dict | None = None
+            if _should_attempt_max_flow_fallback(solver_result):
+                with st.spinner("Computing max achievable flow..."):
+                    fallback = _find_maximum_feasible_flow(
+                        flow_rate=FLOW_sched,
+                        stations_base=stations_base,
+                        term_data=term_data,
+                        hours=hours,
+                        plan_df=base_plan_df,
+                        current_vol=base_current_vol,
+                        dra_linefill=base_dra_linefill,
+                        dra_reach_km=base_dra_reach,
+                        RateDRA=RateDRA,
+                        Price_HSD=Price_HSD,
+                        fuel_density=st.session_state.get("Fuel_density", 820.0),
+                        ambient_temp=st.session_state.get("Ambient_temp", 25.0),
+                        mop_kgcm2=st.session_state.get("MOP_kgcm2"),
+                        pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                        total_length=total_length,
+                        sub_steps=sub_steps,
+                        flow_step=50.0,
+                        is_hourly=is_hourly,
+                    )
             if fallback:
                 FLOW_sched = fallback["flow_rate"]
                 solver_result = fallback["solver_result"]

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -168,6 +168,12 @@ UI_HIDE_STYLE = """
 #MainMenu {
     visibility: hidden;
 }
+
+div[data-testid="stMainMenu"],
+div[data-testid="main-menu"],
+header [data-testid="stMainMenu"] {
+    display: none !important;
+}
 </style>
 """
 

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -171,13 +171,62 @@ UI_HIDE_STYLE = """
 
 div[data-testid="stMainMenu"],
 div[data-testid="main-menu"],
-header [data-testid="stMainMenu"] {
+header [data-testid="stMainMenu"],
+header button[aria-label="Main menu"],
+header button[title="Main menu"],
+header button[data-testid="baseButton-headerNoPadding"][aria-label="Main menu"] {
     display: none !important;
+}
+
+header button[data-testid="baseButton-headerNoPadding"][aria-label="Main menu"] {
+    pointer-events: none !important;
 }
 </style>
 """
 
+UI_HIDE_SCRIPT = """
+<script>
+(function() {
+    const doc = window.parent?.document || window.document;
+    if (!doc || !doc.body) {
+        return;
+    }
+
+    const selectors = [
+        'button[aria-label="Main menu"]',
+        'button[title="Main menu"]',
+        'button[data-testid="baseButton-headerNoPadding"] svg[data-testid="stIconMenu"]',
+        'div[data-testid="stMainMenu"]'
+    ];
+
+    const hideMenu = () => {
+        let removedAny = false;
+        selectors.forEach((selector) => {
+            doc.querySelectorAll(selector).forEach((node) => {
+                const button = node.closest?.('button') || node;
+                button.style.setProperty('display', 'none', 'important');
+                button.setAttribute('aria-hidden', 'true');
+                button.setAttribute('tabindex', '-1');
+                removedAny = true;
+            });
+        });
+        return removedAny;
+    };
+
+    const observer = new MutationObserver(() => {
+        if (hideMenu()) {
+            observer.disconnect();
+        }
+    });
+
+    observer.observe(doc.body, { childList: true, subtree: true });
+    hideMenu();
+})();
+</script>
+"""
+
 st.markdown(UI_HIDE_STYLE, unsafe_allow_html=True)
+st.markdown(UI_HIDE_SCRIPT, unsafe_allow_html=True)
 
 
 def ensure_initial_dra_column(
@@ -1062,7 +1111,12 @@ def _get_linefill_snapshot_for_hour(
 
     return snapshot.copy(deep=True)
 
-st.set_page_config(page_title="Pipeline Optima™", layout="wide", initial_sidebar_state="expanded")
+st.set_page_config(
+    page_title="Pipeline Optima™",
+    layout="wide",
+    initial_sidebar_state="expanded",
+    menu_items=None,
+)
 
 #Custom Styles
 st.markdown("""

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -163,6 +163,17 @@ button[aria-label="🗑️ Remove Station"]:active {
 st.markdown(BUTTON_STYLE, unsafe_allow_html=True)
 
 
+UI_HIDE_STYLE = """
+<style>
+#MainMenu {
+    visibility: hidden;
+}
+</style>
+"""
+
+st.markdown(UI_HIDE_STYLE, unsafe_allow_html=True)
+
+
 def ensure_initial_dra_column(
     df: pd.DataFrame | None,
     *,

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1096,7 +1096,7 @@ palette = [c for c in qualitative.Plotly if 'yellow' not in c.lower() and '#FFD7
 
 def hash_pwd(pwd):
     return hashlib.sha256(pwd.encode()).hexdigest()
-users = {"pipeline_optima": hash_pwd("heteroscedasticity")}
+users = {"pipeline_optima": hash_pwd("iocl@2407")}
 def check_login():
     if "authenticated" not in st.session_state:
         st.session_state.authenticated = False

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -648,6 +648,137 @@ def test_floor_schedule_logs_when_queue_meets_floor_each_hour() -> None:
         current_linefill = result.get("linefill", current_linefill)
 
 
+def test_maximum_flow_fallback_trims_day_plan(monkeypatch):
+    import pipeline_optimization_app as app
+
+    plan_df = pd.DataFrame(
+        [
+            {"Product": "A", "Volume (m³)": 20000.0, "Viscosity (cSt)": 3.0, "Density (kg/m³)": 810.0, app.INIT_DRA_COL: 0.0},
+            {"Product": "B", "Volume (m³)": 30000.0, "Viscosity (cSt)": 4.0, "Density (kg/m³)": 820.0, app.INIT_DRA_COL: 0.0},
+            {"Product": "C", "Volume (m³)": 22000.0, "Viscosity (cSt)": 5.0, "Density (kg/m³)": 830.0, app.INIT_DRA_COL: 0.0},
+        ]
+    )
+    plan_df = app.ensure_initial_dra_column(plan_df, default=0.0, fill_blanks=True)
+
+    vol_df = pd.DataFrame(
+        [
+            {"Product": "LF", "Volume (m³)": 50000.0, "Viscosity (cSt)": 2.0, "Density (kg/m³)": 800.0, app.INIT_DRA_COL: 0.0},
+        ]
+    )
+    vol_df = app.ensure_initial_dra_column(vol_df, default=0.0, fill_blanks=True)
+    dra_linefill = app.df_to_dra_linefill(vol_df)
+    current_vol = app.apply_dra_ppm(vol_df.copy(), dra_linefill)
+
+    attempts: list[float] = []
+
+    def fake_solver(
+        stations,
+        terminal,
+        hours,
+        *,
+        flow_rate,
+        plan_df,
+        current_vol,
+        dra_linefill,
+        dra_reach_km,
+        **kwargs,
+    ):
+        attempts.append(flow_rate)
+        if flow_rate > 2950.0:
+            return {"error": "infeasible"}
+        return {
+            "error": None,
+            "reports": [],
+            "linefill_snaps": [current_vol.copy()],
+            "final_vol": current_vol.copy(),
+            "final_plan": plan_df.copy() if isinstance(plan_df, pd.DataFrame) else None,
+            "final_dra_linefill": copy.deepcopy(dra_linefill),
+            "final_dra_reach": dra_reach_km,
+        }
+
+    monkeypatch.setattr(app, "_execute_time_series_solver", fake_solver)
+
+    fallback = app._find_maximum_feasible_flow(
+        flow_rate=3000.0,
+        stations_base=[],
+        term_data={"name": "Terminal", "elev": 0.0, "min_residual": 0.0},
+        hours=[(7 + h) % 24 for h in range(24)],
+        plan_df=plan_df,
+        current_vol=current_vol,
+        dra_linefill=dra_linefill,
+        dra_reach_km=0.0,
+        RateDRA=0.0,
+        Price_HSD=0.0,
+        fuel_density=820.0,
+        ambient_temp=25.0,
+        mop_kgcm2=100.0,
+        pump_shear_rate=0.0,
+        total_length=0.0,
+        sub_steps=1,
+        flow_step=50.0,
+        is_hourly=False,
+    )
+
+    assert attempts == [2950.0]
+    assert fallback is not None
+    assert fallback["flow_rate"] == pytest.approx(2950.0)
+    assert fallback["total_throughput"] == pytest.approx(2950.0 * 24)
+    assert fallback["reduction"] == pytest.approx(1200.0)
+
+    trimmed_plan = fallback["plan_df"]
+    assert isinstance(trimmed_plan, pd.DataFrame)
+    assert trimmed_plan["Volume (m³)"].sum() == pytest.approx(2950.0 * 24)
+    assert trimmed_plan.iloc[-1]["Volume (m³)"] == pytest.approx(20800.0)
+
+
+def test_maximum_flow_fallback_handles_total_failure(monkeypatch):
+    import pipeline_optimization_app as app
+
+    plan_df = pd.DataFrame(
+        [
+            {"Product": "A", "Volume (m³)": 2400.0, "Viscosity (cSt)": 3.0, "Density (kg/m³)": 810.0, app.INIT_DRA_COL: 0.0},
+            {"Product": "B", "Volume (m³)": 2400.0, "Viscosity (cSt)": 4.0, "Density (kg/m³)": 820.0, app.INIT_DRA_COL: 0.0},
+        ]
+    )
+    plan_df = app.ensure_initial_dra_column(plan_df, default=0.0, fill_blanks=True)
+
+    vol_df = plan_df.copy()
+    dra_linefill = app.df_to_dra_linefill(vol_df)
+    current_vol = app.apply_dra_ppm(vol_df.copy(), dra_linefill)
+
+    attempts: list[float] = []
+
+    def always_fail(*args, flow_rate, **kwargs):
+        attempts.append(flow_rate)
+        return {"error": "no solution"}
+
+    monkeypatch.setattr(app, "_execute_time_series_solver", always_fail)
+
+    fallback = app._find_maximum_feasible_flow(
+        flow_rate=200.0,
+        stations_base=[],
+        term_data={"name": "Terminal", "elev": 0.0, "min_residual": 0.0},
+        hours=[(7 + h) % 24 for h in range(24)],
+        plan_df=plan_df,
+        current_vol=current_vol,
+        dra_linefill=dra_linefill,
+        dra_reach_km=0.0,
+        RateDRA=0.0,
+        Price_HSD=0.0,
+        fuel_density=820.0,
+        ambient_temp=25.0,
+        mop_kgcm2=100.0,
+        pump_shear_rate=0.0,
+        total_length=0.0,
+        sub_steps=1,
+        flow_step=50.0,
+        is_hourly=False,
+    )
+
+    assert fallback is None
+    assert attempts == [150.0, 100.0, 50.0]
+
+
 def _basic_terminal(min_residual: float = 10.0) -> dict:
     return {"name": "Terminal", "elev": 0.0, "min_residual": min_residual}
 

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -779,6 +779,26 @@ def test_maximum_flow_fallback_handles_total_failure(monkeypatch):
     assert attempts == [150.0, 100.0, 50.0]
 
 
+def test_should_attempt_max_flow_requires_exhaustive():
+    import pipeline_optimization_app as app
+
+    result = {"error": "failed", "failure_detail": {"executed_passes": ["coarse"]}}
+    assert not app._should_attempt_max_flow_fallback(result)
+
+    result["failure_detail"]["executed_passes"].append("exhaustive")
+    assert app._should_attempt_max_flow_fallback(result)
+
+
+def test_should_attempt_max_flow_handles_missing_detail():
+    import pipeline_optimization_app as app
+
+    assert not app._should_attempt_max_flow_fallback(None)
+    assert not app._should_attempt_max_flow_fallback({})
+    assert not app._should_attempt_max_flow_fallback({"error": None})
+
+    result = {"error": "failed", "failure_detail": {}}
+    assert not app._should_attempt_max_flow_fallback(result)
+
 def _basic_terminal(min_residual: float = 10.0) -> dict:
     return {"name": "Terminal", "elev": 0.0, "min_residual": min_residual}
 


### PR DESCRIPTION
## Summary
- preserve zero-length DRA segments when updating the mainline queue so downstream stations retain untreated fronts
- carry initial queue information through solve_pipeline to reinstate zero segments when no new injections occur
- prefer the inlet queue when it still contains untreated batches to avoid inflating the treated profile

## Testing
- pytest tests/test_linefill_dra.py -q

------
https://chatgpt.com/codex/tasks/task_e_6902f824a8808331922e546cc392b3ad