### PR TITLE
Broaden max flow fallback trigger

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -5076,12 +5076,43 @@ def _should_attempt_max_flow_fallback(result: Mapping[str, object] | None) -> bo
 
     detail = result.get("failure_detail")
     executed: list[str] = []
+    message_parts: list[str] = []
+    hour_index: int | None = None
+
     if isinstance(detail, Mapping):
         passes = detail.get("executed_passes")
         if isinstance(passes, Sequence):
             executed = [str(p).lower() for p in passes]
+        msg = detail.get("message")
+        if isinstance(msg, str):
+            message_parts.append(msg.lower())
+        hour_idx_val = detail.get("hour_index")
+        try:
+            if hour_idx_val is not None:
+                hour_index = int(hour_idx_val)
+        except (TypeError, ValueError):
+            hour_index = None
 
-    return "exhaustive" in executed
+    err_msg = result.get("error")
+    if isinstance(err_msg, str):
+        message_parts.append(err_msg.lower())
+
+    if "exhaustive" in executed:
+        return True
+
+    reports = result.get("reports")
+    has_reports = isinstance(reports, Sequence) and len(reports) > 0
+    first_hour_failure = hour_index in (None, 0)
+
+    if has_reports or not first_hour_failure:
+        return False
+
+    if not message_parts:
+        return False
+
+    combined = " ".join(message_parts)
+    keywords = ("feasible", "viscosity", "flow rate", "flowrate", "flow-rate")
+    return any(word in combined for word in keywords)
 
 
 def _find_maximum_feasible_flow(

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -779,12 +779,20 @@ def test_maximum_flow_fallback_handles_total_failure(monkeypatch):
     assert attempts == [150.0, 100.0, 50.0]
 
 
-def test_should_attempt_max_flow_requires_exhaustive():
+def test_should_attempt_max_flow_handles_feasible_failure():
     import pipeline_optimization_app as app
 
-    result = {"error": "failed", "failure_detail": {"executed_passes": ["coarse"]}}
+    result = {
+        "error": "failed",
+        "failure_detail": {"executed_passes": ["coarse"], "hour_index": 0},
+        "reports": [],
+    }
     assert not app._should_attempt_max_flow_fallback(result)
 
+    result["failure_detail"]["message"] = "Feasible solution not achieved due to viscosity"
+    assert app._should_attempt_max_flow_fallback(result)
+
+    result["failure_detail"]["message"] = None
     result["failure_detail"]["executed_passes"].append("exhaustive")
     assert app._should_attempt_max_flow_fallback(result)
 
@@ -797,6 +805,18 @@ def test_should_attempt_max_flow_handles_missing_detail():
     assert not app._should_attempt_max_flow_fallback({"error": None})
 
     result = {"error": "failed", "failure_detail": {}}
+    assert not app._should_attempt_max_flow_fallback(result)
+
+
+def test_should_attempt_max_flow_ignores_late_failures():
+    import pipeline_optimization_app as app
+
+    result = {
+        "error": "failed",
+        "failure_detail": {"message": "Feasible solution not achieved", "hour_index": 2},
+        "reports": [{"time": 7, "result": {}}],
+    }
+
     assert not app._should_attempt_max_flow_fallback(result)
 
 def _basic_terminal(min_residual: float = 10.0) -> dict:


### PR DESCRIPTION
## Summary
- expand the fallback trigger to recognise first-hour hydraulic failures and inspect solver messages for feasibility issues
- add unit tests covering the new fallback conditions and ensuring late failures still bypass the search

## Testing
- pytest tests/test_pipeline_performance.py::test_should_attempt_max_flow_handles_feasible_failure tests/test_pipeline_performance.py::test_should_attempt_max_flow_ignores_late_failures tests/test_pipeline_performance.py::test_maximum_flow_fallback_trims_day_plan tests/test_pipeline_performance.py::test_maximum_flow_fallback_handles_total_failure


------
https://chatgpt.com/codex/tasks/task_e_690830bb6c78833185ecca16197d0799