### PR TITLE
Set default refinement DRA step to 5

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1546,7 +1546,7 @@ with st.sidebar:
                 _update_manual_baseline_state(st.session_state.get("stations", []))
 
         rpm_step_default = 50
-        dra_step_default = 2
+        dra_step_default = 5
         coarse_multiplier_default = 2.0
         state_top_k_default = 50
         state_cost_margin_default = 5000.0


### PR DESCRIPTION
## Summary
- set the default refinement DRA step value to 5 so that new sessions start with the updated percentage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69035b5355c88331b833e5daa9dcc156