### PR TITLE
Preserve zero ppm edges in DRA profile reporting

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import datetime as dt
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from itertools import product
 import math
 
@@ -1197,6 +1197,56 @@ def _segment_profile_from_queue(
         return ()
 
     return _take_queue_front(segment_queue, seg_len)
+
+
+def _profile_edge_ppm(
+    profile: Sequence[Mapping[str, float]] | Sequence[tuple[float, float]] | None,
+    *,
+    reverse: bool = False,
+) -> float | None:
+    """Return the ppm value of the first positive-length slice in ``profile``.
+
+    The helper mirrors the inlet/outlet lookup performed when recording the DRA
+    profile for each station.  ``profile`` may contain dictionaries with
+    ``length_km`` and ``dra_ppm`` keys or two-item iterables.  A ``None`` value
+    indicates that no entry is available.  Zero-length slices are ignored while
+    zero-ppm slices are preserved so that untreated fluid is reported correctly
+    at the profile edges.
+    """
+
+    if not profile:
+        return None
+
+    iterator: Iterable
+    if reverse:
+        iterator = reversed(profile)
+    else:
+        iterator = iter(profile)
+
+    for raw in iterator:
+        if isinstance(raw, Mapping):
+            length_raw = raw.get('length_km', 0.0)
+            ppm_raw = raw.get('dra_ppm', 0.0)
+        else:
+            try:
+                length_raw, ppm_raw = raw  # type: ignore[misc]
+            except (TypeError, ValueError):
+                continue
+        try:
+            length_val = float(length_raw or 0.0)
+        except (TypeError, ValueError):
+            length_val = 0.0
+        if length_val <= 0.0:
+            continue
+        try:
+            ppm_val = float(ppm_raw or 0.0)
+        except (TypeError, ValueError):
+            ppm_val = 0.0
+        if ppm_val < 0.0:
+            ppm_val = 0.0
+        return ppm_val
+
+    return None
 
 
 def _normalise_station_profile(
@@ -5866,21 +5916,16 @@ def solve_pipeline(
                         if entry['dra_ppm'] > 0.0
                     )
 
-                    try:
-                        inlet_ppm_profile = float(inj_ppm_main or 0.0)
-                    except (TypeError, ValueError):
-                        inlet_ppm_profile = 0.0
-                    if inlet_ppm_profile <= 0.0:
-                        for entry in profile_entries:
-                            if entry['dra_ppm'] > 0.0:
-                                inlet_ppm_profile = entry['dra_ppm']
-                                break
+                    inlet_ppm_profile = _profile_edge_ppm(segment_profile_raw)
+                    if inlet_ppm_profile is None:
+                        try:
+                            inlet_ppm_profile = float(inj_ppm_main or 0.0)
+                        except (TypeError, ValueError):
+                            inlet_ppm_profile = 0.0
 
-                    outlet_ppm_profile = 0.0
-                    for entry in reversed(profile_entries):
-                        if entry['dra_ppm'] > 0.0:
-                            outlet_ppm_profile = entry['dra_ppm']
-                            break
+                    outlet_ppm_profile = _profile_edge_ppm(segment_profile_raw, reverse=True)
+                    if outlet_ppm_profile is None:
+                        outlet_ppm_profile = 0.0
 
                     if inj_ppm_main <= 0.0 and outlet_ppm_profile <= 0.0:
                         treated_profile_length = 0.0

--- a/tests/test_linefill_dra.py
+++ b/tests/test_linefill_dra.py
@@ -17,6 +17,7 @@ import pipeline_model as pm
 from pipeline_model import (
     _km_from_volume,
     _prepare_dra_queue_consumption,
+    _profile_edge_ppm,
     _segment_profile_from_queue,
     _take_queue_front,
     _trim_queue_front,
@@ -647,6 +648,38 @@ def test_segment_profile_from_queue_downstream_segment() -> None:
     assert profile[0][1] == pytest.approx(12.0, rel=1e-9)
     assert profile[1][0] == pytest.approx(18.0, rel=1e-9)
     assert profile[1][1] == pytest.approx(10.0, rel=1e-9)
+
+
+def test_profile_edge_ppm_preserves_untreated_front() -> None:
+    """Zero-ppm slices at the front should propagate to the inlet reading."""
+
+    profile = (
+        (7.0, 0.0),
+        (93.0, 3.0),
+    )
+
+    inlet_ppm = _profile_edge_ppm(profile)
+    outlet_ppm = _profile_edge_ppm(profile, reverse=True)
+
+    assert inlet_ppm == pytest.approx(0.0)
+    assert outlet_ppm == pytest.approx(3.0)
+
+
+def test_profile_edge_ppm_handles_reverse_and_negative_values() -> None:
+    """Negative ppm values should be clamped while preserving trailing zeros."""
+
+    profile = (
+        (4.0, -2.0),
+        (6.0, 0.0),
+        (10.0, 5.0),
+        (1.0, 0.0),
+    )
+
+    inlet_ppm = _profile_edge_ppm(profile)
+    outlet_ppm = _profile_edge_ppm(profile, reverse=True)
+
+    assert inlet_ppm == pytest.approx(0.0)
+    assert outlet_ppm == pytest.approx(0.0)
 
 
 def test_zero_flow_still_delivers_initial_slug_downstream() -> None:


### PR DESCRIPTION
## Summary
- add a reusable helper that reads the ppm value at the front or back of a segment profile without skipping zero-ppm slices so untreated batches are visible
- update station reporting to use the new helper for DRA inlet/outlet ppm values and cover the behaviour with focused unit tests

## Testing
- pytest tests/test_linefill_dra.py::test_profile_edge_ppm_preserves_untreated_front -q
- pytest tests/test_linefill_dra.py::test_profile_edge_ppm_handles_reverse_and_negative_values -q
- pytest tests/test_pipeline_performance.py::test_dra_profile_reflects_hourly_push_examples -q
- pytest tests/test_pipeline_performance.py::test_dra_profile_preserves_baseline_after_injection -q


------
https://chatgpt.com/codex/tasks/task_e_690aa704357c8331ac48d4ecbaf28e5a