### PR TITLE
Align DRA queue propagation with injection and treatable reach

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -1702,9 +1702,7 @@ def _update_mainline_dra(
             ppm_out = 0.0
         else:
             ppm_out = _apply_shear(ppm_input)
-            if not pump_running and inj_effective > 0.0:
-                ppm_out += inj_effective
-            elif not pump_running and inj_effective <= 0.0:
+            if not pump_running:
                 ppm_out = ppm_input
         ppm_out = max(ppm_out, 0.0)
         if not pumped_differs and abs(ppm_out - ppm_input) > 1e-9:
@@ -1763,27 +1761,65 @@ def _update_mainline_dra(
                 pumped_portion = updated_portion
                 pumped_adjusted = updated_adjusted
 
-    tail_queue: list[tuple[float, float]]
+    tail_ppm_source = 0.0
+    if pumped_portion:
+        tail_ppm_source = float(pumped_portion[-1][1] or 0.0)
+    elif existing_queue:
+        tail_ppm_source = float(existing_queue[0][1] or 0.0)
+
+    head_slug_ppm = 0.0
     if pump_running:
-        advected_portion = [
+        if inj_effective > 0.0 and pumped_adjusted:
+            tail_length, tail_ppm = pumped_adjusted[-1]
+            tail_length = float(tail_length or 0.0)
+            if tail_length > 0.0:
+                if abs(tail_ppm) > 1e-9:
+                    pumped_differs = True
+                pumped_adjusted[-1] = (tail_length, 0.0)
+        advected_raw = [
             (float(length), float(ppm))
             for length, ppm in pumped_adjusted
             if float(length or 0.0) > 0.0
         ]
+        if head_length > 0.0 and advected_raw:
+            trimmed_advected = _trim_queue_front(tuple(advected_raw), head_length)
+            advected_portion = [
+                (float(length), float(ppm))
+                for length, ppm in trimmed_advected
+                if float(length or 0.0) > 0.0
+            ]
+        else:
+            advected_portion = advected_raw
         if inj_effective > 0.0:
+            head_slug_ppm = max(inj_effective, 0.0)
             tail_queue = list(remaining_queue)
         else:
-            tail_queue = list(existing_queue) if pumped_differs else list(remaining_queue)
+            head_slug_ppm = 0.0
+            tail_queue = list(remaining_queue)
     else:
-        advected_portion = pumped_adjusted
-        if inj_effective > 0.0:
-            tail_queue = list(remaining_queue)
+        advected_raw = [
+            (float(length), float(ppm))
+            for length, ppm in pumped_adjusted
+            if float(length or 0.0) > 0.0
+        ]
+        if head_length > 0.0 and advected_raw:
+            trimmed_advected = _trim_queue_front(tuple(advected_raw), head_length)
+            advected_portion = [
+                (float(length), float(ppm))
+                for length, ppm in trimmed_advected
+                if float(length or 0.0) > 0.0
+            ]
         else:
-            tail_queue = list(existing_queue) if pumped_differs else list(remaining_queue)
+            advected_portion = advected_raw
+        tail_queue = list(remaining_queue)
+        if inj_effective > 0.0:
+            head_slug_ppm = max(tail_ppm_source + inj_effective, 0.0)
+        else:
+            head_slug_ppm = max(tail_ppm_source, 0.0)
 
     combined_entries: list[tuple[float, float]] = []
-    if pump_running and inj_effective > 0.0 and head_length > 0.0:
-        combined_entries.append((head_length, max(inj_effective, 0.0)))
+    if head_length > 0.0:
+        combined_entries.append((head_length, head_slug_ppm))
 
     combined_entries.extend(advected_portion)
     combined_entries.extend(tail_queue)
@@ -5963,15 +5999,19 @@ def solve_pipeline(
                         if entry['dra_ppm'] > 0.0
                     )
 
-                    inlet_ppm_profile = _profile_edge_ppm(segment_profile_raw)
-                    if inlet_ppm_profile is None:
+                    if profile_entries:
+                        first_entry = profile_entries[0]
+                        last_entry = profile_entries[-1]
                         try:
-                            inlet_ppm_profile = float(inj_ppm_main or 0.0)
+                            inlet_ppm_profile = float(first_entry.get('dra_ppm', 0.0) or 0.0)
                         except (TypeError, ValueError):
                             inlet_ppm_profile = 0.0
-
-                    outlet_ppm_profile = _profile_edge_ppm(segment_profile_raw, reverse=True)
-                    if outlet_ppm_profile is None:
+                        try:
+                            outlet_ppm_profile = float(last_entry.get('dra_ppm', 0.0) or 0.0)
+                        except (TypeError, ValueError):
+                            outlet_ppm_profile = 0.0
+                    else:
+                        inlet_ppm_profile = 0.0
                         outlet_ppm_profile = 0.0
 
                     if inj_ppm_main <= 0.0 and outlet_ppm_profile <= 0.0:

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -3738,13 +3738,7 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             )
         inlet_ppm = _float_or_none(inlet_ppm_val)
         if inlet_ppm is None:
-            inlet_ppm = 0.0
-            for length_val, ppm_val in profile_entries:
-                if float(ppm_val or 0.0) > 0.0:
-                    inlet_ppm = float(ppm_val)
-                    break
-            else:
-                inlet_ppm = profile_entries[0][1] if profile_entries else 0.0
+            inlet_ppm = float(profile_entries[0][1]) if profile_entries else 0.0
 
         outlet_ppm_val = res.get(f"dra_outlet_ppm_{key}")
         if outlet_ppm_val is None and isinstance(stn, dict):
@@ -3755,13 +3749,7 @@ def build_station_table(res: dict, base_stations: list[dict]) -> pd.DataFrame:
             )
         outlet_ppm = _float_or_none(outlet_ppm_val)
         if outlet_ppm is None:
-            outlet_ppm = 0.0
-            for length_val, ppm_val in reversed(profile_entries):
-                if float(ppm_val or 0.0) > 0.0:
-                    outlet_ppm = float(ppm_val)
-                    break
-            else:
-                outlet_ppm = profile_entries[-1][1] if profile_entries else 0.0
+            outlet_ppm = float(profile_entries[-1][1]) if profile_entries else 0.0
         if profile_entries:
             profile_str = "; ".join(
                 f"{length:.2f} km @ {ppm:.2f} ppm" for length, ppm in profile_entries
@@ -4565,7 +4553,7 @@ def _estimate_treatable_length(
     if not km_per_m3_candidates:
         return 0.0
 
-    km_per_m3 = max(val for val in km_per_m3_candidates if val > 0.0)
+    km_per_m3 = min(val for val in km_per_m3_candidates if val > 0.0)
     if km_per_m3 <= 0.0:
         return 0.0
 
@@ -4738,7 +4726,6 @@ def _enforce_minimum_origin_dra(
         queue_entries=queue,
         plan_volume_m3=plan_total_volume,
     )
-
     total_required_length = 0.0
     for seg in segments_to_enforce:
         try:
@@ -4761,6 +4748,19 @@ def _enforce_minimum_origin_dra(
                 for seg in segments_to_enforce[1:]:
                     seg["length_km"] = 0.0
                 total_required_length = float(treatable_limit)
+        else:
+            desired_length = float(treatable_limit)
+            if total_length_value > 0.0:
+                desired_length = min(desired_length, float(total_length_value))
+            if desired_length > total_required_length + 1e-9:
+                scale_up = desired_length / total_required_length if total_required_length > 0.0 else 0.0
+                for seg in segments_to_enforce:
+                    try:
+                        seg_length = float(seg.get("length_km", 0.0) or 0.0)
+                    except (TypeError, ValueError):
+                        seg_length = 0.0
+                    seg["length_km"] = max(seg_length * scale_up, 0.0)
+                total_required_length = sum(float(seg.get("length_km", 0.0) or 0.0) for seg in segments_to_enforce)
 
     if total_required_length <= 0.0:
         total_required_length = float(min_length)


### PR DESCRIPTION
## Summary
- update `_update_mainline_dra` to trim the advected slug, preserve downstream ppm when idle, and derive head ppm from the injected plus advected queue state
- export station inlet/outlet ppm directly from the normalized DRA profile tuples rather than scanning for positive slices
- tighten `_estimate_treatable_length` and `_enforce_minimum_origin_dra` so the enforced slug never exceeds the treatable reach and scales up when the pump can move farther than the minimum floor

## Testing
- pytest tests/test_apply_dra_ppm.py -q
- pytest tests/test_pipeline_performance.py::test_segment_floors_overlay_queue_minimum -q
- pytest tests/test_pipeline_performance.py::test_time_series_solver_backtracks_to_enforce_dra -q
- pytest tests/test_pipeline_performance.py::test_time_series_solver_enforces_when_head_untreated -q
- PYTHONWARNINGS=ignore stdbuf -oL pytest tests/test_pipeline_performance.py -q *(terminates with 38 passed but requires Ctrl+C because Streamlit keeps emitting warnings)*

------
https://chatgpt.com/codex/tasks/task_e_690af44ae26c8331b179fc562e3799b1