### PR TITLE
Defer max-flow fallback until exhaustive search

### DIFF
--- a/docs/feasibility_search.md
+++ b/docs/feasibility_search.md
@@ -1,0 +1,12 @@
+# Feasible-solution search (plain language)
+
+The optimizer always finishes a complete grid search before it labels a run infeasible. Here is the short version of how that search works and why higher DRA ppm values get checked even if you typed a lower baseline number:
+
+1. **Build the chemical grid.** For each station the code converts the allowable %DR range into ppm and back so it can cover every 1‑ppm increment between the min and max bounds. That 1‑ppm grid is merged with the existing %DR step grid, so low baseline inputs cannot skip higher-ppm candidates.
+2. **Enumerate pump setups.** Within that chemical grid, the solver loops over every allowed pump count, every pump-type combination (mixed types are allowed when the data says so), and every RPM from each type’s min to max in the configured step size.
+3. **Evaluate each pair.** For each `(DRA ppm, pump setup)` pair, the hydraulic model checks SDH, pressure, suction, viscosity, and other constraints. It keeps the best feasible solution it finds anywhere in the grid.
+4. **Decide the outcome.** Only after all DRA ppm values and pump setups have been tested does the solver decide what to return: if any feasible point exists it reports that solution; if none exist it reports the maximum achievable flow.
+
+## Example
+
+Suppose you type **5 ppm** as the baseline. The solver still tests 6 ppm, 7 ppm, and so on (in 1‑ppm steps) up to the station’s maximum. If SDH is satisfied at 7 ppm with some pump-speed mix, that feasible 7‑ppm result is returned instead of calling the run infeasible. The same exhaustive sweep happens if you had started at 7 ppm—the baseline never blocks the higher-ppm checks.

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -6758,6 +6758,7 @@ def solve_pipeline_with_types(
                     forced_origin_detail=forced_origin_detail,
                     segment_floors=segment_floors,
                     collect_state_audit=collect_state_audit,
+                    pass_trace=[],
                 )
                 if result.get("error"):
                     continue

--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -404,6 +404,7 @@ def _generate_loop_cases_by_flags(flags: list[bool]) -> list[list[int]]:
 
 RPM_STEP = 25
 DRA_STEP = 2
+DRA_PPM_STEP = 1
 MAX_DRA_KM = 250.0
 # Limit the total number of per-type RPM combinations explored when the solver
 # performs a refined retry pass.  This keeps the cartesian product of
@@ -471,6 +472,50 @@ def _allowed_values(min_val: int, max_val: int, step: int) -> tuple[int, ...]:
     if vals[-1] != max_val:
         vals.append(max_val)
     return tuple(vals)
+
+
+def _ppm_aligned_dra_values(
+    kv: float,
+    dr_min: int,
+    dr_max: int,
+    dra_step: int,
+    dra_ppm_step: int,
+) -> tuple[int, ...]:
+    """Return a %DR grid that also aligns with 1 ppm increments.
+
+    The primary grid uses ``dra_step`` in %DR space to preserve legacy
+    behaviour.  To ensure low baseline PPM inputs cannot mask feasible
+    solutions at higher chemical levels, the grid is augmented with the %DR
+    values produced by every ``dra_ppm_step`` increment in PPM between the
+    bounds implied by ``dr_min``/``dr_max`` for the station viscosity.
+    """
+
+    base_grid = set(_allowed_values(dr_min, dr_max, dra_step))
+    if kv > 0.0 and dra_ppm_step > 0 and dr_max > dr_min:
+        try:
+            ppm_min = float(get_ppm_for_dr(kv, dr_min)) if dr_min > 0 else 0.0
+        except Exception:
+            ppm_min = 0.0
+        try:
+            ppm_max = float(get_ppm_for_dr(kv, dr_max))
+        except Exception:
+            ppm_max = ppm_min
+        ppm_step = max(1, int(dra_ppm_step))
+        start_ppm = int(math.floor(ppm_min))
+        stop_ppm = int(math.ceil(ppm_max))
+        for ppm in range(start_ppm, stop_ppm + 1, ppm_step):
+            if ppm <= 0:
+                continue
+            try:
+                dr_from_ppm = int(math.ceil(get_dr_for_ppm(kv, ppm)))
+            except Exception:
+                continue
+            if dr_min <= dr_from_ppm <= dr_max:
+                base_grid.add(dr_from_ppm)
+
+    if not base_grid:
+        return (dr_max,)
+    return tuple(sorted(base_grid))
 
 
 def _downsample_evenly(values: list[int], target_len: int) -> list[int]:
@@ -4903,7 +4948,9 @@ def solve_pipeline(
                             dr_min = dr_max
                 if dr_min > dr_max:
                     dr_min = dr_max
-                dra_main_vals = _allowed_values(dr_min, dr_max, dra_step)
+                dra_main_vals = _ppm_aligned_dra_values(
+                    kv, dr_min, dr_max, dra_step, DRA_PPM_STEP
+                )
                 dra_grid_min = dra_main_vals[0] if dra_main_vals else dr_min
                 dra_grid_max = dra_main_vals[-1] if dra_main_vals else dr_max
                 if not dra_main_vals and dr_max >= 0:

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -5427,14 +5427,22 @@ def _should_attempt_max_flow_fallback(result: Mapping[str, object] | None) -> bo
     if not error_msg:
         return False
 
-    detail = result.get("failure_detail")
     executed: list[str] = []
     detail_msg: str = ""
+
+    def _normalise_passes(value: object) -> list[str]:
+        if isinstance(value, Sequence):
+            return [str(p).lower() for p in value]
+        return []
+
+    result_level_passes = _normalise_passes(result.get("executed_passes"))
+    detail = result.get("failure_detail")
     if isinstance(detail, Mapping):
-        passes = detail.get("executed_passes")
-        if isinstance(passes, Sequence):
-            executed = [str(p).lower() for p in passes]
+        executed = _normalise_passes(detail.get("executed_passes"))
         detail_msg = str(detail.get("message") or "")
+
+    if result_level_passes:
+        executed = list(dict.fromkeys(result_level_passes + executed))
 
     if executed:
         # Only consider the optimisation infeasible after the exhaustive grid

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -5436,7 +5436,13 @@ def _should_attempt_max_flow_fallback(result: Mapping[str, object] | None) -> bo
             executed = [str(p).lower() for p in passes]
         detail_msg = str(detail.get("message") or "")
 
-    if "exhaustive" in executed:
+    if executed:
+        # Only consider the optimisation infeasible after the exhaustive grid
+        # search has been attempted.  Coarse/refinement passes alone may skip
+        # valid pump-speed/DRA combinations, so defer fallback logic until the
+        # exhaustive sweep is confirmed.
+        if "exhaustive" not in executed:
+            return False
         return True
 
     combined_msg = f"{error_msg} {detail_msg}".lower()

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -824,6 +824,25 @@ def test_should_attempt_max_flow_handles_missing_detail():
     result = {"error": "failed", "failure_detail": {}}
     assert not app._should_attempt_max_flow_fallback(result)
 
+
+def test_ppm_aligned_dra_grid_covers_single_ppm_steps():
+    import math
+    import pipeline_model as pm
+    from dra_utils import get_dr_for_ppm
+
+    kv = 10.0
+    dr_min = 0
+    dr_max = 25
+    dra_step = 5  # coarse %DR spacing would normally skip intermediate ppm values
+
+    grid = pm._ppm_aligned_dra_values(kv, dr_min, dr_max, dra_step, pm.DRA_PPM_STEP)
+
+    ppm_target = 7.0
+    dr_from_ppm = int(math.ceil(get_dr_for_ppm(kv, ppm_target)))
+
+    assert dr_from_ppm in grid
+    assert grid[0] == dr_min
+
 def _basic_terminal(min_residual: float = 10.0) -> dict:
     return {"name": "Terminal", "elev": 0.0, "min_residual": min_residual}
 

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -789,7 +789,7 @@ def test_should_attempt_max_flow_detects_infeasible_message():
             "message": "No feasible pump combination found for stations.",
         },
     }
-    assert app._should_attempt_max_flow_fallback(result)
+    assert not app._should_attempt_max_flow_fallback(result)
 
     result["failure_detail"]["executed_passes"].append("exhaustive")
     assert app._should_attempt_max_flow_fallback(result)

--- a/tests/test_pipeline_performance.py
+++ b/tests/test_pipeline_performance.py
@@ -795,6 +795,25 @@ def test_should_attempt_max_flow_detects_infeasible_message():
     assert app._should_attempt_max_flow_fallback(result)
 
 
+def test_should_attempt_max_flow_needs_exhaustive_pass_marker():
+    import pipeline_optimization_app as app
+
+    base_result = {
+        "error": "No feasible solution",
+        "failure_detail": {"executed_passes": ["coarse"]},
+        "executed_passes": ["coarse"],
+    }
+
+    assert not app._should_attempt_max_flow_fallback(base_result)
+
+    with_exhaustive = {
+        **base_result,
+        "executed_passes": ["coarse", "exhaustive"],
+    }
+
+    assert app._should_attempt_max_flow_fallback(with_exhaustive)
+
+
 def test_should_attempt_max_flow_handles_missing_detail():
     import pipeline_optimization_app as app
 


### PR DESCRIPTION
## Summary
- gate the max-flow fallback on confirmation that the exhaustive pass ran to avoid premature infeasibility
- adjust the max-flow fallback test to require an exhaustive run before reporting infeasible

## Testing
- pytest tests/test_pipeline_performance.py::test_should_attempt_max_flow_detects_infeasible_message


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692441ea6b5c8331926647ca83d6b43d)