### PR TITLE
Add DRA PPM capping and zero-plan handling

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -4706,12 +4706,27 @@ def solve_pipeline(
 
             fixed_dr = stn.get('fixed_dra_perc', None)
             max_dr_main = _max_dr_int(stn.get('max_dr'))
-            max_ppm_cap = 0.0
+            user_ppm_cap = stn.get('max_dra_ppm', 0.0)
+            try:
+                user_ppm_cap = float(user_ppm_cap or 0.0)
+            except (TypeError, ValueError):
+                user_ppm_cap = 0.0
+            max_ppm_cap = max(user_ppm_cap, 0.0)
+            derived_ppm_cap = 0.0
             if kv > 0.0 and max_dr_main > 0:
                 try:
-                    max_ppm_cap = float(get_ppm_for_dr(kv, max_dr_main))
+                    derived_ppm_cap = float(get_ppm_for_dr(kv, max_dr_main))
                 except Exception:
-                    max_ppm_cap = 0.0
+                    derived_ppm_cap = 0.0
+            if max_ppm_cap <= 0.0:
+                max_ppm_cap = derived_ppm_cap
+            elif kv > 0.0 and max_ppm_cap > 0.0:
+                try:
+                    cap_dr_from_ppm = float(get_dr_for_ppm(kv, max_ppm_cap))
+                except Exception:
+                    cap_dr_from_ppm = 0.0
+                if cap_dr_from_ppm > 0.0:
+                    max_dr_main = min(max_dr_main, int(math.ceil(cap_dr_from_ppm)))
             floor_limited_local = bool(floor_limited)
             floor_exceeds_cap = False
             if floor_ppm_min > 0.0:
@@ -4780,6 +4795,28 @@ def solve_pipeline(
                     dra_main_vals = filtered_vals
             max_dr_loop = _max_dr_int(loop_dict.get('max_dr')) if loop_dict else 0
             dr_loop_min, dr_loop_max = 0, max_dr_loop
+            user_ppm_cap_loop = 0.0
+            if loop_dict:
+                try:
+                    user_ppm_cap_loop = float(loop_dict.get('max_dra_ppm', 0.0) or 0.0)
+                except (TypeError, ValueError):
+                    user_ppm_cap_loop = 0.0
+            max_ppm_cap_loop = max(user_ppm_cap_loop, 0.0)
+            derived_ppm_cap_loop = 0.0
+            if kv > 0.0 and max_dr_loop > 0:
+                try:
+                    derived_ppm_cap_loop = float(get_ppm_for_dr(kv, max_dr_loop))
+                except Exception:
+                    derived_ppm_cap_loop = 0.0
+            if max_ppm_cap_loop <= 0.0:
+                max_ppm_cap_loop = derived_ppm_cap_loop
+            elif kv > 0.0 and max_ppm_cap_loop > 0.0:
+                try:
+                    loop_dr_from_ppm = float(get_dr_for_ppm(kv, max_ppm_cap_loop))
+                except Exception:
+                    loop_dr_from_ppm = 0.0
+                if loop_dr_from_ppm > 0.0:
+                    max_dr_loop = min(max_dr_loop, int(math.ceil(loop_dr_from_ppm)))
             if rng and 'dra_loop' in rng:
                 dr_loop_min = max(0, rng['dra_loop'][0])
                 dr_loop_max = min(max_dr_loop, rng['dra_loop'][1])
@@ -4815,6 +4852,8 @@ def solve_pipeline(
                     seen_ppm_keys: set[int] = set()
                     for dra_main in dra_main_vals:
                         ppm_main = float(get_ppm_for_dr(kv, dra_main)) if dra_main > 0 else 0.0
+                        if max_ppm_cap > 0.0 and ppm_main > max_ppm_cap:
+                            ppm_main = max_ppm_cap
                         if floor_ppm_min > 0.0:
                             if ppm_main <= 0.0 and not floor_exceeds_cap:
                                 continue
@@ -4828,7 +4867,7 @@ def solve_pipeline(
                         if ppm_main < 0.0:
                             ppm_main = 0.0
                         ppm_for_dr = ppm_main
-                        if floor_exceeds_cap and max_ppm_cap > 0.0:
+                        if max_ppm_cap > 0.0:
                             ppm_for_dr = min(ppm_for_dr, max_ppm_cap)
                         key = int(round(ppm_main / tol_ppm)) if tol_ppm > 0 else int(round(ppm_main))
                         if key in seen_ppm_keys:
@@ -4882,6 +4921,8 @@ def solve_pipeline(
                     for dra_main_use, ppm_main in ppm_candidates:
                         for dra_loop in dra_loop_vals:
                             ppm_loop = float(get_ppm_for_dr(kv, dra_loop)) if dra_loop > 0 else 0.0
+                            if max_ppm_cap_loop > 0.0 and ppm_loop > max_ppm_cap_loop:
+                                ppm_loop = max_ppm_cap_loop
                             inj_effective_est = _predict_effective_injection(
                                 ppm_main,
                                 kv,
@@ -4944,12 +4985,27 @@ def solve_pipeline(
             # upstream PPM simply carries forward.
             non_pump_opts: list[dict] = []
             max_dr_main = _max_dr_int(stn.get('max_dr'))
-            max_ppm_cap = 0.0
+            user_ppm_cap = stn.get('max_dra_ppm', 0.0)
+            try:
+                user_ppm_cap = float(user_ppm_cap or 0.0)
+            except (TypeError, ValueError):
+                user_ppm_cap = 0.0
+            max_ppm_cap = max(user_ppm_cap, 0.0)
+            derived_ppm_cap = 0.0
             if kv > 0.0 and max_dr_main > 0:
                 try:
-                    max_ppm_cap = float(get_ppm_for_dr(kv, max_dr_main))
+                    derived_ppm_cap = float(get_ppm_for_dr(kv, max_dr_main))
                 except Exception:
-                    max_ppm_cap = 0.0
+                    derived_ppm_cap = 0.0
+            if max_ppm_cap <= 0.0:
+                max_ppm_cap = derived_ppm_cap
+            elif kv > 0.0 and max_ppm_cap > 0.0:
+                try:
+                    cap_dr_from_ppm = float(get_dr_for_ppm(kv, max_ppm_cap))
+                except Exception:
+                    cap_dr_from_ppm = 0.0
+                if cap_dr_from_ppm > 0.0:
+                    max_dr_main = min(max_dr_main, int(math.ceil(cap_dr_from_ppm)))
             floor_limited_local = bool(floor_limited)
             floor_exceeds_cap = False
             if floor_ppm_min > 0.0:
@@ -5008,6 +5064,8 @@ def solve_pipeline(
                     dra_vals = filtered_vals
                 for dra_main in dra_vals:
                     ppm_main = float(get_ppm_for_dr(kv, dra_main)) if dra_main > 0 else 0.0
+                    if max_ppm_cap > 0.0 and ppm_main > max_ppm_cap:
+                        ppm_main = max_ppm_cap
                     if floor_ppm_min > 0.0:
                         if ppm_main <= 0.0 and not floor_exceeds_cap:
                             continue
@@ -5022,7 +5080,7 @@ def solve_pipeline(
                     if ppm_main > 0.0 and kv > 0.0:
                         try:
                             ppm_for_dr = ppm_main
-                            if floor_exceeds_cap and max_ppm_cap > 0.0:
+                            if max_ppm_cap > 0.0:
                                 ppm_for_dr = min(ppm_for_dr, max_ppm_cap)
                             dra_from_ppm = float(get_dr_for_ppm(kv, ppm_for_dr))
                         except Exception:

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -892,10 +892,13 @@ def _prepare_pipeline_context():
 
         stn.setdefault("name", f"Station {idx}")
         stn.setdefault("max_dr", 0.0)
+        stn.setdefault("max_dra_ppm", 0.0)
         stn.setdefault("min_residual", 0.0)
         stn.setdefault("loopline", False)
         stn.setdefault("max_pumps", stn.get("available", 0))
         stn.setdefault("min_pumps", 0)
+        if isinstance(stn.get("loopline"), Mapping):
+            stn["loopline"].setdefault("max_dra_ppm", stn["loopline"].get("max_dra_ppm", 0.0))
         pump_types = stn.get("pump_types") if isinstance(stn.get("pump_types"), Mapping) else None
         if pump_types:
             for ptype, pdata in pump_types.items():
@@ -1828,6 +1831,7 @@ if "stations" not in st.session_state:
         'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
         'max_pumps': 1, 'MinRPM': 1200.0, 'DOL': 1500.0,
         'max_dr': 0.0,
+        'max_dra_ppm': 0.0,
         'delivery': 0.0,
         'supply': 0.0
     }]
@@ -1843,6 +1847,7 @@ with st.sidebar:
             'power_type': 'Grid', 'rate': 9.0, 'sfc': 150.0,
             'max_pumps': 1, 'MinRPM': 1000.0, 'DOL': 1500.0,
             'max_dr': 0.0,
+            'max_dra_ppm': 0.0,
             'delivery': 0.0,
             'supply': 0.0
         }
@@ -1864,6 +1869,13 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                 "Max achievable Drag Reduction (%)",
                 value=stn.get('max_dr', 0.0),
                 key=f"mdr{idx}"
+            )
+            stn['max_dra_ppm'] = st.number_input(
+                "Max DRA PPM",
+                value=stn.get('max_dra_ppm', 0.0),
+                min_value=0.0,
+                step=1.0,
+                key=f"mdrppm{idx}"
             )
             if idx == 1:
                 stn['min_residual'] = st.number_input("Available Suction Head (m)", value=stn.get('min_residual',50.0), step=0.1, key=f"res{idx}")
@@ -1900,6 +1912,13 @@ for idx, stn in enumerate(st.session_state.stations, start=1):
                     "Max Drag Reduction (%)",
                     value=loop.get('max_dr', 0.0),
                     key=f"loopmdr{idx}"
+                )
+                loop['max_dra_ppm'] = st.number_input(
+                    "Max DRA PPM",
+                    value=loop.get('max_dra_ppm', 0.0),
+                    min_value=0.0,
+                    step=1.0,
+                    key=f"loopmdrppm{idx}"
                 )
                 loop['elev'] = st.number_input("Elevation (m)", value=loop.get('elev', stn.get('elev',0.0)), step=0.1, key=f"loopelev{idx}")
 
@@ -2670,13 +2689,11 @@ def _append_zero_plan_segments_to_result(
 
     if queue_entries:
         head_length, head_ppm = queue_entries[0]
-        if head_ppm <= 0.0:
-            if head_length < zero_length - 1e-9:
-                queue_entries[0] = (zero_length, 0.0)
-        elif zero_length > 1e-9:
-            # Preserve treated head segments by appending untreated plan slices
-            # to the back of the queue rather than prepending them.
-            queue_entries.append((zero_length, 0.0))
+        if zero_length > 1e-9:
+            if head_ppm <= 0.0:
+                queue_entries[0] = (head_length + zero_length, 0.0)
+            else:
+                queue_entries.insert(0, (zero_length, 0.0))
     else:
         queue_entries = [(zero_length, 0.0)]
 
@@ -3903,7 +3920,7 @@ def _collect_search_depth_kwargs() -> dict[str, float | int]:
     coarse_multiplier_default = getattr(pipeline_model, "COARSE_MULTIPLIER", 5.0)
     state_top_k_default = getattr(pipeline_model, "STATE_TOP_K", 50)
     state_cost_margin_default = getattr(pipeline_model, "STATE_COST_MARGIN", 5000.0)
-    state_cost_margin_pct_default = getattr(pipeline_model, "STATE_COST_MARGIN_PCT", 0.01) * 100.0
+    state_cost_margin_pct_default = getattr(pipeline_model, "STATE_COST_MARGIN_PCT", None)
 
     rpm_step = int(st.session_state.get("search_rpm_step", rpm_step_default) or rpm_step_default)
     if rpm_step <= 0:
@@ -3934,22 +3951,27 @@ def _collect_search_depth_kwargs() -> dict[str, float | int]:
     if state_cost_margin < 0:
         state_cost_margin = 0.0
 
-    state_cost_margin_pct = float(
-        st.session_state.get("search_state_cost_margin_pct", state_cost_margin_pct_default)
-        or state_cost_margin_pct_default
-    )
-    if state_cost_margin_pct < 0:
-        state_cost_margin_pct = 0.0
-    state_cost_margin_pct /= 100.0
+    state_cost_margin_pct: float | None = None
+    if state_cost_margin_pct_default is not None:
+        pct_default = state_cost_margin_pct_default * 100.0
+        state_cost_margin_pct = float(
+            st.session_state.get("search_state_cost_margin_pct", pct_default)
+            or pct_default
+        )
+        if state_cost_margin_pct < 0:
+            state_cost_margin_pct = 0.0
+        state_cost_margin_pct /= 100.0
 
-    return {
+    result = {
         "rpm_step": rpm_step,
         "dra_step": dra_step,
         "coarse_multiplier": coarse_multiplier,
         "state_top_k": state_top_k,
         "state_cost_margin": state_cost_margin,
-        "state_cost_margin_pct": state_cost_margin_pct,
     }
+    if state_cost_margin_pct is not None:
+        result["state_cost_margin_pct"] = state_cost_margin_pct
+    return result
 
 
 


### PR DESCRIPTION
## Summary
- add max DRA PPM configuration for stations and looplines in the UI and defaults
- cap mainline and loop DRA search grids using user PPM limits while clamping evaluated ppm values
- adjust zero-ppm plan handling and guard optional search depth defaults to satisfy validation

## Testing
- PYTHONPATH=. pytest -q tests/test_pipeline_app_defaults.py::test_collect_search_depth_kwargs_handles_missing_pipeline_constants tests/test_pipeline_performance.py::test_time_series_solver_extends_zero_plan_injections


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69254cbbe5008331bec199523a46cda2)