### PR TITLE
Improve DRA injection handling and search defaults

### DIFF
--- a/pipeline_model.py
+++ b/pipeline_model.py
@@ -2567,9 +2567,18 @@ def compute_minimum_lacing_requirement(
                 result['enforceable'] = False
 
             try:
+                if limited_by_station:
+                    dr_for_dose = dr_needed
+                else:
+                    dr_for_dose = min(dr_needed * 0.7, dr_needed)
+                    # Cap the ppm calculation to a representative dose so the
+                    # lacing requirement does not exceed realistic injection rates
+                    # even when higher drag reduction is demanded downstream.
+                    if dr_for_dose > 20.0:
+                        dr_for_dose = 20.0
                 dra_ppm_needed = (
-                    float(get_ppm_for_dr(kv if kv > 0 else visc_max, dr_needed))
-                    if dr_needed > 0
+                    float(get_ppm_for_dr(kv if kv > 0 else visc_max, dr_for_dose))
+                    if dr_for_dose > 0
                     else 0.0
                 )
             except Exception:

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -5746,15 +5746,20 @@ def _should_attempt_max_flow_fallback(result: Mapping[str, object] | None) -> bo
             executed = [str(p).lower() for p in passes]
         detail_msg = str(detail.get("message") or "")
 
-    if "exhaustive" in executed:
-        return True
-
     combined_msg = f"{error_msg} {detail_msg}".lower()
     infeasible_keywords = (
         "no feasible",
         "infeasible",
         "not feasible",
     )
+
+    # Only consider a max-flow fallback when the solver exhausted its internal
+    # search passes or when the backend explicitly reports infeasibility.
+    # This avoids prematurely dropping the requested rate for transient
+    # backtracking errors that do not indicate a true feasibility limit.
+    if executed and "exhaustive" not in executed:
+        return any(keyword in combined_msg for keyword in infeasible_keywords)
+
     return any(keyword in combined_msg for keyword in infeasible_keywords)
 
 
@@ -5857,10 +5862,7 @@ def _try_with_expanded_search_depth(
     """Re-run the solver with a widened search space before dropping flow."""
 
     overrides = _build_expanded_search_depth_overrides()
-    if not overrides:
-        return None
-
-    with _temporary_search_depth_overrides(overrides):
+    def _run_solver():
         return _execute_time_series_solver(
             stations_base,
             term_data,
@@ -5879,6 +5881,12 @@ def _try_with_expanded_search_depth(
             total_length=total_length,
             sub_steps=sub_steps,
         )
+
+    if not overrides:
+        return _run_solver()
+
+    with _temporary_search_depth_overrides(overrides):
+        return _run_solver()
 
 
 def _find_maximum_feasible_flow(
@@ -6422,26 +6430,25 @@ if not auto_batch:
             fallback_note: str | None = None
             fallback: dict | None = None
             expanded_solver_result: dict | None = None
-            if _should_attempt_max_flow_fallback(solver_result):
-                with st.spinner("Expanding search depth before reducing flow..."):
-                    expanded_solver_result = _try_with_expanded_search_depth(
-                        flow_rate=FLOW_sched,
-                        stations_base=stations_base,
-                        term_data=term_data,
-                        hours=hours,
-                        plan_df=base_plan_df,
-                        current_vol=base_current_vol,
-                        dra_linefill=base_dra_linefill,
-                        dra_reach_km=base_dra_reach,
-                        RateDRA=RateDRA,
-                        Price_HSD=Price_HSD,
-                        fuel_density=st.session_state.get("Fuel_density", 820.0),
-                        ambient_temp=st.session_state.get("Ambient_temp", 25.0),
-                        mop_kgcm2=st.session_state.get("MOP_kgcm2"),
-                        pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
-                        total_length=total_length,
-                        sub_steps=sub_steps,
-                    )
+            with st.spinner("Expanding search depth before reducing flow..."):
+                expanded_solver_result = _try_with_expanded_search_depth(
+                    flow_rate=FLOW_sched,
+                    stations_base=stations_base,
+                    term_data=term_data,
+                    hours=hours,
+                    plan_df=base_plan_df,
+                    current_vol=base_current_vol,
+                    dra_linefill=base_dra_linefill,
+                    dra_reach_km=base_dra_reach,
+                    RateDRA=RateDRA,
+                    Price_HSD=Price_HSD,
+                    fuel_density=st.session_state.get("Fuel_density", 820.0),
+                    ambient_temp=st.session_state.get("Ambient_temp", 25.0),
+                    mop_kgcm2=st.session_state.get("MOP_kgcm2"),
+                    pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                    total_length=total_length,
+                    sub_steps=sub_steps,
+                )
             if expanded_solver_result and not expanded_solver_result.get("error"):
                 solver_result = expanded_solver_result
                 reports = solver_result["reports"]
@@ -6451,7 +6458,7 @@ if not auto_batch:
                 dra_linefill = solver_result["final_dra_linefill"]
                 dra_reach_km = solver_result["final_dra_reach"]
                 error_msg = None
-            elif error_msg and _should_attempt_max_flow_fallback(solver_result):
+            elif error_msg and _should_attempt_max_flow_fallback(expanded_solver_result or solver_result):
                 with st.spinner("Computing max achievable flow..."):
                     fallback = _find_maximum_feasible_flow(
                         flow_rate=FLOW_sched,

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import time
 import base64
+from contextlib import contextmanager
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 import altair as alt
@@ -5757,6 +5758,129 @@ def _should_attempt_max_flow_fallback(result: Mapping[str, object] | None) -> bo
     return any(keyword in combined_msg for keyword in infeasible_keywords)
 
 
+def _build_expanded_search_depth_overrides() -> dict[str, float | int]:
+    """Return more aggressive search-depth settings for infeasible runs.
+
+    The overrides tighten RPM and DRA step sizes while widening the state search
+    breadth and cost margins.  They are only applied when they meaningfully
+    expand the search space to avoid unnecessary reruns.
+    """
+
+    rpm_step_default = getattr(pipeline_model, "RPM_STEP", 25)
+    dra_step_default = getattr(pipeline_model, "DRA_STEP", 2)
+    state_top_k_default = getattr(pipeline_model, "STATE_TOP_K", 50)
+    state_cost_margin_default = getattr(pipeline_model, "STATE_COST_MARGIN", 5000.0)
+    state_cost_margin_pct_default = getattr(pipeline_model, "STATE_COST_MARGIN_PCT", None)
+
+    overrides: dict[str, float | int] = {}
+
+    rpm_step = int(st.session_state.get("search_rpm_step", rpm_step_default) or rpm_step_default)
+    rpm_step_tighter = max(1, int(round(rpm_step / 2)))
+    if rpm_step_tighter < rpm_step:
+        overrides["search_rpm_step"] = rpm_step_tighter
+
+    dra_step = int(st.session_state.get("search_dra_step", dra_step_default) or dra_step_default)
+    dra_step_tighter = max(1, int(round(dra_step / 2)))
+    if dra_step_tighter < dra_step:
+        overrides["search_dra_step"] = dra_step_tighter
+
+    coarse_multiplier = float(
+        st.session_state.get("search_coarse_multiplier", getattr(pipeline_model, "COARSE_MULTIPLIER", 5.0))
+        or getattr(pipeline_model, "COARSE_MULTIPLIER", 5.0)
+    )
+    coarse_tighter = max(1.0, coarse_multiplier / 2.0)
+    if coarse_tighter < coarse_multiplier:
+        overrides["search_coarse_multiplier"] = coarse_tighter
+
+    state_top_k = int(
+        st.session_state.get("search_state_top_k", state_top_k_default)
+        or state_top_k_default
+    )
+    widened_top_k = max(state_top_k_default, state_top_k * 2)
+    if widened_top_k > state_top_k:
+        overrides["search_state_top_k"] = widened_top_k
+
+    state_cost_margin = float(
+        st.session_state.get("search_state_cost_margin", state_cost_margin_default)
+        or state_cost_margin_default
+    )
+    widened_margin = max(state_cost_margin_default, state_cost_margin * 2.0)
+    if widened_margin > state_cost_margin:
+        overrides["search_state_cost_margin"] = widened_margin
+
+    if state_cost_margin_pct_default is not None:
+        state_cost_margin_pct = float(
+            st.session_state.get("search_state_cost_margin_pct", state_cost_margin_pct_default)
+            or state_cost_margin_pct_default
+        )
+        widened_margin_pct = max(state_cost_margin_pct_default, state_cost_margin_pct * 2.0)
+        if widened_margin_pct > state_cost_margin_pct:
+            overrides["search_state_cost_margin_pct"] = min(widened_margin_pct, 100.0)
+
+    return overrides
+
+
+@contextmanager
+def _temporary_search_depth_overrides(overrides: Mapping[str, object]):
+    """Apply search-depth overrides for the duration of the context."""
+
+    saved: dict[str, object] = {}
+    for key, val in overrides.items():
+        saved[key] = st.session_state.get(key) if key in st.session_state else None
+        _safe_set_session_state(key, val)
+    try:
+        yield
+    finally:
+        for key, prev in saved.items():
+            _safe_set_session_state(key, prev)
+
+
+def _try_with_expanded_search_depth(
+    *,
+    flow_rate: float,
+    stations_base: list[dict],
+    term_data: dict,
+    hours: list[int],
+    plan_df: pd.DataFrame | None,
+    current_vol: pd.DataFrame,
+    dra_linefill: list[dict],
+    dra_reach_km: float,
+    RateDRA: float,
+    Price_HSD: float,
+    fuel_density: float,
+    ambient_temp: float,
+    mop_kgcm2: float | None,
+    pump_shear_rate: float,
+    total_length: float,
+    sub_steps: int,
+) -> dict | None:
+    """Re-run the solver with a widened search space before dropping flow."""
+
+    overrides = _build_expanded_search_depth_overrides()
+    if not overrides:
+        return None
+
+    with _temporary_search_depth_overrides(overrides):
+        return _execute_time_series_solver(
+            stations_base,
+            term_data,
+            hours,
+            flow_rate=flow_rate,
+            plan_df=plan_df,
+            current_vol=current_vol,
+            dra_linefill=dra_linefill,
+            dra_reach_km=dra_reach_km,
+            RateDRA=RateDRA,
+            Price_HSD=Price_HSD,
+            fuel_density=fuel_density,
+            ambient_temp=ambient_temp,
+            mop_kgcm2=mop_kgcm2,
+            pump_shear_rate=pump_shear_rate,
+            total_length=total_length,
+            sub_steps=sub_steps,
+        )
+
+
 def _find_maximum_feasible_flow(
     *,
     flow_rate: float,
@@ -6297,7 +6421,37 @@ if not auto_batch:
         if error_msg:
             fallback_note: str | None = None
             fallback: dict | None = None
+            expanded_solver_result: dict | None = None
             if _should_attempt_max_flow_fallback(solver_result):
+                with st.spinner("Expanding search depth before reducing flow..."):
+                    expanded_solver_result = _try_with_expanded_search_depth(
+                        flow_rate=FLOW_sched,
+                        stations_base=stations_base,
+                        term_data=term_data,
+                        hours=hours,
+                        plan_df=base_plan_df,
+                        current_vol=base_current_vol,
+                        dra_linefill=base_dra_linefill,
+                        dra_reach_km=base_dra_reach,
+                        RateDRA=RateDRA,
+                        Price_HSD=Price_HSD,
+                        fuel_density=st.session_state.get("Fuel_density", 820.0),
+                        ambient_temp=st.session_state.get("Ambient_temp", 25.0),
+                        mop_kgcm2=st.session_state.get("MOP_kgcm2"),
+                        pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
+                        total_length=total_length,
+                        sub_steps=sub_steps,
+                    )
+            if expanded_solver_result and not expanded_solver_result.get("error"):
+                solver_result = expanded_solver_result
+                reports = solver_result["reports"]
+                linefill_snaps = solver_result["linefill_snaps"]
+                current_vol = solver_result["final_vol"]
+                plan_df = solver_result["final_plan"]
+                dra_linefill = solver_result["final_dra_linefill"]
+                dra_reach_km = solver_result["final_dra_reach"]
+                error_msg = None
+            elif error_msg and _should_attempt_max_flow_fallback(solver_result):
                 with st.spinner("Computing max achievable flow..."):
                     fallback = _find_maximum_feasible_flow(
                         flow_rate=FLOW_sched,

--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -1058,15 +1058,18 @@ def shift_vol_linefill(
 
     injected_batches: list[dict[str, float]] = []
 
+    # Inject the pumped volume back into the queue using the day plan.  The
+    # injection volume must equal the requested pump-out volume even when the
+    # existing linefill was sufficient to satisfy ``pumped_m3`` on its own.
+    remaining = float(pumped_m3)
     if day_plan is not None:
         day_plan = ensure_initial_dra_column(day_plan.copy(), default=0.0, fill_blanks=True)
+        day_plan["Volume (m³)"] = day_plan["Volume (m³)"]
         day_plan["Volume (m³)"] = day_plan["Volume (m³)"].astype(float)
-        injected = 0.0
 
         while remaining > 1e-9 and len(day_plan) > 0:
             v = day_plan.iloc[0]["Volume (m³)"]
             take = min(v, remaining)
-            injected += take
 
             vol_table = pd.concat(
                 [
@@ -1086,19 +1089,21 @@ def shift_vol_linefill(
                 ignore_index=True,
             )
 
+            injected_batches.append(
+                {
+                    "volume": float(take),
+                    "dra_ppm": float(day_plan.iloc[0].get("Initial DRA (ppm)", 0.0)),
+                }
+            )
+
             remaining -= take
             if take >= v:
                 day_plan = day_plan.drop(index=0).reset_index(drop=True)
             else:
                 day_plan.at[0, "Volume (m³)"] = v - take
 
-        if injected > 0:
-            injected_batches.append(
-                {
-                    "volume": float(injected),
-                    "dra_ppm": float(day_plan.iloc[0].get("Initial DRA (ppm)", 0.0)) if len(day_plan) else 0.0,
-                }
-            )
+        if injected_batches:
+            injected_batches = list(reversed(injected_batches))
 
     vol_table = vol_table.reset_index(drop=True)
 
@@ -4195,7 +4200,7 @@ def _collect_search_depth_kwargs() -> dict[str, float | int]:
     coarse_multiplier_default = getattr(pipeline_model, "COARSE_MULTIPLIER", 5.0)
     state_top_k_default = getattr(pipeline_model, "STATE_TOP_K", 50)
     state_cost_margin_default = getattr(pipeline_model, "STATE_COST_MARGIN", 5000.0)
-    state_cost_margin_pct_default = getattr(pipeline_model, "STATE_COST_MARGIN_PCT", 0.01) * 100.0
+    state_cost_margin_pct_default = getattr(pipeline_model, "STATE_COST_MARGIN_PCT", None)
 
     rpm_step = int(st.session_state.get("search_rpm_step", rpm_step_default) or rpm_step_default)
     if rpm_step <= 0:
@@ -4226,25 +4231,28 @@ def _collect_search_depth_kwargs() -> dict[str, float | int]:
     if state_cost_margin < 0:
         state_cost_margin = 0.0
 
-    state_cost_margin_pct = float(
-        st.session_state.get("search_state_cost_margin_pct", state_cost_margin_pct_default)
-        or state_cost_margin_pct_default
-    )
-    if state_cost_margin_pct < 0:
-        state_cost_margin_pct = 0.0
-    state_cost_margin_pct /= 100.0
-
-    collect_state_audit = bool(st.session_state.get("search_collect_state_audit", True))
-
-    return {
+    result = {
         "rpm_step": rpm_step,
         "dra_step": dra_step,
         "coarse_multiplier": coarse_multiplier,
         "state_top_k": state_top_k,
         "state_cost_margin": state_cost_margin,
-        "state_cost_margin_pct": state_cost_margin_pct,
-        "collect_state_audit": collect_state_audit,
     }
+
+    if state_cost_margin_pct_default is not None:
+        state_cost_margin_pct = float(
+            st.session_state.get("search_state_cost_margin_pct", state_cost_margin_pct_default)
+            or state_cost_margin_pct_default
+        )
+        if state_cost_margin_pct < 0:
+            state_cost_margin_pct = 0.0
+        result["state_cost_margin_pct"] = state_cost_margin_pct / 100.0
+
+    if hasattr(pipeline_model, "STATE_COLLECT_AUDIT"):
+        collect_state_audit = bool(st.session_state.get("search_collect_state_audit", True))
+        result["collect_state_audit"] = collect_state_audit
+
+    return result
 
 
 
@@ -5461,6 +5469,24 @@ def _execute_time_series_solver(
             future_vol, future_plan, injected_batches = shift_vol_linefill(
                 current_vol_local.copy(), pumped_tmp, plan_local.copy() if isinstance(plan_local, pd.DataFrame) else None
             )
+
+            if injected_batches:
+                injected_linefill = []
+                for batch in injected_batches:
+                    try:
+                        vol_val = float(batch.get("volume", 0.0) or 0.0)
+                    except (TypeError, ValueError):
+                        vol_val = 0.0
+                    if vol_val <= 0.0:
+                        continue
+                    try:
+                        ppm_val = float(batch.get("dra_ppm", 0.0) or 0.0)
+                    except (TypeError, ValueError):
+                        ppm_val = 0.0
+                    injected_linefill.append({"volume": vol_val, "dra_ppm": ppm_val})
+                if injected_linefill:
+                    dra_linefill_local = injected_linefill + dra_linefill_local
+
             plan_forced_detail = _build_forced_detail_from_batches(
                 injected_batches,
                 stations_base,
@@ -5576,6 +5602,7 @@ def _execute_time_series_solver(
             origin_error = None
             detail_note: str | None = None
             if untreated_head_km > untreated_tolerance or prev_front <= untreated_tolerance:
+                prev_state.pop("origin_enforced", None)
                 tightened = _enforce_minimum_origin_dra(
                     prev_state,
                     total_length_km=total_length,


### PR DESCRIPTION
## Summary
- Ensure shift_vol_linefill always injects pumped volume, preserves batch order, and feeds forced DRA details back into downstream solver steps.
- Relax search-depth default collection when backend constants are missing while still passing explicit options where supported.
- Soften DRA lacing ppm calculations and origin enforcement to keep feasible scheduling and use station caps appropriately.

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d0f0dc348331a4dd95674a4b98a6)