### PR TITLE
Adjust max flow search decrement to 25 m3/hr

### DIFF
--- a/pipeline_optimization_app.py
+++ b/pipeline_optimization_app.py
@@ -5748,7 +5748,7 @@ def _find_maximum_feasible_flow(
     pump_shear_rate: float,
     total_length: float,
     sub_steps: int,
-    flow_step: float = 50.0,
+    flow_step: float = 25.0,
     is_hourly: bool = False,
 ) -> dict | None:
     """Return the first feasible solution below ``flow_rate`` reducing in ``flow_step`` increments."""
@@ -5760,9 +5760,9 @@ def _find_maximum_feasible_flow(
     try:
         step = abs(float(flow_step))
     except (TypeError, ValueError):
-        step = 50.0
+        step = 25.0
     if step <= 0.0:
-        step = 50.0
+        step = 25.0
 
     hours_count = len(hours) if hours else 0
     if base_flow <= 0.0 or hours_count <= 0:
@@ -5785,9 +5785,9 @@ def _find_maximum_feasible_flow(
     else:
         initial_total = base_flow * hours_count
     # Align the initial candidate with the step size so we don't skip feasible
-    # flows that sit just below the requested rate (e.g. 2,833 -> 2,800 for
-    # a 50 m³/h step).  Otherwise the search would jump straight to
-    # ``base_flow - step`` (2,783 in the example) and potentially miss a
+    # flows that sit just below the requested rate (e.g. 2,833 -> 2,825 for
+    # a 25 m³/h step).  Otherwise the search would jump straight to
+    # ``base_flow - step`` (2,808 in the example) and potentially miss a
     # narrow feasible window.
     remainder = base_flow % step
     initial_decrement = remainder if remainder > 0 else step
@@ -6289,7 +6289,7 @@ if not auto_batch:
                         pump_shear_rate=st.session_state.get("pump_shear_rate", 0.0),
                         total_length=total_length,
                         sub_steps=sub_steps,
-                        flow_step=50.0,
+                        flow_step=25.0,
                         is_hourly=is_hourly,
                     )
             if fallback:


### PR DESCRIPTION
## Summary
- reduce the maximum flow fallback search decrement from 50 to 25 m3/hr
- align default step handling and documentation with the new increment size

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9222ca8c8331bb92a85e57105394)